### PR TITLE
Fix toIncludeMultiple code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,8 +848,8 @@ Use `.toIncludeMultiple` when checking if a `String` includes all of the given s
 
 ```js
 test('passes when value includes all substrings', () => {
-  expect('hello world').toInclude(['world', 'hello']);
-  expect('hello world').not.toInclude(['world', 'hello', 'bob']);
+  expect('hello world').toIncludeMultiple(['world', 'hello']);
+  expect('hello world').not.toIncludeMultiple(['world', 'hello', 'bob']);
 });
 ```
 


### PR DESCRIPTION
### What
Fixes `toIncludeMultiple` code example

### Why
Because it accidentally used the `toInclude` function
