### PR TITLE
Use generics for toSatisfy/toSatisfyAll

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,7 +39,7 @@ declare namespace jest {
      * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
      * @param {Function} predicate
      */
-    toSatisfy(predicate: (x: any) => boolean): R;
+    toSatisfy<T = any>(predicate: (x: T) => boolean): R;
 
     /**
      * Use `.toBeArray` when checking if a value is an `Array`.
@@ -86,7 +86,7 @@ declare namespace jest {
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
      * @param {Function} predicate
      */
-    toSatisfyAll(predicate: (x: any) => boolean): R;
+    toSatisfyAll<T = any>(predicate: (x: T) => boolean): R;
 
     /**
      * Use `.toBeBoolean` when checking if a value is a `Boolean`.


### PR DESCRIPTION
### What
Feature (change in types)

### Why
In #163, we changed the `toSatisfy`/`toSatisfyAll` predicate to take an argument of type `any`, which can potentially hide type-related errors, such as:

    expect(promise1).toSatisfy(x => x.nonexistent()); // runtime error
    expect([promise1, promise2]).toSatisfyAll(x => x.nonexistent()); // runtime error

We can make the predicate generic to mitigate the problem, allowing for:

    expect(promise1).toSatisfy<CustomPromise>(x => x.isPending);
    expect([promise1, promise2]).toSatisfyAll<CustomPromise>(x => x.isPending);

The default type argument is `any` to maintain backward compatibility (i.e., it's still possible to call `toSatisfy(x => /*...*)` and `toSatisfyAll(x => /*...*)` without a type argument).

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] Add yourself to contributors list (`yarn contributor`)
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
