### PR TITLE
Add Pass & Fail matchers

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -450,7 +450,16 @@
       "contributions": [
         "code"
       ]
-    }
+    },
+        {
+          "login": "williamrchr",
+          "name": "William Archer",
+          "avatar_url": "https://avatars2.githubusercontent.com/u/7919424?s=460&v=4",
+          "profile": "https://github.com/williamrchr",
+          "contributions": [
+            "code"
+          ]
+        }
   ],
   "repoType": "github"
 }

--- a/README.md
+++ b/README.md
@@ -171,7 +171,6 @@ test('passes when using an asymmetrical matcher', () => {
 
 #### .pass(message)
 
-_Note: Currently unimplemented_
 
 Passing assertion.
 
@@ -181,7 +180,6 @@ expect().pass('should pass');
 
 #### .fail(message)
 
-_Note: Currently unimplemented_
 
 Failing assertion.
 

--- a/src/matchers/fail/__snapshots__/index.test.js.snap
+++ b/src/matchers/fail/__snapshots__/index.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.fail fails with message 1`] = `"This shouldn't fail!"`;
+
+exports[`.fail fails without message 1`] = `"Failure!"`;

--- a/src/matchers/fail/index.js
+++ b/src/matchers/fail/index.js
@@ -1,0 +1,21 @@
+import predicate from './predicate';
+
+const passMessage = message => {
+  if (message) return () => message;
+  else return () => 'Failure!';
+};
+
+const failMessage = message => {
+  if (message) return () => message;
+  else return () => 'Failure!';
+};
+
+export default {
+  fail: (expected, message) => {
+    const pass = predicate(message);
+    if (pass) {
+      return { pass: true, message: passMessage(message) };
+    }
+    return { pass: false, message: failMessage(message) };
+  }
+};

--- a/src/matchers/fail/index.test.js
+++ b/src/matchers/fail/index.test.js
@@ -1,0 +1,21 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.fail', () => {
+  test('fails without message', () => {
+    expect(() => expect().fail()).toThrowErrorMatchingSnapshot();
+  });
+  test('fails with message', () => {
+    expect(() => expect().fail("This shouldn't fail!")).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.fail', () => {
+  test('does not fail without message', () => {
+    expect().not.fail();
+  });
+  test('does not fail with message', () => {
+    expect().not.fail('this should fail!');
+  });
+});

--- a/src/matchers/fail/predicate.js
+++ b/src/matchers/fail/predicate.js
@@ -1,0 +1,1 @@
+export default (expected, message) => false;

--- a/src/matchers/fail/predicate.test.js
+++ b/src/matchers/fail/predicate.test.js
@@ -1,0 +1,11 @@
+import predicate from './predicate';
+
+describe('fail Predicate', () => {
+  test('returns false when given nothing', () => {
+    expect(predicate()).toBe(false);
+  });
+
+  test('returns false when given a value', () => {
+    expect(predicate('', 'test')).toBe(false);
+  });
+});

--- a/src/matchers/pass/__snapshots__/index.test.js.snap
+++ b/src/matchers/pass/__snapshots__/index.test.js.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.pass does not pass, has no message 1`] = `"Passed!"`;
+
+exports[`.not.pass does not.pass, has no message 1`] = `"This should not pass!"`;

--- a/src/matchers/pass/index.js
+++ b/src/matchers/pass/index.js
@@ -1,0 +1,21 @@
+import predicate from './predicate';
+
+const passMessage = message => {
+  if (message) return () => message;
+  else return () => 'Passed!';
+};
+
+const failMessage = message => {
+  if (message) return () => message;
+  else return () => 'Passed!';
+};
+
+export default {
+  pass: (expected, message) => {
+    const pass = predicate(message);
+    if (pass) {
+      return { pass: true, message: passMessage(message) };
+    }
+    return { pass: false, message: failMessage(message) };
+  }
+};

--- a/src/matchers/pass/index.test.js
+++ b/src/matchers/pass/index.test.js
@@ -1,0 +1,21 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.pass', () => {
+  test('passes without message', () => {
+    expect().pass();
+  });
+  test('passes with message', () => {
+    expect().pass('this should pass!');
+  });
+});
+
+describe('.not.pass', () => {
+  test('does not pass, has no message', () => {
+    expect(() => expect().not.pass()).toThrowErrorMatchingSnapshot();
+  });
+  test('does not.pass, has no message', () => {
+    expect(() => expect().not.pass('This should not pass!')).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/pass/predicate.js
+++ b/src/matchers/pass/predicate.js
@@ -1,0 +1,1 @@
+export default (expected, message) => true;

--- a/src/matchers/pass/predicate.test.js
+++ b/src/matchers/pass/predicate.test.js
@@ -1,0 +1,11 @@
+import predicate from './predicate';
+
+describe('true Predicate', () => {
+  test('returns true when given nothing', () => {
+    expect(predicate()).toBe(true);
+  });
+
+  test('returns true when given a value', () => {
+    expect(predicate('', 'test')).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
This PR creates the implementation for the pass and fail matchers.

<!-- Why are these changes necessary? Link any related issues -->
These matchers are currently unimplemented.

<!-- If necessary add any additional notes on the implementation -->
I'm not sold on the default pass/failure message, and I created separate pass/fail message constants for both matchers in case someone wants to update one but not the other. Let me know if you'd rather avoid the code duplication.

### Housekeeping

- [y] Unit tests
- [y ] Documentation is up to date
- [y] No additional lint warnings
- [y] Add yourself to contributors list (`yarn contributor`)
- [y] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
