### PR TITLE
Move to Object.keys as opposed to Object.values

### DIFF
--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -2,4 +2,6 @@ import importAll from 'import-all.macro';
 
 const imports = importAll.sync('./*/index.js');
 
-export default Object.values(imports).reduce((acc, matcher) => ({ ...acc, ...matcher.default }), {});
+export default Object.keys(imports)
+  .map(key => imports[key])
+  .reduce((acc, matcher) => ({ ...acc, ...matcher.default }), {});


### PR DESCRIPTION
### What
Bug

### Why
https://github.com/jest-community/jest-extended/issues/150 was raised today, Object.values doesn't work in Node 6, which is still in LTS from Node until next year. This uses Object.keys which is supported in node 6.

### Notes
I cannot test this in Node 6 as failure snapshot tests fail locally. However, the unit tests for the file charged passes.

### Housekeeping

- [x] Unit tests
- [ ]  Documentation is up to date
- [x] No additional lint warnings
- [ ] Add yourself to contributors list (`yarn contributor`)
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
