### PR TITLE
Update docs to use setupFilesAfterEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ yarn add -D jest-extended
 
 ## Setup
 
-Add jest-extended to your Jest setupTestFrameworkScriptFile configuration. [See for help](http://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string)
+Add jest-extended to your Jest setupFilesAfterEnv configuration. [See for help](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)
 
 ``` json
 "jest": {
-  "setupTestFrameworkScriptFile": "jest-extended"
+  "setupFilesAfterEnv": ["jest-extended"]
 }
 ```
 
@@ -145,7 +145,7 @@ Then in your Jest config:
 
 ```json
 "jest": {
-  "setupTestFrameworkScriptFile": "./testSetup.js"
+  "setupFilesAfterEnv": ["./testSetup.js"]
 }
 ```
 


### PR DESCRIPTION
### What
Update docs to use setupFilesAfterEnv 

### Why
setupTestFrameworkScriptFile is deprecated.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] Add yourself to contributors list (`yarn contributor`)
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
