### PR TITLE
Export toBeDate matcher

### DIFF
--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -43,6 +43,7 @@ import toBeEmpty from './toBeEmpty';
 import toBeSealed from './toBeSealed';
 import toIncludeRepeated from './toIncludeRepeated';
 import toHaveBeenCalledBefore from './toHaveBeenCalledBefore';
+import toBeDate from './toBeDate';
 
 export default [
   toBeEven,
@@ -89,5 +90,6 @@ export default [
   toBeSealed,
   toSatisfy,
   toIncludeRepeated,
-  toHaveBeenCalledBefore
+  toHaveBeenCalledBefore,
+  toBeDate
 ].reduce((acc, matcher) => ({ ...acc, ...matcher }), {});


### PR DESCRIPTION
### What
Issue #134 

### Why
To be able to use the `toBeDate` matcher.

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] Add yourself to contributors list (`yarn contributor`)
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
