### PR TITLE
Add toResolve/toReject custom matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toBeExtensible()](#tobeextensible)
     - [.toBeFrozen()](#tobefrozen)
     - [.toBeSealed()](#tobesealed)
-  - [~~Promise~~](#promise)
+  - [Promise](#promise)
+    - [.toResolve()](#toresolve)
+    - [.toReject()](#toreject)
   - [String](#string)
     - [.toBeString()](#tobestring)
     - [.toEqualCaseInsensitive(string)](#toequalcaseinsensitivestring)
@@ -751,9 +753,27 @@ test('passes when value is sealed', () => {
 });
 ```
 
-### ~~Promise~~
+### Promise
 
-_No APIs proposed yet_
+#### .toResolve()
+
+Use `.toResolve` when checking if a promise is resolved.
+
+```js
+test('passes when a promise resolves', async () => {
+  await expect(Promise.resolve()).toResolve();
+});
+```
+
+#### .toReject()
+
+Use `.toReject` when checking if a promise is rejected.
+
+```js
+test('passes when a promise rejects', async () => {
+  await expect(Promise.reject()).toReject();
+});
+```
 
 ### String
 

--- a/src/matchers/toReject/__snapshots__/index.test.js.snap
+++ b/src/matchers/toReject/__snapshots__/index.test.js.snap
@@ -1,29 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toReject fails when passed a promise that rejects 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toReject(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toReject(</><dim>)</>
 
-Expected promise to <green>\\"resolve\\"</>, however it <red>\\"rejected\\"</>.
-"
-`;
-
-exports[`.not.toReject fails when passed a promise that resolved 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toReject(</><green>expected</><dim>)</>
-
-Expected promise to <green>\\"resolve\\"</>, however it <red>\\"rejected\\"</>.
-"
-`;
-
-exports[`.toReject fails when passed a promise that rejects 1`] = `
-"<dim>expect(</><red>received</><dim>).toReject(</><green>expected</><dim>)</>
-
-Expected promise to <green>\\"reject\\"</>, however it <red>\\"resolved\\"</>.
+Expected promise to resolve, however it rejected.
 "
 `;
 
 exports[`.toReject fails when passed a promise that resolved 1`] = `
-"<dim>expect(</><red>received</><dim>).toReject(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toReject(</><dim>)</>
 
-Expected promise to <green>\\"reject\\"</>, however it <red>\\"resolved\\"</>.
+Expected promise to reject, however it resolved.
 "
 `;

--- a/src/matchers/toReject/__snapshots__/index.test.js.snap
+++ b/src/matchers/toReject/__snapshots__/index.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toReject fails when passed a promise that rejects 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toReject(</><green>expected</><dim>)</>
+
+Expected promise to <green>\\"resolve\\"</>, however it <red>\\"rejected\\"</>.
+"
+`;
+
+exports[`.not.toReject fails when passed a promise that resolved 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toReject(</><green>expected</><dim>)</>
+
+Expected promise to <green>\\"resolve\\"</>, however it <red>\\"rejected\\"</>.
+"
+`;
+
+exports[`.toReject fails when passed a promise that rejects 1`] = `
+"<dim>expect(</><red>received</><dim>).toReject(</><green>expected</><dim>)</>
+
+Expected promise to <green>\\"reject\\"</>, however it <red>\\"resolved\\"</>.
+"
+`;
+
+exports[`.toReject fails when passed a promise that resolved 1`] = `
+"<dim>expect(</><red>received</><dim>).toReject(</><green>expected</><dim>)</>
+
+Expected promise to <green>\\"reject\\"</>, however it <red>\\"resolved\\"</>.
+"
+`;

--- a/src/matchers/toReject/index.js
+++ b/src/matchers/toReject/index.js
@@ -3,17 +3,17 @@ import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import predicate from './predicate';
 
 const passMessage = () => () =>
-  matcherHint('.not.toResolve') +
-  '\n\n' +
-  `Expected promise to ${printExpected('reject')}, however it ${printReceived('resolved')}.\n`;
-
-const failMessage = () => () =>
-  matcherHint('.toResolve') +
+  matcherHint('.not.toReject') +
   '\n\n' +
   `Expected promise to ${printExpected('resolve')}, however it ${printReceived('rejected')}.\n`;
 
+const failMessage = () => () =>
+  matcherHint('.toReject') +
+  '\n\n' +
+  `Expected promise to ${printExpected('reject')}, however it ${printReceived('resolved')}.\n`;
+
 export default {
-  toResolve: async promise => {
+  toReject: async promise => {
     const pass = await predicate(promise);
     if (pass) {
       return { pass: true, message: passMessage() };

--- a/src/matchers/toReject/index.js
+++ b/src/matchers/toReject/index.js
@@ -1,16 +1,12 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import { matcherHint } from 'jest-matcher-utils';
 
 import predicate from './predicate';
 
 const passMessage = () => () =>
-  matcherHint('.not.toReject') +
-  '\n\n' +
-  `Expected promise to ${printExpected('resolve')}, however it ${printReceived('rejected')}.\n`;
+  matcherHint('.not.toReject', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
 
 const failMessage = () => () =>
-  matcherHint('.toReject') +
-  '\n\n' +
-  `Expected promise to ${printExpected('reject')}, however it ${printReceived('resolved')}.\n`;
+  matcherHint('.toReject', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
 
 export default {
   toReject: async promise => {

--- a/src/matchers/toReject/index.js
+++ b/src/matchers/toReject/index.js
@@ -2,18 +2,18 @@ import { matcherHint } from 'jest-matcher-utils';
 
 import predicate from './predicate';
 
-const passMessage = () => () =>
+const passMessage = () =>
   matcherHint('.not.toReject', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
 
-const failMessage = () => () =>
+const failMessage = () =>
   matcherHint('.toReject', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
 
 export default {
   toReject: async promise => {
     const pass = await predicate(promise);
     if (pass) {
-      return { pass: true, message: passMessage() };
+      return { pass: true, message: passMessage };
     }
-    return { pass: false, message: failMessage() };
+    return { pass: false, message: failMessage };
   }
 };

--- a/src/matchers/toReject/index.test.js
+++ b/src/matchers/toReject/index.test.js
@@ -1,0 +1,27 @@
+import matcher from '.';
+
+expect.extend(matcher);
+
+describe('.toReject', () => {
+  test('passes when passed a promise that rejects', async () => {
+    const promise = Promise.reject();
+    await expect(promise).toReject();
+  });
+
+  test('fails when passed a promise that resolved', async () => {
+    const promise = Promise.resolve();
+    await expect(expect(promise).toReject()).rejects.toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toReject', () => {
+  test('fails when passed a promise that rejects', async () => {
+    const promise = Promise.reject();
+    await expect(expect(promise).not.toReject()).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  test('passes when passed a promise that resolved', async () => {
+    const promise = Promise.resolve();
+    await expect(promise).not.toReject();
+  });
+});

--- a/src/matchers/toReject/predicate.js
+++ b/src/matchers/toReject/predicate.js
@@ -1,10 +1,1 @@
-export default async promise => {
-  return promise.then(
-    resolved => {
-      return false;
-    },
-    rejected => {
-      return true;
-    }
-  );
-};
+export default promise => promise.then(() => false, () => true);

--- a/src/matchers/toReject/predicate.js
+++ b/src/matchers/toReject/predicate.js
@@ -1,0 +1,10 @@
+export default async promise => {
+  return promise.then(
+    resolved => {
+      return false;
+    },
+    rejected => {
+      return true;
+    }
+  );
+};

--- a/src/matchers/toReject/predicate.test.js
+++ b/src/matchers/toReject/predicate.test.js
@@ -1,6 +1,6 @@
 import predicate from './predicate';
 
-describe('toResolve predicate', () => {
+describe('toReject predicate', () => {
   test('should return true when passed a promise that rejects', async () => {
     const promise = Promise.reject();
     expect(await predicate(promise)).toBe(true);

--- a/src/matchers/toReject/predicate.test.js
+++ b/src/matchers/toReject/predicate.test.js
@@ -1,0 +1,13 @@
+import predicate from './predicate';
+
+describe('toResolve predicate', () => {
+  test('should return true when passed a promise that rejects', async () => {
+    const promise = Promise.reject();
+    expect(await predicate(promise)).toBe(true);
+  });
+
+  test('should return false when passed a promise that resolves', async () => {
+    const promise = Promise.resolve();
+    expect(await predicate(promise)).toBe(false);
+  });
+});

--- a/src/matchers/toResolve/__snapshots__/index.test.js.snap
+++ b/src/matchers/toResolve/__snapshots__/index.test.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toResolve fails when passed a promise that resolved 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toResolve(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toResolve(</><dim>)</>
 
-Expected promise to <green>\\"reject\\"</>, however it <red>\\"resolved\\"</>.
+Expected promise to reject, however it resolved.
 "
 `;
 
 exports[`.toResolve fails when passed a promise that rejects 1`] = `
-"<dim>expect(</><red>received</><dim>).toResolve(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toResolve(</><dim>)</>
 
-Expected promise to <green>\\"resolve\\"</>, however it <red>\\"rejected\\"</>.
+Expected promise to resolve, however it rejected.
 "
 `;

--- a/src/matchers/toResolve/__snapshots__/index.test.js.snap
+++ b/src/matchers/toResolve/__snapshots__/index.test.js.snap
@@ -1,3 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toIncludeSameMembers fails when array contents match 1`] = `"expect(...).not.toIncludeSameMembers is not a function"`;
+exports[`.not.toResolve fails when passed a promise that resolved 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toResolve(</><green>expected</><dim>)</>
+
+Expected promise to <green>\\"reject\\"</>, however it <red>\\"resolved\\"</>.
+"
+`;
+
+exports[`.toResolve fails when passed a promise that rejects 1`] = `
+"<dim>expect(</><red>received</><dim>).toResolve(</><green>expected</><dim>)</>
+
+Expected promise to <green>\\"resolve\\"</>, however it <red>\\"rejected\\"</>.
+"
+`;

--- a/src/matchers/toResolve/__snapshots__/index.test.js.snap
+++ b/src/matchers/toResolve/__snapshots__/index.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toIncludeSameMembers fails when array contents match 1`] = `"expect(...).not.toIncludeSameMembers is not a function"`;

--- a/src/matchers/toResolve/index.js
+++ b/src/matchers/toResolve/index.js
@@ -2,18 +2,18 @@ import { matcherHint } from 'jest-matcher-utils';
 
 import predicate from './predicate';
 
-const passMessage = () => () =>
+const passMessage = () =>
   matcherHint('.not.toResolve', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
 
-const failMessage = () => () =>
+const failMessage = () =>
   matcherHint('.toResolve', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
 
 export default {
   toResolve: async promise => {
     const pass = await predicate(promise);
     if (pass) {
-      return { pass: true, message: passMessage() };
+      return { pass: true, message: passMessage };
     }
-    return { pass: false, message: failMessage() };
+    return { pass: false, message: failMessage };
   }
 };

--- a/src/matchers/toResolve/index.js
+++ b/src/matchers/toResolve/index.js
@@ -1,0 +1,19 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (actual, expected) => () =>
+  matcherHint('.not.toResolve') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
+
+const failMessage = (actual, expected) => () =>
+  matcherHint('.toResolve') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
+
+export default {
+  toResolve: async promise => {
+    const pass = await predicate(promise);
+    if (pass) {
+      return { pass: true, message: passMessage() };
+    }
+    return { pass: false, message: failMessage() };
+  }
+};

--- a/src/matchers/toResolve/index.js
+++ b/src/matchers/toResolve/index.js
@@ -1,16 +1,12 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import { matcherHint } from 'jest-matcher-utils';
 
 import predicate from './predicate';
 
 const passMessage = () => () =>
-  matcherHint('.not.toResolve') +
-  '\n\n' +
-  `Expected promise to ${printExpected('reject')}, however it ${printReceived('resolved')}.\n`;
+  matcherHint('.not.toResolve', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
 
 const failMessage = () => () =>
-  matcherHint('.toResolve') +
-  '\n\n' +
-  `Expected promise to ${printExpected('resolve')}, however it ${printReceived('rejected')}.\n`;
+  matcherHint('.toResolve', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
 
 export default {
   toResolve: async promise => {

--- a/src/matchers/toResolve/index.test.js
+++ b/src/matchers/toResolve/index.test.js
@@ -2,9 +2,26 @@ import matcher from '.';
 
 expect.extend(matcher);
 
-describe('.toIncludeSameMembers', () => {
+describe('.toResolve', () => {
   test('passes when passed a promise that resolved', async () => {
     const promise = Promise.resolve();
     await expect(promise).toResolve();
+  });
+
+  test('fails when passed a promise that rejects', async () => {
+    const promise = Promise.reject();
+    await expect(expect(promise).toResolve()).rejects.toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toResolve', () => {
+  test('fails when passed a promise that resolved', async () => {
+    const promise = Promise.resolve();
+    await expect(expect(promise).not.toResolve()).rejects.toThrowErrorMatchingSnapshot();
+  });
+
+  test('passes when passed a promise that rejects', async () => {
+    const promise = Promise.reject();
+    await expect(promise).not.toResolve();
   });
 });

--- a/src/matchers/toResolve/index.test.js
+++ b/src/matchers/toResolve/index.test.js
@@ -1,0 +1,10 @@
+import matcher from '.';
+
+expect.extend(matcher);
+
+describe('.toIncludeSameMembers', () => {
+  test('passes when passed a promise that resolved', async () => {
+    const promise = Promise.resolve();
+    await expect(promise).toResolve();
+  });
+});

--- a/src/matchers/toResolve/predicate.js
+++ b/src/matchers/toResolve/predicate.js
@@ -1,10 +1,1 @@
-export default async promise => {
-  return promise.then(
-    resolved => {
-      return true;
-    },
-    rejected => {
-      return false;
-    }
-  );
-};
+export default promise => promise.then(() => true, () => false);

--- a/src/matchers/toResolve/predicate.js
+++ b/src/matchers/toResolve/predicate.js
@@ -1,0 +1,10 @@
+export default async promise => {
+  return promise.then(
+    resolved => {
+      return true;
+    },
+    rejected => {
+      return false;
+    }
+  );
+};

--- a/src/matchers/toResolve/predicate.test.js
+++ b/src/matchers/toResolve/predicate.test.js
@@ -1,0 +1,13 @@
+import predicate from './predicate';
+
+describe('toResolve predicate', () => {
+  test('should return true when passed a promise that resolves', async () => {
+    const promise = Promise.resolve();
+    expect(await predicate(promise)).toBe(true);
+  });
+
+  test('should return false when passed a promise that rejects', async () => {
+    const promise = Promise.reject();
+    expect(await predicate(promise)).toBe(false);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -284,6 +284,16 @@ declare namespace jest {
     toBeSealed(): R;
 
     /**
+     * Use `.toResolve` when checking if a promise resolves.
+     */
+    toResolve(): R;
+
+    /**
+     * Use `.toReject` when checking if a promise rejects.
+     */
+    toReject(): R;
+
+    /**
      * Use `.toBeString` when checking if a value is a `String`.
      */
     toBeString(): R;


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
Added custom matcher's for determining if a promise has resolved or rejected

<!-- Why are these changes necessary? Link any related issues -->
### Why
As pair https://github.com/jest-community/jest-extended/issues/130

<!-- If necessary add any additional notes on the implementation -->
### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] Add yourself to contributors list (`yarn contributor`)
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
