### PR TITLE
replaced all 'it' with 'test' to standardize codebase with readme

### DIFF
--- a/src/matchers/toBeArray/index.test.js
+++ b/src/matchers/toBeArray/index.test.js
@@ -5,24 +5,24 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeArray', () => {
-  it('passes when given an array', () => {
+  test('passes when given an array', () => {
     expect([]).toBeArray();
   });
 
-  it('fails when not given an array', () => {
+  test('fails when not given an array', () => {
     expect(() => expect(false).toBeArray()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeArray', () => {
-  each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]]).test(
     'passes when not given an array: %s',
     given => {
       expect(given).not.toBeArray();
     }
   );
 
-  it('fails when given an array', () => {
+  test('fails when given an array', () => {
     expect(() => expect([]).not.toBeArray()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeArray/predicate.test.js
+++ b/src/matchers/toBeArray/predicate.test.js
@@ -2,11 +2,14 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeArray Predicate', () => {
-  it('returns true when given an array', () => {
+  test('returns true when given an array', () => {
     expect(predicate(['an array'])).toBe(true);
   });
 
-  each([[false], [''], [0], [{}], [() => {}], [undefined], [null], [NaN]]).it('returns false when given: %s', given => {
-    expect(predicate(given)).toBe(false);
-  });
+  each([[false], [''], [0], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+    'returns false when given: %s',
+    given => {
+      expect(predicate(given)).toBe(false);
+    }
+  );
 });

--- a/src/matchers/toBeBoolean/index.test.js
+++ b/src/matchers/toBeBoolean/index.test.js
@@ -5,23 +5,23 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeBoolean', () => {
-  it('passes when given false', () => {
+  test('passes when given false', () => {
     expect(false).toBeBoolean();
   });
 
-  it('passes when given true', () => {
+  test('passes when given true', () => {
     expect(true).toBeBoolean();
   });
 
-  it('passes when given something that evaluates to a boolean', () => {
+  test('passes when given something that evaluates to a boolean', () => {
     expect(1 === 1).toBeBoolean();
   });
 
-  it('passes when given an object of type Boolean', () => {
+  test('passes when given an object of type Boolean', () => {
     expect(new Boolean()).toBeBoolean();
   });
 
-  it('fails when not given a boolean', () => {
+  test('fails when not given a boolean', () => {
     expect(() => expect(1).toBeBoolean()).toThrowErrorMatchingSnapshot();
   });
 });
@@ -36,15 +36,15 @@ describe('.not.toBeBoolean', () => {
     [undefined],
     [null],
     [NaN]
-  ]).it('passes when item is not of type boolean: %s', given => {
+  ]).test('passes when item is not of type boolean: %s', given => {
     expect(given).not.toBeBoolean();
   });
 
-  it('fails when given a boolean', () => {
+  test('fails when given a boolean', () => {
     expect(() => expect(true).not.toBeBoolean()).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given an object of type boolean', () => {
+  test('fails when given an object of type boolean', () => {
     expect(() => expect(new Boolean()).not.toBeBoolean()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeBoolean/predicate.test.js
+++ b/src/matchers/toBeBoolean/predicate.test.js
@@ -2,15 +2,15 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeBoolean', () => {
-  it('returns true when given a boolean', () => {
+  test('returns true when given a boolean', () => {
     expect(predicate(false)).toBe(true);
   });
 
-  it('returns true when given an object of type Boolean', () => {
+  test('returns true when given an object of type Boolean', () => {
     expect(predicate(new Boolean(false))).toBe(true);
   });
 
-  each([['false'], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).it(
+  each([['false'], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeEmpty/index.test.js
+++ b/src/matchers/toBeEmpty/index.test.js
@@ -3,45 +3,45 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeEmpty', () => {
-  it('passes when given empty string', () => {
+  test('passes when given empty string', () => {
     expect('').toBeEmpty();
   });
 
-  it('passes when given empty string object', () => {
+  test('passes when given empty string object', () => {
     expect(new String('')).toBeEmpty();
   });
 
-  it('passes when given empty array', () => {
+  test('passes when given empty array', () => {
     expect([]).toBeEmpty();
   });
 
-  it('passes when given empty object', () => {
+  test('passes when given empty object', () => {
     expect({}).toBeEmpty();
   });
 
-  it('fails when given non-empty string', () => {
+  test('fails when given non-empty string', () => {
     expect(() => expect('string').toBeEmpty()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeEmpty', () => {
-  it('passes when given a non-empty string', () => {
+  test('passes when given a non-empty string', () => {
     expect('string').not.toBeEmpty();
   });
 
-  it('passes when given a non-empty string object', () => {
+  test('passes when given a non-empty string object', () => {
     expect(new String('string')).not.toBeEmpty();
   });
 
-  it('passes when given a non-empty array', () => {
+  test('passes when given a non-empty array', () => {
     expect([1, 2]).not.toBeEmpty();
   });
 
-  it('passes when given a non-empty object', () => {
+  test('passes when given a non-empty object', () => {
     expect({ foo: 'bar' }).not.toBeEmpty();
   });
 
-  it('fails when given empty string', () => {
+  test('fails when given empty string', () => {
     expect(() => expect('').not.toBeEmpty()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeEmpty/predicate.test.js
+++ b/src/matchers/toBeEmpty/predicate.test.js
@@ -2,37 +2,37 @@ import predicate from './predicate';
 
 describe('toBeEmpty Predicate', () => {
   describe('returns true', () => {
-    it('When empty string is passed', () => {
+    test('When empty string is passed', () => {
       expect(predicate('')).toBe(true);
     });
 
-    it('When empty string object is passed', () => {
+    test('When empty string object is passed', () => {
       expect(predicate(new String(''))).toBe(true);
     });
 
-    it('When empty array is passed', () => {
+    test('When empty array is passed', () => {
       expect(predicate([])).toBe(true);
     });
 
-    it('When empty object is passed', () => {
+    test('When empty object is passed', () => {
       expect(predicate({})).toBe(true);
     });
   });
 
   describe('return false', () => {
-    it('When array with members is passed', () => {
+    test('When array with members is passed', () => {
       expect(predicate(['1'])).toBe(false);
     });
 
-    it('When non-empty string is passed', () => {
+    test('When non-empty string is passed', () => {
       expect(predicate('string')).toBe(false);
     });
 
-    it('When non-empty string object is passed', () => {
+    test('When non-empty string object is passed', () => {
       expect(predicate(new String('string'))).toBe(false);
     });
 
-    it('When object with members is passed', () => {
+    test('When object with members is passed', () => {
       expect(predicate({ foo: 'bar' })).toBe(false);
     });
   });

--- a/src/matchers/toBeEven/index.test.js
+++ b/src/matchers/toBeEven/index.test.js
@@ -5,7 +5,7 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeEven', () => {
-  it('passes when given even number', () => {
+  test('passes when given even number', () => {
     expect(2).toBeEven();
   });
 
@@ -19,13 +19,13 @@ describe('.toBeEven', () => {
     [undefined],
     [null],
     [NaN]
-  ]).it('fails when not given an even number', given => {
+  ]).test('fails when not given an even number', given => {
     expect(() => expect(given).toBeEven()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeEven', () => {
-  it('fails when given an even number', () => {
+  test('fails when given an even number', () => {
     expect(() => expect(2).not.toBeEven()).toThrowErrorMatchingSnapshot();
   });
 
@@ -40,7 +40,7 @@ describe('.not.toBeEven', () => {
     [undefined],
     [null],
     [NaN]
-  ]).it('passes when not given an even number: %s', given => {
+  ]).test('passes when not given an even number: %s', given => {
     expect(given).not.toBeEven();
   });
 });

--- a/src/matchers/toBeEven/predicate.test.js
+++ b/src/matchers/toBeEven/predicate.test.js
@@ -2,15 +2,15 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeEven Predicate', () => {
-  it('returns true when given an even number', () => {
+  test('returns true when given an even number', () => {
     expect(predicate(2)).toBe(true);
   });
 
-  it('returns false when given an odd number', () => {
+  test('returns false when given an odd number', () => {
     expect(predicate(1)).toBe(false);
   });
 
-  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeExtensible/index.test.js
+++ b/src/matchers/toBeExtensible/index.test.js
@@ -5,7 +5,7 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeExtensible', () => {
-  each([[{}], [[]], [() => {}]]).it('passes when given an extensible object: %s', given => {
+  each([[{}], [[]], [() => {}]]).test('passes when given an extensible object: %s', given => {
     expect(given).toBeExtensible();
   });
 
@@ -18,7 +18,7 @@ describe('.toBeExtensible', () => {
     [NaN],
     [Object.seal({})],
     [Object.freeze({})]
-  ]).it('fails when not given an extensible object: %s', given => {
+  ]).test('fails when not given an extensible object: %s', given => {
     expect(() => expect(given).toBeExtensible()).toThrowErrorMatchingSnapshot();
   });
 });
@@ -33,11 +33,11 @@ describe('.not.toBeExtensible', () => {
     [NaN],
     [Object.seal({})],
     [Object.freeze({})]
-  ]).it('passes when not given extensible object: %s', given => {
+  ]).test('passes when not given extensible object: %s', given => {
     expect(given).not.toBeExtensible();
   });
 
-  each([[{}], [[]], [() => {}]]).it('fails when given an extensible object: %s', given => {
+  each([[{}], [[]], [() => {}]]).test('fails when given an extensible object: %s', given => {
     expect(() => expect(given).not.toBeExtensible()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeExtensible/predicate.test.js
+++ b/src/matchers/toBeExtensible/predicate.test.js
@@ -2,7 +2,7 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeExpected Predicate', () => {
-  each([[{}], [[]], [() => {}]]).it('returns true when given extensible object: %s', given => {
+  each([[{}], [[]], [() => {}]]).test('returns true when given extensible object: %s', given => {
     expect(predicate(given)).toBe(true);
   });
 
@@ -15,7 +15,7 @@ describe('toBeExpected Predicate', () => {
     [NaN],
     [Object.seal({})],
     [Object.freeze({})]
-  ]).it('returns false when given non-extensible object: %s', given => {
+  ]).test('returns false when given non-extensible object: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeFalse/index.test.js
+++ b/src/matchers/toBeFalse/index.test.js
@@ -5,24 +5,24 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeFalse', () => {
-  it('passes when given false', () => {
+  test('passes when given false', () => {
     expect(false).toBeFalse();
   });
 
-  it('fails when not given false', () => {
+  test('fails when not given false', () => {
     expect(() => expect(true).toBeFalse()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeFalse', () => {
-  each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
     'passes when not given false: %s',
     given => {
       expect(given).not.toBeFalse();
     }
   );
 
-  it('fails when given false', () => {
+  test('fails when given false', () => {
     expect(() => expect(false).not.toBeFalse()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeFalse/predicate.test.js
+++ b/src/matchers/toBeFalse/predicate.test.js
@@ -2,11 +2,11 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeFalse Predicate', () => {
-  it('returns true when given false', () => {
+  test('returns true when given false', () => {
     expect(predicate(false)).toBe(true);
   });
 
-  each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeFinite/index.test.js
+++ b/src/matchers/toBeFinite/index.test.js
@@ -3,45 +3,45 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeFinite', () => {
-  it('passes when given a positive finite number', () => {
+  test('passes when given a positive finite number', () => {
     expect(1).toBeFinite();
   });
 
-  it('passes when given a negative finite number', () => {
+  test('passes when given a negative finite number', () => {
     expect(-1).toBeFinite();
   });
 
-  it('passes when given the largest finite number', () => {
+  test('passes when given the largest finite number', () => {
     expect(Number.MAX_SAFE_INTEGER).toBeFinite();
   });
 
-  it('passes when given the largetst negative finite number', () => {
+  test('passes when given the largetst negative finite number', () => {
     expect(Number.MIN_SAFE_INTEGER).toBeFinite();
   });
 
-  it('passes when given 0', () => {
+  test('passes when given 0', () => {
     expect(0).toBeFinite();
   });
 
-  it('fails when not given NaN', () => {
+  test('fails when not given NaN', () => {
     expect(() => expect(NaN).toBeFinite()).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when not given Infinity', () => {
+  test('fails when not given Infinity', () => {
     expect(() => expect(Infinity).toBeFinite()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeFinite', () => {
-  it('fails when given a finite number', () => {
+  test('fails when given a finite number', () => {
     expect(() => expect(1).not.toBeFinite()).toThrowErrorMatchingSnapshot();
   });
 
-  it('passes when given NaN', () => {
+  test('passes when given NaN', () => {
     expect(NaN).not.toBeFinite();
   });
 
-  it('passes when given Infinity', () => {
+  test('passes when given Infinity', () => {
     expect(Infinity).not.toBeFinite();
   });
 });

--- a/src/matchers/toBeFinite/predicate.test.js
+++ b/src/matchers/toBeFinite/predicate.test.js
@@ -1,15 +1,15 @@
 import predicate from './predicate';
 
 describe('toBeFinite Predicate', () => {
-  it('returns true when given a finite number', () => {
+  test('returns true when given a finite number', () => {
     expect(predicate(1)).toBe(true);
   });
 
-  it('return false when given infinity', () => {
+  test('return false when given infinity', () => {
     expect(predicate(Infinity)).toBe(false);
   });
 
-  it('return false when given NaN', () => {
+  test('return false when given NaN', () => {
     expect(predicate(NaN)).toBe(false);
   });
 });

--- a/src/matchers/toBeFrozen/index.test.js
+++ b/src/matchers/toBeFrozen/index.test.js
@@ -3,21 +3,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeFrozen', () => {
-  it('passes when given frozen object', () => {
+  test('passes when given frozen object', () => {
     expect(Object.freeze({})).toBeFrozen();
   });
 
-  it('fails when given a non-frozen object', () => {
+  test('fails when given a non-frozen object', () => {
     expect(() => expect({}).toBeFrozen()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeFrozen', () => {
-  it('fails when given frozen object', () => {
+  test('fails when given frozen object', () => {
     expect(() => expect(Object.freeze({})).not.toBeFrozen()).toThrowErrorMatchingSnapshot();
   });
 
-  it('passes when given a non-frozen object', () => {
+  test('passes when given a non-frozen object', () => {
     expect({}).not.toBeFrozen();
   });
 });

--- a/src/matchers/toBeFrozen/predicate.test.js
+++ b/src/matchers/toBeFrozen/predicate.test.js
@@ -1,11 +1,11 @@
 import predicate from './predicate';
 
 describe('toBeFrozen Predicate', () => {
-  it('returns true when given a frozen object', () => {
+  test('returns true when given a frozen object', () => {
     expect(predicate(Object.freeze({}))).toBe(true);
   });
 
-  it('returns false when given a non-frozen object', () => {
+  test('returns false when given a non-frozen object', () => {
     expect(predicate({})).toBe(false);
   });
 });

--- a/src/matchers/toBeFunction/index.test.js
+++ b/src/matchers/toBeFunction/index.test.js
@@ -5,24 +5,24 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeFunction', () => {
-  it('passes when given a function', () => {
+  test('passes when given a function', () => {
     expect(() => {}).toBeFunction();
   });
 
-  it('fails when not given a function', () => {
+  test('fails when not given a function', () => {
     expect(() => expect(false).toBeFunction()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeFunction', () => {
-  each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]]).it(
+  each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]]).test(
     'passes when not given a function: %s',
     given => {
       expect(given).not.toBeFunction();
     }
   );
 
-  it('fails when given a function', () => {
+  test('fails when given a function', () => {
     expect(() => expect(() => {}).not.toBeFunction()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeFunction/predicate.test.js
+++ b/src/matchers/toBeFunction/predicate.test.js
@@ -2,11 +2,11 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeFunction Predicate', () => {
-  it('returns true when given a function', () => {
+  test('returns true when given a function', () => {
     expect(predicate(() => {})).toBe(true);
   });
 
-  each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]]).it('returns false when given: %s', given => {
+  each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]]).test('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeNaN/index.test.js
+++ b/src/matchers/toBeNaN/index.test.js
@@ -5,21 +5,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeNaN', () => {
-  it('passes when given a non-number', () => {
+  test('passes when given a non-number', () => {
     expect({}).toBeNaN();
   });
 
-  it('fails when given a number', () => {
+  test('fails when given a number', () => {
     expect(() => expect(3).toBeNaN()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeNaN', () => {
-  each([[0], [1], [300], [10.5], [-50]]).it('passes when given a number: %s', given => {
+  each([[0], [1], [300], [10.5], [-50]]).test('passes when given a number: %s', given => {
     expect(given).not.toBeNaN();
   });
 
-  it('fails when given a non-number', () => {
+  test('fails when given a non-number', () => {
     expect(() => expect(undefined).not.toBeNaN()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeNaN/predicate.test.js
+++ b/src/matchers/toBeNaN/predicate.test.js
@@ -2,11 +2,11 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeNaN Predicate', () => {
-  it('returns true when given a non-number', () => {
+  test('returns true when given a non-number', () => {
     expect(predicate({})).toBe(true);
   });
 
-  each([[0], [1], [300], [10.5], [-50]]).it('returns false when given: %s', given => {
+  each([[0], [1], [300], [10.5], [-50]]).test('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeNegative/index.test.js
+++ b/src/matchers/toBeNegative/index.test.js
@@ -3,33 +3,33 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeNegative', () => {
-  it('passes when given negative number', () => {
+  test('passes when given negative number', () => {
     expect(-1).toBeNegative();
   });
 
-  it('fails when given positive number', () => {
+  test('fails when given positive number', () => {
     expect(() => expect(1).toBeNegative()).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given Infinity', () => {
+  test('fails when given Infinity', () => {
     expect(() => expect(Infinity).toBeNegative()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeNegative', () => {
-  it('passes when given positive number', () => {
+  test('passes when given positive number', () => {
     expect(1).not.toBeNegative();
   });
 
-  it('passes when given Infinity', () => {
+  test('passes when given Infinity', () => {
     expect(Infinity).not.toBeNegative();
   });
 
-  it('passes when given NaN', () => {
+  test('passes when given NaN', () => {
     expect(NaN).not.toBeNegative();
   });
 
-  it('fails when given negative number', () => {
+  test('fails when given negative number', () => {
     expect(() => expect(-1).not.toBeNegative()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeNegative/predicate.test.js
+++ b/src/matchers/toBeNegative/predicate.test.js
@@ -2,24 +2,24 @@ import predicate from './predicate';
 
 describe('toBeNegative Predicate', () => {
   describe('returns true', () => {
-    it('When negative number is passed', () => {
+    test('When negative number is passed', () => {
       expect(predicate(-1)).toBe(true);
       expect(predicate(-100.1)).toBe(true);
     });
   });
 
   describe('return false', () => {
-    it('When positive number is passed', () => {
+    test('When positive number is passed', () => {
       expect(predicate(1)).toBe(false);
       expect(predicate(100.1)).toBe(false);
       expect(predicate(Infinity)).toBe(false);
     });
 
-    it('When Infinity is passed', () => {
+    test('When Infinity is passed', () => {
       expect(predicate(Infinity)).toBe(false);
     });
 
-    it('When NaN is passed', () => {
+    test('When NaN is passed', () => {
       expect(predicate(NaN)).toBe(false);
       expect(predicate('Not a number!')).toBe(false);
       expect(predicate({})).toBe(false);

--- a/src/matchers/toBeNil/index.test.js
+++ b/src/matchers/toBeNil/index.test.js
@@ -5,24 +5,24 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeNil', () => {
-  it('passes when null is given', () => {
+  test('passes when null is given', () => {
     expect(null).toBeNil();
   });
 
-  it('passes when undefined is given', () => {
+  test('passes when undefined is given', () => {
     expect(undefined).toBeNil();
   });
-  it('fails when the value is not null or undefined', () => {
+  test('fails when the value is not null or undefined', () => {
     expect(() => expect('value').toBeNil()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeNil', () => {
-  each([['true'], [{}], [true]]).it('passes when value is not null or undefined : %s', given => {
+  each([['true'], [{}], [true]]).test('passes when value is not null or undefined : %s', given => {
     expect(given).not.toBeNil();
   });
 
-  it('fails when null is given', () => {
+  test('fails when null is given', () => {
     expect(() => expect(null).not.toBeNil()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeNil/predicate.test.js
+++ b/src/matchers/toBeNil/predicate.test.js
@@ -2,15 +2,15 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeNil', () => {
-  it('returns true when value is undefined', () => {
+  test('returns true when value is undefined', () => {
     expect(predicate(undefined)).toBe(true);
   });
 
-  it('returns true when value is null', () => {
+  test('returns true when value is null', () => {
     expect(predicate(null)).toBe(true);
   });
 
-  each([['false'], [['hello', 'world']], [{ hello: 'world' }]]).it('returns false when given: %s', given => {
+  each([['false'], [['hello', 'world']], [{ hello: 'world' }]]).test('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeNumber/index.test.js
+++ b/src/matchers/toBeNumber/index.test.js
@@ -5,24 +5,24 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeNumber', () => {
-  it('passes when given a number', () => {
+  test('passes when given a number', () => {
     expect(1).toBeNumber();
   });
 
-  it('fails when not given a number', () => {
+  test('fails when not given a number', () => {
     expect(() => expect(false).toBeNumber()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeNumber', () => {
-  each([[false], [true], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[false], [true], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
     'passes when not given a number: %s',
     given => {
       expect(given).not.toBeNumber();
     }
   );
 
-  it('fails when given a number', () => {
+  test('fails when given a number', () => {
     expect(() => expect(1).not.toBeNumber()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeNumber/predicate.test.js
+++ b/src/matchers/toBeNumber/predicate.test.js
@@ -2,11 +2,11 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeNumber Predicate', () => {
-  it('returns true when given a number', () => {
+  test('returns true when given a number', () => {
     expect(predicate(10)).toBe(true);
   });
 
-  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeObject/index.test.js
+++ b/src/matchers/toBeObject/index.test.js
@@ -5,21 +5,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeObject', () => {
-  it('passes when given an object', () => {
+  test('passes when given an object', () => {
     expect({}).toBeObject();
   });
 
-  each([[false], [''], [0], [() => {}], [undefined], [NaN]]).it('fails when not given an object: %s', given => {
+  each([[false], [''], [0], [() => {}], [undefined], [NaN]]).test('fails when not given an object: %s', given => {
     expect(() => expect(given).toBeObject()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeObject', () => {
-  each([[false], [''], [0], [() => {}], [undefined], [NaN]]).it('passes when not given an object: %s', given => {
+  each([[false], [''], [0], [() => {}], [undefined], [NaN]]).test('passes when not given an object: %s', given => {
     expect(given).not.toBeObject();
   });
 
-  it('fails when given an object', () => {
+  test('fails when given an object', () => {
     expect(() => expect({}).not.toBeObject()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeObject/predicate.test.js
+++ b/src/matchers/toBeObject/predicate.test.js
@@ -2,11 +2,11 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeObject Predicate', () => {
-  it('returns true when given an object', () => {
+  test('returns true when given an object', () => {
     expect(predicate({})).toBe(true);
   });
 
-  each([[false], [''], [0], [() => {}], [undefined], [NaN]]).it('returns false when given: %s', given => {
+  each([[false], [''], [0], [() => {}], [undefined], [NaN]]).test('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeOdd/index.test.js
+++ b/src/matchers/toBeOdd/index.test.js
@@ -5,7 +5,7 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeOdd', () => {
-  it('passes when given an odd number', () => {
+  test('passes when given an odd number', () => {
     expect(1).toBeOdd();
   });
 
@@ -19,7 +19,7 @@ describe('.toBeOdd', () => {
     [undefined],
     [null],
     [NaN]
-  ]).it('fails when given not given an odd number', given => {
+  ]).test('fails when given not given an odd number', given => {
     expect(() => expect(given).toBeOdd()).toThrowErrorMatchingSnapshot();
   });
 });
@@ -36,11 +36,11 @@ describe('.not.toBeOdd', () => {
     [undefined],
     [null],
     [NaN]
-  ]).it('passes when not given an odd number: %s', given => {
+  ]).test('passes when not given an odd number: %s', given => {
     expect(given).not.toBeOdd();
   });
 
-  it('fails when given an odd number', () => {
+  test('fails when given an odd number', () => {
     expect(() => expect(1).not.toBeOdd()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeOdd/predicate.test.js
+++ b/src/matchers/toBeOdd/predicate.test.js
@@ -2,15 +2,15 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeOdd Predicate', () => {
-  it('returns true when given an odd number', () => {
+  test('returns true when given an odd number', () => {
     expect(predicate(1)).toBe(true);
   });
 
-  it('returns false when given an even number', () => {
+  test('returns false when given an even number', () => {
     expect(predicate(2)).toBe(false);
   });
 
-  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeOneOf/index.test.js
+++ b/src/matchers/toBeOneOf/index.test.js
@@ -3,21 +3,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeOneOf', () => {
-  it('passes when value is in given array', () => {
+  test('passes when value is in given array', () => {
     expect(1).toBeOneOf([1, 2, 3]);
   });
 
-  it('fails when value is not in given array', () => {
+  test('fails when value is not in given array', () => {
     expect(() => expect(4).toBeOneOf([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeOneOf', () => {
-  it('passes when value is not in given array', () => {
+  test('passes when value is not in given array', () => {
     expect(4).not.toBeOneOf([1, 2, 3]);
   });
 
-  it('fails when value is in given array', () => {
+  test('fails when value is in given array', () => {
     expect(() => expect(1).not.toBeOneOf([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeOneOf/predicate.test.js
+++ b/src/matchers/toBeOneOf/predicate.test.js
@@ -2,14 +2,14 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('.toBeOneOf', () => {
-  each([[1], [null], [undefined], [false], ['']]).it(
+  each([[1], [null], [undefined], [false], ['']]).test(
     'returns true when primitive value: %s is in given array',
     value => {
       expect(predicate(value, [1, 2, 3, null, undefined, false, ''])).toBe(true);
     }
   );
 
-  each([[{ hello: 'world' }], [['foo']]]).it('returns true when nested value: %s is in given array', value => {
+  each([[{ hello: 'world' }], [['foo']]]).test('returns true when nested value: %s is in given array', value => {
     expect(predicate(value, [1, 2, { hello: 'world' }, ['foo']])).toBe(true);
   });
 
@@ -21,7 +21,7 @@ describe('.toBeOneOf', () => {
     [''],
     [{ hello: 'world' }],
     [['foo']]
-  ]).it('returns false when value: %s is not in given array', value => {
+  ]).test('returns false when value: %s is not in given array', value => {
     expect(predicate(value, [1, 2, 3])).toBe(false);
   });
 });

--- a/src/matchers/toBePositive/index.test.js
+++ b/src/matchers/toBePositive/index.test.js
@@ -5,11 +5,11 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBePositive', () => {
-  it('passes when given a positive number', () => {
+  test('passes when given a positive number', () => {
     expect(1).toBePositive();
   });
 
-  it('fails when not given a positive number', () => {
+  test('fails when not given a positive number', () => {
     expect(() => expect(-1).toBePositive()).toThrowErrorMatchingSnapshot();
   });
 });
@@ -27,11 +27,11 @@ describe('.not.toBePositive', () => {
     [null],
     [NaN],
     [Infinity]
-  ]).it('passes when not given a positive number: %s', given => {
+  ]).test('passes when not given a positive number: %s', given => {
     expect(given).not.toBePositive();
   });
 
-  it('fails when given a positive number', () => {
+  test('fails when given a positive number', () => {
     expect(() => expect(5).not.toBePositive()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBePositive/predicate.test.js
+++ b/src/matchers/toBePositive/predicate.test.js
@@ -2,7 +2,7 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBePositive Predicate', () => {
-  it('returns true when given a positive number', () => {
+  test('returns true when given a positive number', () => {
     expect(predicate(1)).toBe(true);
   });
 
@@ -18,7 +18,7 @@ describe('toBePositive Predicate', () => {
     [null],
     [NaN],
     [Infinity]
-  ]).it('returns false when given: %s', given => {
+  ]).test('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeSealed/index.test.js
+++ b/src/matchers/toBeSealed/index.test.js
@@ -3,21 +3,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeSealed', () => {
-  it('passes when given sealed object', () => {
+  test('passes when given sealed object', () => {
     expect(Object.seal({})).toBeSealed();
   });
 
-  it('fails when given a non-sealed object', () => {
+  test('fails when given a non-sealed object', () => {
     expect(() => expect({}).toBeSealed()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeSealed', () => {
-  it('fails when given sealed object', () => {
+  test('fails when given sealed object', () => {
     expect(() => expect(Object.seal({})).not.toBeSealed()).toThrowErrorMatchingSnapshot();
   });
 
-  it('passes when given a non-sealed object', () => {
+  test('passes when given a non-sealed object', () => {
     expect({}).not.toBeSealed();
   });
 });

--- a/src/matchers/toBeSealed/predicate.test.js
+++ b/src/matchers/toBeSealed/predicate.test.js
@@ -1,11 +1,11 @@
 import predicate from './predicate';
 
 describe('toBeSealed Predicate', () => {
-  it('returns true when given a sealed object', () => {
+  test('returns true when given a sealed object', () => {
     expect(predicate(Object.seal({}))).toBe(true);
   });
 
-  it('returns false when given a non-sealed object', () => {
+  test('returns false when given a non-sealed object', () => {
     expect(predicate({})).toBe(false);
   });
 });

--- a/src/matchers/toBeString/index.test.js
+++ b/src/matchers/toBeString/index.test.js
@@ -5,15 +5,15 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeString', () => {
-  it('passes when given a string literal', () => {
+  test('passes when given a string literal', () => {
     expect('string type').toBeString();
   });
 
-  it('passes when given an object of type string', () => {
+  test('passes when given an object of type string', () => {
     expect(new String('string type')).toBeString();
   });
 
-  it('fails when not given a string', () => {
+  test('fails when not given a string', () => {
     expect(() => expect(5).toBeString()).toThrowErrorMatchingSnapshot();
   });
 });
@@ -28,15 +28,15 @@ describe('.not.toBeString', () => {
     [undefined],
     [null],
     [NaN]
-  ]).it('passes when not item is not of type string: %s', given => {
+  ]).test('passes when not item is not of type string: %s', given => {
     expect(given).not.toBeString();
   });
 
-  it('fails when given a string literal', () => {
+  test('fails when given a string literal', () => {
     expect(() => expect('').not.toBeString()).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given an object of type string', () => {
+  test('fails when given an object of type string', () => {
     expect(() => expect(new String('string type')).not.toBeString()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeString/predicate.test.js
+++ b/src/matchers/toBeString/predicate.test.js
@@ -2,15 +2,18 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeString Predicate', () => {
-  it('returns true when given a string literal', () => {
+  test('returns true when given a string literal', () => {
     expect(predicate('string example')).toBe(true);
   });
 
-  it('returns true when given a string object', () => {
+  test('returns true when given a string object', () => {
     expect(predicate(new String('string example'))).toBe(true);
   });
 
-  each([[false], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).it('returns false when given: %s', given => {
-    expect(predicate(given)).toBe(false);
-  });
+  each([[false], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+    'returns false when given: %s',
+    given => {
+      expect(predicate(given)).toBe(false);
+    }
+  );
 });

--- a/src/matchers/toBeTrue/index.test.js
+++ b/src/matchers/toBeTrue/index.test.js
@@ -5,24 +5,24 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeTrue', () => {
-  it('passes when given true', () => {
+  test('passes when given true', () => {
     expect(true).toBeTrue();
   });
 
-  it('fails when not given true', () => {
+  test('fails when not given true', () => {
     expect(() => expect(false).toBeTrue()).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeTrue', () => {
-  each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
     'passes when not given true: %s',
     given => {
       expect(given).not.toBeTrue();
     }
   );
 
-  it('fails when given true', () => {
+  test('fails when given true', () => {
     expect(() => expect(true).not.toBeTrue()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeTrue/predicate.test.js
+++ b/src/matchers/toBeTrue/predicate.test.js
@@ -2,11 +2,11 @@ import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeTrue Predicate', () => {
-  it('returns true when given an array', () => {
+  test('returns true when given an array', () => {
     expect(predicate(true)).toBe(true);
   });
 
-  each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).it(
+  each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeWithin/index.test.js
+++ b/src/matchers/toBeWithin/index.test.js
@@ -3,21 +3,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toBeWithin', () => {
-  it('passes when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
+  test('passes when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
     expect(1).toBeWithin(1, 3);
   });
 
-  it('fails when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
+  test('fails when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
     expect(() => expect(3).toBeWithin(1, 3)).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toBeWithin', () => {
-  it('passes when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
+  test('passes when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
     expect(3).not.toBeWithin(1, 3);
   });
 
-  it('fails when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
+  test('fails when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
     expect(() => expect(1).not.toBeWithin(1, 3)).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeWithin/predicate.test.js
+++ b/src/matchers/toBeWithin/predicate.test.js
@@ -1,11 +1,11 @@
 import predicate from './predicate';
 
 describe('toBeWithin Predicate', () => {
-  it('returns true when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
+  test('returns true when given number is within the given bounds of start (inclusive) and end (exclusive)', () => {
     expect(predicate(1, 1, 3)).toBe(true);
   });
 
-  it('returns false when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
+  test('returns false when given number is not within the given bounds of start (inclusive) and end (exclusive)', () => {
     expect(predicate(3, 1, 3)).toBe(false);
   });
 });

--- a/src/matchers/toContainAllEntries/index.test.js
+++ b/src/matchers/toContainAllEntries/index.test.js
@@ -5,21 +5,21 @@ expect.extend(matcher);
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainAllEntries', () => {
-  it('passes when object only contains all of the given entries', () => {
+  test('passes when object only contains all of the given entries', () => {
     expect(data).toContainAllEntries([['a', 'foo'], ['b', 'bar'], ['c', 'baz']]);
   });
 
-  it('fails when object does not only contain all of the given entries', () => {
+  test('fails when object does not only contain all of the given entries', () => {
     expect(() => expect(data).toContainAllEntries([['a', 'foo'], ['b', 'bar']])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainAllEntries', () => {
-  it('passes when object does not only contain all of the given entries', () => {
+  test('passes when object does not only contain all of the given entries', () => {
     expect(data).not.toContainAllEntries([['a', 'qux'], ['b', 'bar'], ['c', 'baz']]);
   });
 
-  it('fails when object only contains all of the given entries', () => {
+  test('fails when object only contains all of the given entries', () => {
     expect(() =>
       expect(data).not.toContainAllEntries([['b', 'bar'], ['a', 'foo'], ['c', 'baz']])
     ).toThrowErrorMatchingSnapshot();

--- a/src/matchers/toContainAllEntries/predicate.test.js
+++ b/src/matchers/toContainAllEntries/predicate.test.js
@@ -3,18 +3,18 @@ import predicate from './predicate';
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainAllEntries', () => {
-  it('passes when given nested values', () => {
+  test('passes when given nested values', () => {
     expect(predicate({ hello: { message: 'world' } }, [['hello', { message: 'world' }]])).toBe(true);
   });
-  it('passes when object only contains all of the given entries', () => {
+  test('passes when object only contains all of the given entries', () => {
     expect(predicate(data, [['a', 'foo'], ['b', 'bar'], ['c', 'baz']])).toBe(true);
   });
 
-  it('fails when object does not only contain all of the given entries', () => {
+  test('fails when object does not only contain all of the given entries', () => {
     expect(predicate(data, [['a', 'foo'], ['b', 'bar']])).toBe(false);
   });
 
-  it('fails when object does not contain all of the given entries', () => {
+  test('fails when object does not contain all of the given entries', () => {
     expect(predicate(data, [['a', 'foo'], ['b', 'bar'], ['c', 'baz'], ['d', 'qux']])).toBe(false);
   });
 });

--- a/src/matchers/toContainAllKeys/index.test.js
+++ b/src/matchers/toContainAllKeys/index.test.js
@@ -5,21 +5,21 @@ expect.extend(matcher);
 const data = { a: 'hello', b: 'world' };
 
 describe('.toContainAllKeys', () => {
-  it('passes when given object contains all keys', () => {
+  test('passes when given object contains all keys', () => {
     expect(data).toContainAllKeys(['a', 'b']);
   });
 
-  it('fails when given object does not contain all keys', () => {
+  test('fails when given object does not contain all keys', () => {
     expect(() => expect(data).toContainAllKeys(['a'])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainAllKeys', () => {
-  it('passes when given object does not contain key', () => {
+  test('passes when given object does not contain key', () => {
     expect(data).not.toContainAllKeys(['a']);
   });
 
-  it('fails when given object contains all keys', () => {
+  test('fails when given object contains all keys', () => {
     expect(() => expect(data).not.toContainAllKeys(['b', 'a'])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainAllKeys/predicate.test.js
+++ b/src/matchers/toContainAllKeys/predicate.test.js
@@ -3,15 +3,15 @@ import predicate from './predicate';
 const data = { a: 'hello', b: 'world' };
 
 describe('.toContainAllKeys', () => {
-  it('passes when given object contains all keys', () => {
+  test('passes when given object contains all keys', () => {
     expect(predicate(data, ['a', 'b'])).toBe(true);
   });
 
-  it('passes when given object contains all keys, regardless of order', () => {
+  test('passes when given object contains all keys, regardless of order', () => {
     expect(predicate(data, ['b', 'a'])).toBe(true);
   });
 
-  it('fails when given object does not contain all keys', () => {
+  test('fails when given object does not contain all keys', () => {
     expect(predicate(data, ['b'])).toBe(false);
   });
 });

--- a/src/matchers/toContainAllValues/index.test.js
+++ b/src/matchers/toContainAllValues/index.test.js
@@ -17,56 +17,56 @@ const deepArray = {
 };
 
 describe('.toContainAllValues', () => {
-  it('passes when given object contains primitive values', () => {
+  test('passes when given object contains primitive values', () => {
     expect(shallow).toContainAllValues(['world', 0, false]);
   });
 
-  it('passes when given object contains all values including objects', () => {
+  test('passes when given object contains all values including objects', () => {
     expect(deep).toContainAllValues([{ hello: 'world', foo: 0, bar: false }, 'duck']);
   });
 
-  it('passes when given object contains all values including arrays', () => {
+  test('passes when given object contains all values including arrays', () => {
     expect(deepArray).toContainAllValues(['duck', [{ hello: 'world', foo: 0, bar: false }]]);
   });
 
-  it('fails when given object does not contain all primitive values', () => {
+  test('fails when given object does not contain all primitive values', () => {
     expect(() => expect(shallow).toContainAllValues(['hello', 0, false])).toThrowErrorMatchingSnapshot();
     expect(() => expect(shallow).toContainAllValues(['world', 0])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object does not contain all values including objects', () => {
+  test('fails when given object does not contain all values including objects', () => {
     expect(() => expect(deep).toContainAllValues([{ hello: 'world' }])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object does not contain all values including arrays', () => {
+  test('fails when given object does not contain all values including arrays', () => {
     expect(() => expect(deepArray).toContainAllValues(['duck', [{ hello: 'world' }]])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainAllValues', () => {
-  it('passes when given object does not contain all primitive values', () => {
+  test('passes when given object does not contain all primitive values', () => {
     expect(shallow).not.toContainAllValues(['foo', 0]);
   });
 
-  it('passes when given object does not contain all values including objects', () => {
+  test('passes when given object does not contain all values including objects', () => {
     expect(deep).not.toContainAllValues(['duck', { foo: 'bar' }]);
   });
 
-  it('passes when given object does not contain all values including arrays', () => {
+  test('passes when given object does not contain all values including arrays', () => {
     expect(deepArray).not.toContainAllValues(['duck', [{ foo: 'bar' }]]);
   });
 
-  it('fails when given object contains primitive values', () => {
+  test('fails when given object contains primitive values', () => {
     expect(() => expect(shallow).not.toContainAllValues(['world', 0, false])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object contains all values including objects', () => {
+  test('fails when given object contains all values including objects', () => {
     expect(() =>
       expect(deep).not.toContainAllValues([{ hello: 'world', foo: 0, bar: false }, 'duck'])
     ).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object contains all values including arrays', () => {
+  test('fails when given object contains all values including arrays', () => {
     expect(() =>
       expect(deepArray).not.toContainAllValues(['duck', [{ hello: 'world', foo: 0, bar: false }]])
     ).toThrowErrorMatchingSnapshot();

--- a/src/matchers/toContainAllValues/predicate.test.js
+++ b/src/matchers/toContainAllValues/predicate.test.js
@@ -16,33 +16,33 @@ describe('toContainAllValues Predicate', () => {
   };
 
   describe('returns true', () => {
-    it('when given object contains all primitive values', () => {
+    test('when given object contains all primitive values', () => {
       expect(predicate(shallow, ['world', false, 0])).toBe(true);
     });
 
-    it('when given object contains all values including objects', () => {
+    test('when given object contains all values including objects', () => {
       expect(predicate(deep, ['duck', { hello: 'world', foo: 0, bar: false }])).toBe(true);
     });
 
-    it('when given object contains all values including arrays', () => {
+    test('when given object contains all values including arrays', () => {
       expect(predicate(deepArray, ['duck', [{ hello: 'world', foo: 0, bar: false }]])).toBe(true);
     });
   });
 
   describe('returns false', () => {
-    it('returns false when object does not contain all values', () => {
+    test('returns false when object does not contain all values', () => {
       const o = { a: 'foo', b: 'bar', c: 'baz' };
       expect(predicate(o, ['foo', 'bar', 'baz', 'qux'])).toBe(false);
     });
-    it('when given object does not contain all primitive value', () => {
+    test('when given object does not contain all primitive value', () => {
       expect(predicate(shallow, ['world', false])).toBe(false);
     });
 
-    it('when given object does not contain all values including objects', () => {
+    test('when given object does not contain all values including objects', () => {
       expect(predicate(deep, ['made up value', 'duck', { hello: 'world', foo: 0 }])).toBe(false);
     });
 
-    it('when given object does not contain all values including arrays', () => {
+    test('when given object does not contain all values including arrays', () => {
       expect(predicate(deepArray, ['duck', 'made up value', [{ hello: 'world', foo: 0 }]])).toBe(false);
     });
   });

--- a/src/matchers/toContainAnyEntries/index.test.js
+++ b/src/matchers/toContainAnyEntries/index.test.js
@@ -5,21 +5,21 @@ expect.extend(matcher);
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainAnyEntries', () => {
-  it('passes when given object contains atleast one of the given entries', () => {
+  test('passes when given object contains atleast one of the given entries', () => {
     expect(data).toContainAnyEntries([['a', 'qux'], ['a', 'foo']]);
   });
 
-  it('fails when given object does not contain any of the given entries', () => {
+  test('fails when given object does not contain any of the given entries', () => {
     expect(() => expect(data).toContainAnyEntries([['a', 'qux'], ['b', 'foo']])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainAnyEntries', () => {
-  it('passes when given object does not contain any of the given entries', () => {
+  test('passes when given object does not contain any of the given entries', () => {
     expect(data).not.toContainAnyEntries([['a', 'qux'], ['b', 'foo']]);
   });
 
-  it('fails when given object contains atleast one of the given entries', () => {
+  test('fails when given object contains atleast one of the given entries', () => {
     expect(() => expect(data).not.toContainAnyEntries([['a', 'qux'], ['a', 'foo']])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainAnyEntries/predicate.test.js
+++ b/src/matchers/toContainAnyEntries/predicate.test.js
@@ -3,17 +3,17 @@ import predicate from './predicate';
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainAnyEntries', () => {
-  it('passes when given object contains entries', () => {
+  test('passes when given object contains entries', () => {
     expect(predicate(data, [['a', 'qux'], ['a', 'foo'], ['x', 'foo']])).toBe(true);
   });
 
-  it('passes when given object contains entries with nested values', () => {
+  test('passes when given object contains entries with nested values', () => {
     expect(
       predicate({ hello: { message: 'world' } }, [['hello', { message: 'world' }], ['a', 'foo'], ['x', 'foo']])
     ).toBe(true);
   });
 
-  it('fails when given object does not contain entries', () => {
+  test('fails when given object does not contain entries', () => {
     expect(predicate(data, [['a', 'qux'], ['b', 'foo'], ['x', 'foo']])).toBe(false);
   });
 });

--- a/src/matchers/toContainAnyKeys/index.test.js
+++ b/src/matchers/toContainAnyKeys/index.test.js
@@ -8,21 +8,21 @@ const testObject = {
 };
 
 describe('.toContainAnyKeys', () => {
-  it('passes when object contains one or more keys', () => {
+  test('passes when object contains one or more keys', () => {
     expect(testObject).toContainAnyKeys(['name']);
   });
 
-  it('fails when object does not contain any keys', () => {
+  test('fails when object does not contain any keys', () => {
     expect(() => expect(testObject).toContainAnyKeys(['occupation'])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainAnyKeys', () => {
-  it('passes when object does not contain any keys', () => {
+  test('passes when object does not contain any keys', () => {
     expect(testObject).not.toContainAnyKeys(['occupation']);
   });
 
-  it('fails when object contains one or more keys', () => {
+  test('fails when object contains one or more keys', () => {
     expect(() => expect(testObject).not.toContainAnyKeys(['name', 'age'])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainAnyKeys/predicate.test.js
+++ b/src/matchers/toContainAnyKeys/predicate.test.js
@@ -2,7 +2,7 @@ import predicate from './predicate';
 
 describe('toContainAnyKeys Predicate', () => {
   describe('returns true', () => {
-    it('when one or more key is found in the object', () => {
+    test('when one or more key is found in the object', () => {
       var test = predicate(
         {
           name: 'Steve the Pirate'
@@ -15,7 +15,7 @@ describe('toContainAnyKeys Predicate', () => {
   });
 
   describe('returns false', () => {
-    it('when no keys are found in the object', () => {
+    test('when no keys are found in the object', () => {
       var test = predicate(
         {
           name: 'Steve the Pirate'

--- a/src/matchers/toContainAnyValues/index.test.js
+++ b/src/matchers/toContainAnyValues/index.test.js
@@ -5,14 +5,14 @@ expect.extend(matcher);
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainAnyValues', () => {
-  it('passes when given object contains value', () => {
+  test('passes when given object contains value', () => {
     expect(data).toContainAnyValues(['foo']);
     expect(data).toContainAnyValues(['foo', 'fax']);
     expect(data).toContainAnyValues(['qux', 'bar']);
     expect(data).toContainAnyValues(['qux', 'baz', 'rod']);
   });
 
-  it('fails when given object does not contain value', () => {
+  test('fails when given object does not contain value', () => {
     expect(() => expect(data).toContainAnyValues(['fax'])).toThrowErrorMatchingSnapshot();
     expect(() => expect(data).toContainAnyValues(['fax', 'rom'])).toThrowErrorMatchingSnapshot();
     expect(() => expect(data).toContainAnyValues(['dae', 'mur', 'zoe'])).toThrowErrorMatchingSnapshot();
@@ -20,12 +20,12 @@ describe('.toContainAnyValues', () => {
 });
 
 describe('.not.toContainAnyValues', () => {
-  it('passes when given object does not contain value', () => {
+  test('passes when given object does not contain value', () => {
     expect(data).not.toContainAnyValues(['qux']);
     expect(data).not.toContainAnyValues(['bui', 'mur']);
   });
 
-  it('fails when given object contains value', () => {
+  test('fails when given object contains value', () => {
     expect(() => expect(data).not.toContainAnyValues(['baz'])).toThrowErrorMatchingSnapshot();
     expect(() => expect(data).not.toContainAnyValues(['foo', 'bar'])).toThrowErrorMatchingSnapshot();
   });

--- a/src/matchers/toContainAnyValues/predicate.test.js
+++ b/src/matchers/toContainAnyValues/predicate.test.js
@@ -3,14 +3,14 @@ import predicate from './predicate';
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('toContainAnyValues Predicate', () => {
-  it('passes when object contains at least one of the given values ', () => {
+  test('passes when object contains at least one of the given values ', () => {
     expect(predicate(data, ['qux', 'foo'])).toBe(true);
     expect(predicate(data, ['qux', 'bar'])).toBe(true);
     expect(predicate(data, ['foo', 'bar'])).toBe(true);
     expect(predicate(data, ['baz'])).toBe(true);
   });
 
-  it('fails when object does not contain any given values', () => {
+  test('fails when object does not contain any given values', () => {
     expect(predicate(data, ['qux'])).toBe(false);
     expect(predicate(data, ['qux', 'zoo'])).toBe(false);
   });

--- a/src/matchers/toContainEntries/index.test.js
+++ b/src/matchers/toContainEntries/index.test.js
@@ -5,21 +5,21 @@ expect.extend(matcher);
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainEntries', () => {
-  it('passes when object contains all of the given entries', () => {
+  test('passes when object contains all of the given entries', () => {
     expect(data).toContainEntries([['c', 'baz'], ['a', 'foo']]);
   });
 
-  it('fails when object does not contain all of the given entries', () => {
+  test('fails when object does not contain all of the given entries', () => {
     expect(() => expect(data).toContainEntries(['b', 'foo'], ['a', 'foo'])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainEntries', () => {
-  it('passes when object does not contain all of the given entries', () => {
+  test('passes when object does not contain all of the given entries', () => {
     expect(data).not.toContainEntries([['a', 'qux']]);
   });
 
-  it('fails when object contains all of the given entries', () => {
+  test('fails when object contains all of the given entries', () => {
     expect(() => expect(data).not.toContainEntries([['b', 'bar'], ['c', 'baz']])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainEntries/predicate.test.js
+++ b/src/matchers/toContainEntries/predicate.test.js
@@ -3,15 +3,15 @@ import predicate from './predicate';
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainEntries', () => {
-  it('passes when object contains given entry', () => {
+  test('passes when object contains given entry', () => {
     expect(predicate(data, [['c', 'baz'], ['a', 'foo']])).toBe(true);
   });
 
-  it('passes when given nested values', () => {
+  test('passes when given nested values', () => {
     expect(predicate({ hello: { message: 'world' } }, [['hello', { message: 'world' }]])).toBe(true);
   });
 
-  it('fails when object does not contain given entry', () => {
+  test('fails when object does not contain given entry', () => {
     expect(predicate(data, [['a', 'qux'], ['b', 'bar']])).toBe(false);
   });
 });

--- a/src/matchers/toContainEntry/index.test.js
+++ b/src/matchers/toContainEntry/index.test.js
@@ -5,23 +5,23 @@ expect.extend(matcher);
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainEntry', () => {
-  it('passes when object contains given entry', () => {
+  test('passes when object contains given entry', () => {
     expect(data).toContainEntry(['a', 'foo']);
     expect(data).toContainEntry(['b', 'bar']);
     expect(data).toContainEntry(['c', 'baz']);
   });
 
-  it('fails when object does not contain given entry', () => {
+  test('fails when object does not contain given entry', () => {
     expect(() => expect(data).toContainEntry(['b', 'foo'])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainEntry', () => {
-  it('passes when object does not contain given entry', () => {
+  test('passes when object does not contain given entry', () => {
     expect(data).not.toContainEntry(['a', 'qux']);
   });
 
-  it('fails when object contains given entry', () => {
+  test('fails when object contains given entry', () => {
     expect(() => expect(data).not.toContainEntry(['b', 'bar'])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainEntry/predicate.test.js
+++ b/src/matchers/toContainEntry/predicate.test.js
@@ -3,17 +3,17 @@ import predicate from './predicate';
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainEntry', () => {
-  it('passes when object contains given entry', () => {
+  test('passes when object contains given entry', () => {
     expect(predicate(data, ['a', 'foo'])).toBe(true);
     expect(predicate(data, ['b', 'bar'])).toBe(true);
     expect(predicate(data, ['c', 'baz'])).toBe(true);
   });
 
-  it('passes when object contain given entry with nested value', () => {
+  test('passes when object contain given entry with nested value', () => {
     expect(predicate({ data }, ['data', data])).toBe(true);
   });
 
-  it('fails when object does not contain given entry', () => {
+  test('fails when object does not contain given entry', () => {
     expect(predicate(data, ['a', 'qux'])).toBe(false);
   });
 });

--- a/src/matchers/toContainKey/index.test.js
+++ b/src/matchers/toContainKey/index.test.js
@@ -5,21 +5,21 @@ expect.extend(matcher);
 const data = { hello: 'world' };
 
 describe('.toContainKey', () => {
-  it('passes when given object contains key', () => {
+  test('passes when given object contains key', () => {
     expect(data).toContainKey('hello');
   });
 
-  it('fails when given object does not contain key', () => {
+  test('fails when given object does not contain key', () => {
     expect(() => expect(data).toContainKey('missing')).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainKey', () => {
-  it('passes when given object does not contain key', () => {
+  test('passes when given object does not contain key', () => {
     expect(data).not.toContainKey('missing');
   });
 
-  it('fails when given object contains key', () => {
+  test('fails when given object contains key', () => {
     expect(() => expect(data).not.toContainKey('hello')).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainKey/predicate.test.js
+++ b/src/matchers/toContainKey/predicate.test.js
@@ -3,11 +3,11 @@ import predicate from './predicate';
 const data = { hello: 'world' };
 
 describe('.toContainKey', () => {
-  it('passes when given object contains key', () => {
+  test('passes when given object contains key', () => {
     expect(predicate(data, 'hello')).toBe(true);
   });
 
-  it('fails when given object does not contain key', () => {
+  test('fails when given object does not contain key', () => {
     expect(predicate(data, 'missing')).toBe(false);
   });
 });

--- a/src/matchers/toContainKeys/index.test.js
+++ b/src/matchers/toContainKeys/index.test.js
@@ -5,21 +5,21 @@ expect.extend(matcher);
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainKeys', () => {
-  it('passes when object contains all keys', () => {
+  test('passes when object contains all keys', () => {
     expect(data).toContainKeys(['b', 'c']);
   });
 
-  it('fails when object does not contain all keys', () => {
+  test('fails when object does not contain all keys', () => {
     expect(() => expect(data).toContainKeys(['a', 'd'])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainKeys', () => {
-  it('passes when object does not contain all keys', () => {
+  test('passes when object does not contain all keys', () => {
     expect(data).not.toContainKeys(['d']);
   });
 
-  it('fails when object contains all keys', () => {
+  test('fails when object contains all keys', () => {
     expect(() => expect(data).not.toContainKeys(['a', 'b', 'c'])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainKeys/predicate.test.js
+++ b/src/matchers/toContainKeys/predicate.test.js
@@ -3,11 +3,11 @@ import predicate from './predicate';
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainKeys', () => {
-  it('passes when object contains all keys', () => {
+  test('passes when object contains all keys', () => {
     expect(predicate(data, ['a', 'b'])).toBe(true);
   });
 
-  it('fails when object does not contain all keys', () => {
+  test('fails when object does not contain all keys', () => {
     expect(predicate(data, ['d'])).toBe(false);
   });
 });

--- a/src/matchers/toContainValue/index.test.js
+++ b/src/matchers/toContainValue/index.test.js
@@ -7,31 +7,31 @@ const deep = { message: shallow };
 const deepArray = { message: [shallow] };
 
 describe('.toContainValue', () => {
-  it('passes when given object contains primitive value', () => {
+  test('passes when given object contains primitive value', () => {
     expect(shallow).toContainValue('world');
   });
 
-  it('passes when given object contains falsy primitive value', () => {
+  test('passes when given object contains falsy primitive value', () => {
     expect({ foo: false }).toContainValue(false);
   });
 
-  it('passes when given object contains object value', () => {
+  test('passes when given object contains object value', () => {
     expect(deep).toContainValue({ hello: 'world' });
   });
 
-  it('passes when given object contains array value', () => {
+  test('passes when given object contains array value', () => {
     expect(deepArray).toContainValue([{ hello: 'world' }]);
   });
 
-  it('fails when given object does not contain primitive value', () => {
+  test('fails when given object does not contain primitive value', () => {
     expect(() => expect(shallow).toContainValue('hello')).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object does not contain object value', () => {
+  test('fails when given object does not contain object value', () => {
     expect(() => expect(deep).toContainValue({ world: 'hello' })).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object does not contain array value', () => {
+  test('fails when given object does not contain array value', () => {
     expect(() => expect(deepArray).toContainValue([{ world: 'hello' }])).toThrowErrorMatchingSnapshot();
   });
 });
@@ -41,27 +41,27 @@ describe('.not.toContainValue', () => {
   const deep = { message: shallow };
   const deepArray = { message: [shallow] };
 
-  it('passes when given object does not contain primitive value', () => {
+  test('passes when given object does not contain primitive value', () => {
     expect(shallow).not.toContainValue('foo');
   });
 
-  it('passes when given object does not contain object value', () => {
+  test('passes when given object does not contain object value', () => {
     expect(deep).not.toContainValue({ foo: 'bar' });
   });
 
-  it('passes when given object does not contain array value', () => {
+  test('passes when given object does not contain array value', () => {
     expect(deepArray).not.toContainValue([{ foo: 'bar' }]);
   });
 
-  it('fails when given object contains primitive value', () => {
+  test('fails when given object contains primitive value', () => {
     expect(() => expect(shallow).not.toContainValue('world')).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object contains object value', () => {
+  test('fails when given object contains object value', () => {
     expect(() => expect(deep).not.toContainValue({ hello: 'world' })).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object contains array value', () => {
+  test('fails when given object contains array value', () => {
     expect(() => expect(deepArray).not.toContainValue([{ hello: 'world' }])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toContainValue/predicate.test.js
+++ b/src/matchers/toContainValue/predicate.test.js
@@ -7,18 +7,18 @@ describe('toContainValue Predicate', () => {
   const deepArray = { message: [{ hello: 'world' }] };
 
   describe('returns true', () => {
-    each([['world'], [false], [undefined], [null], [''], [0]]).it(
+    each([['world'], [false], [undefined], [null], [''], [0]]).test(
       'when given object contains primitive value: %s',
       value => {
         expect(predicate(shallow, value)).toBe(true);
       }
     );
 
-    it('when given object contains object value', () => {
+    test('when given object contains object value', () => {
       expect(predicate(deep, { hello: 'world' })).toBe(true);
     });
 
-    it('when given object contains array value', () => {
+    test('when given object contains array value', () => {
       expect(predicate(deepArray, [{ hello: 'world' }])).toBe(true);
     });
   });
@@ -31,15 +31,15 @@ describe('toContainValue Predicate', () => {
       [null],
       [''],
       [0]
-    ]).it('when given object does not contain primitive value: %s', value => {
+    ]).test('when given object does not contain primitive value: %s', value => {
       expect(predicate({}, value)).toBe(false);
     });
 
-    it('when given object does not contain object value', () => {
+    test('when given object does not contain object value', () => {
       expect(predicate(deep, { foo: 'bar' })).toBe(false);
     });
 
-    it('when given object does not contain array value', () => {
+    test('when given object does not contain array value', () => {
       expect(predicate(deepArray, [{ bar: 'foo' }])).toBe(false);
     });
   });

--- a/src/matchers/toContainValues/index.test.js
+++ b/src/matchers/toContainValues/index.test.js
@@ -17,55 +17,55 @@ const deepArray = {
 };
 
 describe('.toContainValues', () => {
-  it('passes when given object contains primitive values', () => {
+  test('passes when given object contains primitive values', () => {
     expect(shallow).toContainValues(['world', false]);
   });
 
-  it('passes when given object contains all values including objects', () => {
+  test('passes when given object contains all values including objects', () => {
     expect(deep).toContainValues([{ hello: 'world', foo: 0, bar: false }, 'duck']);
   });
 
-  it('passes when given object contains all values including arrays', () => {
+  test('passes when given object contains all values including arrays', () => {
     expect(deepArray).toContainValues(['duck', [{ hello: 'world', foo: 0, bar: false }]]);
   });
 
-  it('fails when given object does not contain all primitive values', () => {
+  test('fails when given object does not contain all primitive values', () => {
     expect(() => expect(shallow).toContainValues(['hello', 0, false])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object does not contain all values including objects', () => {
+  test('fails when given object does not contain all values including objects', () => {
     expect(() => expect(deep).toContainValues([{ hello: 'world' }])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object does not contain all values including arrays', () => {
+  test('fails when given object does not contain all values including arrays', () => {
     expect(() => expect(deepArray).toContainValues(['duck', [{ hello: 'world' }]])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toContainValues', () => {
-  it('passes when given object does not contain all primitive values', () => {
+  test('passes when given object does not contain all primitive values', () => {
     expect(shallow).not.toContainValues(['foo', 0]);
   });
 
-  it('passes when given object does not contain all values including objects', () => {
+  test('passes when given object does not contain all values including objects', () => {
     expect(deep).not.toContainValues(['duck', { foo: 'bar' }]);
   });
 
-  it('passes when given object does not contain all values including arrays', () => {
+  test('passes when given object does not contain all values including arrays', () => {
     expect(deepArray).not.toContainValues(['duck', [{ foo: 'bar' }]]);
   });
 
-  it('fails when given object contains primitive values', () => {
+  test('fails when given object contains primitive values', () => {
     expect(() => expect(shallow).not.toContainValues(['world', false])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object contains all values including objects', () => {
+  test('fails when given object contains all values including objects', () => {
     expect(() =>
       expect(deep).not.toContainValues([{ hello: 'world', foo: 0, bar: false }, 'duck'])
     ).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object contains all values including arrays', () => {
+  test('fails when given object contains all values including arrays', () => {
     expect(() =>
       expect(deepArray).not.toContainValues(['duck', [{ hello: 'world', foo: 0, bar: false }]])
     ).toThrowErrorMatchingSnapshot();

--- a/src/matchers/toContainValues/predicate.test.js
+++ b/src/matchers/toContainValues/predicate.test.js
@@ -16,29 +16,29 @@ describe('toContainValue Predicate', () => {
   };
 
   describe('returns true', () => {
-    it('when given object contains all primitive values', () => {
+    test('when given object contains all primitive values', () => {
       expect(predicate(shallow, ['world', false, 0])).toBe(true);
     });
 
-    it('when given object contains all values including objects', () => {
+    test('when given object contains all values including objects', () => {
       expect(predicate(deep, ['duck', { hello: 'world', foo: 0, bar: false }])).toBe(true);
     });
 
-    it('when given object contains all values including arrays', () => {
+    test('when given object contains all values including arrays', () => {
       expect(predicate(deepArray, ['duck', [{ hello: 'world', foo: 0, bar: false }]])).toBe(true);
     });
   });
 
   describe('returns false', () => {
-    it('when given object does not contain all primitive value', () => {
+    test('when given object does not contain all primitive value', () => {
       expect(predicate(shallow, [false, undefined])).toBe(false);
     });
 
-    it('when given object does not contain all values including objects', () => {
+    test('when given object does not contain all values including objects', () => {
       expect(predicate(deep, ['made up value', 'duck', { hello: 'world', foo: 0, bar: false }])).toBe(false);
     });
 
-    it('when given object does not contain all values including arrays', () => {
+    test('when given object does not contain all values including arrays', () => {
       expect(predicate(deepArray, ['duck', 'made up value', [{ hello: 'world', foo: 0, bar: false }]])).toBe(false);
     });
   });

--- a/src/matchers/toEndWith/index.test.js
+++ b/src/matchers/toEndWith/index.test.js
@@ -3,29 +3,29 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toEndWith', () => {
-  it('passes when string ends with given suffix', () => {
+  test('passes when string ends with given suffix', () => {
     expect('hello world').toEndWith('world');
   });
 
-  it('fails when the string is shorter than the given suffix', () => {
+  test('fails when the string is shorter than the given suffix', () => {
     expect(() => expect('hello').toEndWith('hello world')).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when string does not end with the given suffix', () => {
+  test('fails when string does not end with the given suffix', () => {
     expect(() => expect('hello world').toEndWith('hello')).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toEndWith', () => {
-  it('passes when string does not end with the given suffix', () => {
+  test('passes when string does not end with the given suffix', () => {
     expect('hello world').not.toEndWith('hello');
   });
 
-  it('passes when string is shorter than the given suffix', () => {
+  test('passes when string is shorter than the given suffix', () => {
     expect('hello').not.toEndWith('hello world');
   });
 
-  it('fails when string ends with given suffix', () => {
+  test('fails when string ends with given suffix', () => {
     expect(() => expect('hello world').not.toEndWith('world')).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toEndWith/predicate.test.js
+++ b/src/matchers/toEndWith/predicate.test.js
@@ -1,11 +1,11 @@
 import predicate from './predicate';
 
 describe('toEndWith Predicate', () => {
-  it('returns true when string ends with given suffix', () => {
+  test('returns true when string ends with given suffix', () => {
     expect(predicate('world', 'hello world')).toBe(true);
   });
 
-  it('returns false when string does not end with given suffix', () => {
+  test('returns false when string does not end with given suffix', () => {
     expect(predicate('hello', 'hello world')).toBe(false);
   });
 });

--- a/src/matchers/toEqualCaseInsensitive/index.test.js
+++ b/src/matchers/toEqualCaseInsensitive/index.test.js
@@ -3,7 +3,7 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toEqualCaseInsensitive', () => {
-  it('passes if strings are equal despite case', () => {
+  test('passes if strings are equal despite case', () => {
     expect('a').toEqualCaseInsensitive('A');
     expect('aaAA').toEqualCaseInsensitive('aaaa');
     expect('HELLO WORLD').toEqualCaseInsensitive('hello world');
@@ -13,7 +13,7 @@ describe('.toEqualCaseInsensitive', () => {
 });
 
 describe('.not.toEqualCaseInsensitive', () => {
-  it('fails if strings do not match', () => {
+  test('fails if strings do not match', () => {
     expect('hello world').not.toEqualCaseInsensitive('hello');
     expect(() => expect('aaaa').not.toEqualCaseInsensitive('aaaa')).toThrowErrorMatchingSnapshot();
   });

--- a/src/matchers/toEqualCaseInsensitive/predicate.test.js
+++ b/src/matchers/toEqualCaseInsensitive/predicate.test.js
@@ -1,13 +1,13 @@
 import predicate from './predicate';
 
 describe('toEqualCaseInsensitive Predicate', () => {
-  it('returns true given equal strings regardless of case', () => {
+  test('returns true given equal strings regardless of case', () => {
     expect(predicate('hello WORLD', 'hello world')).toEqual(true);
     expect(predicate('HeLLo WORLD', 'hello world')).toEqual(true);
     expect(predicate('HELLO WORLD', 'hello world')).toEqual(true);
   });
 
-  it('returns false when given two different strings', () => {
+  test('returns false when given two different strings', () => {
     expect(predicate('hello', 'world')).toEqual(false);
   });
 });

--- a/src/matchers/toInclude/index.test.js
+++ b/src/matchers/toInclude/index.test.js
@@ -5,20 +5,20 @@ expect.extend(matcher);
 const data = 'hello world';
 
 describe('.toInclude', () => {
-  it('passes when a string has a given substring', () => {
+  test('passes when a string has a given substring', () => {
     expect(data).toInclude('ell');
   });
 
-  it('fails when a string does not have a given substring', () => {
+  test('fails when a string does not have a given substring', () => {
     expect(() => expect(data).toInclude('bob')).toThrowErrorMatchingSnapshot();
   });
 
   describe('.not.toInclude', () => {
-    it('passes when a string does not have a given substring', () => {
+    test('passes when a string does not have a given substring', () => {
       expect(data).not.toInclude('bob');
     });
 
-    it('fails when a string does have a given substring', () => {
+    test('fails when a string does have a given substring', () => {
       expect(() => expect(data).not.toInclude('ell')).toThrowErrorMatchingSnapshot();
     });
   });

--- a/src/matchers/toInclude/predicate.test.js
+++ b/src/matchers/toInclude/predicate.test.js
@@ -3,11 +3,11 @@ import predicate from './predicate';
 const data = 'hello world';
 
 describe('.toInclude', () => {
-  it('passes when string contains substring', () => {
+  test('passes when string contains substring', () => {
     expect(predicate(data, 'ell')).toBe(true);
   });
 
-  it('fails when string does not contain substring', () => {
+  test('fails when string does not contain substring', () => {
     expect(predicate(data, 'bob')).toBe(false);
   });
 });

--- a/src/matchers/toIncludeAllMembers/index.test.js
+++ b/src/matchers/toIncludeAllMembers/index.test.js
@@ -6,21 +6,21 @@ describe('.toIncludeAllMembers', () => {
   const array1 = [1, 2, 3];
   const array2 = [1, 2, 2];
 
-  it('passes when array values matches the members of the set', () => {
+  test('passes when array values matches the members of the set', () => {
     expect(array1).toIncludeAllMembers([2, 1, 3]);
     expect(array2).toIncludeAllMembers([2, 1]);
     expect([{ foo: 'bar' }, { baz: 'qux' }]).toIncludeAllMembers([{ foo: 'bar' }]);
   });
 
-  it('fails when array values do not contain any of the members of the set', () => {
+  test('fails when array values do not contain any of the members of the set', () => {
     expect(() => expect([4, 5, 6]).toIncludeAllMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object is not an array', () => {
+  test('fails when given object is not an array', () => {
     expect(() => expect(2).toIncludeAllMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when expected object is not an array', () => {
+  test('fails when expected object is not an array', () => {
     expect(() => expect(array1).toIncludeAllMembers(2)).toThrowErrorMatchingSnapshot();
   });
 });
@@ -28,16 +28,16 @@ describe('.toIncludeAllMembers', () => {
 describe('.not.toIncludeAllMembers', () => {
   const array1 = [1, 2, 3];
 
-  it('passes when array values does not contain any members of the set', () => {
+  test('passes when array values does not contain any members of the set', () => {
     expect(array1).not.toIncludeAllMembers([4, 5, 6]);
     expect([{ foo: 'bar' }, { baz: 'qux' }]).not.toIncludeAllMembers([{ hello: 'world' }]);
   });
 
-  it('passes when given object is not an array', () => {
+  test('passes when given object is not an array', () => {
     expect(4).not.toIncludeAllMembers([4, 5, 6]);
   });
 
-  it('fails when array values matches the members of the set', () => {
+  test('fails when array values matches the members of the set', () => {
     expect(() => expect(array1).not.toIncludeAllMembers([2, 1, 3])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toIncludeAllMembers/predicate.test.js
+++ b/src/matchers/toIncludeAllMembers/predicate.test.js
@@ -7,21 +7,21 @@ describe('toIncludeAllMembers Predicate', () => {
   const set2 = [1, 2, 3];
 
   describe('returns true', () => {
-    it('when Array contains all the same members of given set', () => {
+    test('when Array contains all the same members of given set', () => {
       expect(predicate(array1, set1)).toBe(true);
     });
 
-    it('when Array contains all of the same nested members of given set', () => {
+    test('when Array contains all of the same nested members of given set', () => {
       expect(predicate([{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'bar' }])).toBe(true);
     });
   });
 
   describe('returns false', () => {
-    it('when Array does not contain any of the members of given set', () => {
+    test('when Array does not contain any of the members of given set', () => {
       expect(predicate(array2, set2)).toBe(false);
     });
 
-    it('when Array contains does not contain all of the same nested members of given set', () => {
+    test('when Array contains does not contain all of the same nested members of given set', () => {
       expect(predicate([{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'qux' }])).toBe(false);
     });
   });

--- a/src/matchers/toIncludeAnyMembers/index.test.js
+++ b/src/matchers/toIncludeAnyMembers/index.test.js
@@ -6,27 +6,27 @@ describe('.toIncludeAnyMembers', () => {
   const shallow = { hello: 'world' };
   const deep = { message: shallow };
 
-  it('passes when given array is a subset', () => {
+  test('passes when given array is a subset', () => {
     expect([2, 3]).toIncludeAnyMembers([1, 2, 3]);
   });
 
-  it('passes when given array contains some of the members', () => {
+  test('passes when given array contains some of the members', () => {
     expect([1, 2, 3]).toIncludeAnyMembers([2, 3, 4]);
   });
 
-  it('passes when given array contains object value', () => {
+  test('passes when given array contains object value', () => {
     expect([shallow]).toIncludeAnyMembers([shallow, deep]);
   });
 
-  it('fails when given array does not contain any members ', () => {
+  test('fails when given array does not contain any members ', () => {
     expect(() => expect([4, 5, 6]).toIncludeAnyMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given object is not an array', () => {
+  test('fails when given object is not an array', () => {
     expect(() => expect(7).toIncludeAnyMembers([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when expected object does not contain array value', () => {
+  test('fails when expected object does not contain array value', () => {
     expect(() => expect([1, 2, 3]).toIncludeAnyMembers('world')).toThrowErrorMatchingSnapshot();
   });
 });
@@ -34,27 +34,27 @@ describe('.toIncludeAnyMembers', () => {
 describe('.not.toIncludeAnyMembers', () => {
   const shallow = { hello: 'world' };
 
-  it('passes when given array does not contain primitive value', () => {
+  test('passes when given array does not contain primitive value', () => {
     expect(['hola', 'mundo']).not.toIncludeAnyMembers(['hello', 'world']);
   });
 
-  it('passes when given array does not contain object value', () => {
+  test('passes when given array does not contain object value', () => {
     expect([{ hello: 'world' }]).not.toIncludeAnyMembers([{ world: 'hello' }]);
   });
 
-  it('passes when given object is not array', () => {
+  test('passes when given object is not array', () => {
     expect(7).not.toIncludeAnyMembers([7]);
   });
 
-  it('fails when given object contains primitive value', () => {
+  test('fails when given object contains primitive value', () => {
     expect(() => expect([7]).not.toIncludeAnyMembers([7, 8])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given array contains object value', () => {
+  test('fails when given array contains object value', () => {
     expect(() => expect([{ foo: 'bar' }]).not.toIncludeAnyMembers([{ foo: 'bar' }])).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when given array contains array value', () => {
+  test('fails when given array contains array value', () => {
     expect(() => expect([[shallow]]).not.toIncludeAnyMembers([[shallow], 7])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toIncludeAnyMembers/predicate.test.js
+++ b/src/matchers/toIncludeAnyMembers/predicate.test.js
@@ -6,32 +6,32 @@ describe('toIncludeAnyMembers Predicate', () => {
   const shallow = { hello: 'world' };
 
   describe('returns true', () => {
-    each([['world'], [false], [undefined], [null], [''], [0]]).it(
+    each([['world'], [false], [undefined], [null], [''], [0]]).test(
       'when given array contains primitive value: %s',
       given => {
         expect(predicate([given], array)).toBe(true);
       }
     );
 
-    it('when given array contains object value', () => {
+    test('when given array contains object value', () => {
       expect(predicate([shallow, 7], [shallow])).toBe(true);
     });
 
-    it('when given object contains array value', () => {
+    test('when given object contains array value', () => {
       expect(predicate([[shallow]], [[shallow], 7])).toBe(true);
     });
   });
 
   describe('returns false', () => {
-    it('when given array does not contain primitive value', () => {
+    test('when given array does not contain primitive value', () => {
       expect(predicate([3, 4, 5], [1])).toBe(false);
     });
 
-    it('when given array does not contain object value', () => {
+    test('when given array does not contain object value', () => {
       expect(predicate([3], [{ foo: 'bar' }])).toBe(false);
     });
 
-    it('when given object does not contain array value', () => {
+    test('when given object does not contain array value', () => {
       expect(predicate([7], [[7]])).toBe(false);
     });
   });

--- a/src/matchers/toIncludeMultiple/index.test.js
+++ b/src/matchers/toIncludeMultiple/index.test.js
@@ -3,21 +3,21 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toIncludeMultiple', () => {
-  it('passes when string includes all substrings', () => {
+  test('passes when string includes all substrings', () => {
     expect('hello world').toIncludeMultiple(['world', 'hello']);
   });
 
-  it('fails when string does not include all substrings', () => {
+  test('fails when string does not include all substrings', () => {
     expect(() => expect('hello world').toIncludeMultiple(['hello', 'world', 'bob'])).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toIncludeMultiple', () => {
-  it('passes when string does not include all substrings', () => {
+  test('passes when string does not include all substrings', () => {
     expect('hello world').not.toIncludeMultiple(['world', 'hello', 'bob']);
   });
 
-  it('fails when string includes all substrings', () => {
+  test('fails when string includes all substrings', () => {
     expect(() => expect('hello world').not.toIncludeMultiple(['hello', 'world'])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toIncludeMultiple/predicate.test.js
+++ b/src/matchers/toIncludeMultiple/predicate.test.js
@@ -2,13 +2,13 @@ import predicate from './predicate';
 
 describe('toIncludeMultiple Predicate', () => {
   describe('returns true', () => {
-    it('when string contains all substrings', () => {
+    test('when string contains all substrings', () => {
       expect(predicate('hello world', ['hello', 'world'])).toBe(true);
     });
   });
 
   describe('returns false', () => {
-    it('when string does not contain one or more substrings', () => {
+    test('when string does not contain one or more substrings', () => {
       expect(predicate('hello world', ['hello', 'world', 'bob'])).toBe(false);
     });
   });

--- a/src/matchers/toSatisfy/index.test.js
+++ b/src/matchers/toSatisfy/index.test.js
@@ -5,11 +5,11 @@ expect.extend(matcher);
 describe('.toSatisfy', () => {
   const is2 = n => n === 2;
 
-  it('passes when given a function that returns true', () => {
+  test('passes when given a function that returns true', () => {
     expect(2).toSatisfy(is2);
   });
 
-  it('fails when given function that returns false', () => {
+  test('fails when given function that returns false', () => {
     expect(() => expect(3).toSatisfy(is2)).toThrowErrorMatchingSnapshot();
   });
 });
@@ -17,11 +17,11 @@ describe('.toSatisfy', () => {
 describe('.not.toSatisfy', () => {
   const isTrue = a => a === true;
 
-  it('passes when given a function that returns false', () => {
+  test('passes when given a function that returns false', () => {
     expect(false).not.toSatisfy(isTrue);
   });
 
-  it('fails when given a function that returns true', () => {
+  test('fails when given a function that returns true', () => {
     expect(() => expect(true).not.toSatisfy(isTrue)).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toSatisfyAll/index.test.js
+++ b/src/matchers/toSatisfyAll/index.test.js
@@ -6,25 +6,25 @@ let isEven = el => el % 2 === 0;
 let isOdd = el => el % 2 === 1;
 
 describe('.toSatisfyAll', () => {
-  it('passes when all values satisfy predicate', () => {
+  test('passes when all values satisfy predicate', () => {
     expect([1, 3, 5, 7]).toSatisfyAll(isOdd);
     expect([2, 4, 6, 8]).toSatisfyAll(isEven);
     expect([11]).toSatisfyAll(isOdd);
     expect([10]).toSatisfyAll(isEven);
   });
 
-  it('fails when any value does not satisfy the predicate', () => {
+  test('fails when any value does not satisfy the predicate', () => {
     expect(() => expect([1, 3, 4, 5]).toSatisfyAll(isOdd)).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toSatisfyAll', () => {
-  it('passes when any value does not satisfy the predicate', () => {
+  test('passes when any value does not satisfy the predicate', () => {
     expect([1, 3, 4, 5]).not.toSatisfyAll(isOdd);
     expect([8, 6, 3, 1, 2]).not.toSatisfyAll(isEven);
   });
 
-  it('fails when all values satisfy predicate', () => {
+  test('fails when all values satisfy predicate', () => {
     expect(() => expect([1, 3, 5, 7]).not.toSatisfyAll(isOdd)).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toSatisfyAll/predicate.test.js
+++ b/src/matchers/toSatisfyAll/predicate.test.js
@@ -4,25 +4,25 @@ describe('toSatisfyAll', () => {
   let isOdd = el => el % 2 === 1;
 
   describe('returns true', () => {
-    it('when all elements satisfy', () => {
+    test('when all elements satisfy', () => {
       expect(predicate([1, 3, 7, 9], isOdd)).toBe(true);
     });
 
-    it('works for repeated elements', () => {
+    test('works for repeated elements', () => {
       expect(predicate([1, 3, 3, 9], isOdd)).toBe(true);
     });
   });
 
   describe('returns false', () => {
-    it('when all elements fail', () => {
+    test('when all elements fail', () => {
       expect(predicate([10, 2, 4, 6], isOdd)).toBe(false);
     });
 
-    it('when either element fails', () => {
+    test('when either element fails', () => {
       expect(predicate([5, 7, 8, 9], isOdd)).toBe(false);
     });
 
-    it('works for repeated elements', () => {
+    test('works for repeated elements', () => {
       expect(predicate([1, 3, 3, 9, 10, 11], isOdd)).toBe(false);
     });
   });

--- a/src/matchers/toStartWith/index.test.js
+++ b/src/matchers/toStartWith/index.test.js
@@ -3,29 +3,29 @@ import matcher from './';
 expect.extend(matcher);
 
 describe('.toStartWith', () => {
-  it('passes when string starts with given prefix', () => {
+  test('passes when string starts with given prefix', () => {
     expect('hello world').toStartWith('hello');
   });
 
-  it('fails when the string is shorter than the given prefix', () => {
+  test('fails when the string is shorter than the given prefix', () => {
     expect(() => expect('hello').toStartWith('hello world')).toThrowErrorMatchingSnapshot();
   });
 
-  it('fails when string does not start with the given prefix', () => {
+  test('fails when string does not start with the given prefix', () => {
     expect(() => expect('hello world').toStartWith('world')).toThrowErrorMatchingSnapshot();
   });
 });
 
 describe('.not.toStartWith', () => {
-  it('passes when string does not start with the given prefix', () => {
+  test('passes when string does not start with the given prefix', () => {
     expect('hello world').not.toStartWith('world');
   });
 
-  it('passes when string is shorter than the given prefix', () => {
+  test('passes when string is shorter than the given prefix', () => {
     expect('hello').not.toStartWith('hello world');
   });
 
-  it('fails when string starts with given prefix', () => {
+  test('fails when string starts with given prefix', () => {
     expect(() => expect('hello world').not.toStartWith('hello')).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toStartWith/predicate.test.js
+++ b/src/matchers/toStartWith/predicate.test.js
@@ -1,11 +1,11 @@
 import predicate from './predicate';
 
 describe('toStartWith Predicate', () => {
-  it('returns true when string starts with given prefix', () => {
+  test('returns true when string starts with given prefix', () => {
     expect(predicate('hello', 'hello world')).toBe(true);
   });
 
-  it('returns false when string does not start with given prefix', () => {
+  test('returns false when string does not start with given prefix', () => {
     expect(predicate('world', 'hello world')).toBe(false);
   });
 });

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -8,11 +8,11 @@ describe('Utils', () => {
     const array = [1, 0, '', 'hello', false, true, undefined, null, NaN, fn, { foo: 'bar' }, ['foo']];
     const testRows = array.map(item => [item]);
 
-    each(testRows).it('returns true when array contains given value: %s', value => {
+    each(testRows).test('returns true when array contains given value: %s', value => {
       expect(contains(array, value)).toBe(true);
     });
 
-    each(testRows).it('returns false when array does not contain given value: %s', value => {
+    each(testRows).test('returns false when array does not contain given value: %s', value => {
       expect(contains([], value)).toBe(false);
     });
   });


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
Change all `it` to `test` to make things consistent across the codebase with the readme.

<!-- Why are these changes necessary? Link any related issues -->
### Why
It's more of a cosmetic change but it helps with the consistency and reduces confusion. Referencing #90 

<!-- If necessary add any additional notes on the implementation -->
<!-- ### Notes -->

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] Add yourself to contributors list (`yarn contributor`)
