### PR TITLE
Update instructions to use setupFilesAfterEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,25 +127,7 @@ Add jest-extended to your Jest setupTestFrameworkScriptFile configuration. [See 
 
 ``` json
 "jest": {
-  "setupTestFrameworkScriptFile": "jest-extended"
-}
-```
-
-If you are already using another test framework, like [jest-chain](https://github.com/mattphillips/jest-chain), then you should create a test setup file and `require` each of the frameworks you are using.
-
-For example:
-
-```js
-// ./testSetup.js
-require('jest-extended');
-require('any other test framework libraries you are using');
-```
-
-Then in your Jest config:
-
-```json
-"jest": {
-  "setupTestFrameworkScriptFile": "./testSetup.js"
+  "setupFilesAfterEnv": ["jest-extended"]
 }
 ```
 


### PR DESCRIPTION
### What

Current README instructs users to use Jest's `setupTestFrameworkScriptFile` config, which is not updated. The `setupFilesAfterEnv` config allows for multiple files, so the rest of the explanation is unnecessary.

### Why

Cause the instructions it will not work in latest jest.