### PR TITLE
Fix types for toSatisfy()/toSatisfyAll()

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -411,6 +411,15 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "tony19",
+      "name": "Tony Trinh",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/26580?v=4",
+      "profile": "https://github.com/tony19",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,7 +39,7 @@ declare namespace jest {
      * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
      * @param {Function} predicate
      */
-    toSatisfy(predicate: () => boolean): R;
+    toSatisfy(predicate: (x: any) => boolean): R;
 
     /**
      * Use `.toBeArray` when checking if a value is an `Array`.
@@ -86,7 +86,7 @@ declare namespace jest {
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
      * @param {Function} predicate
      */
-    toSatisfyAll(predicate: () => boolean): R;
+    toSatisfyAll(predicate: (x: any) => boolean): R;
 
     /**
      * Use `.toBeBoolean` when checking if a value is a `Boolean`.


### PR DESCRIPTION
### What
Bug fix in types

### Why
The type for the arg of `toSatisfy()`/`toSatisfyAll()` is currently a predicate `() => boolean`, but the predicate itself has an argument (the item being iterated). The current signature causes an error in this TypeScript code:

    expect(fooItem).toSatisfy((x: any) => x.myBoolProp); // Argument of type '(x: any) => any' is not assignable to parameter of type '() => boolean'.
    expect(fooArray).toSatisfyAll((x: any) => x.myBoolProp); // Argument of type '(x: any) => any' is not assignable to parameter of type '() => boolean'.


### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [x] Add yourself to contributors list (`yarn contributor`)
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
