### PR TITLE
update the name of jest configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ yarn add -D jest-extended
 
 ## Setup
 
-Add jest-extended to your Jest setupTestFrameworkScriptFile configuration. [See for help](http://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string)
+Add jest-extended to your Jest setupFilesAfterEnv configuration. [See for help](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array)
 
 ``` json
 "jest": {
-  "setupTestFrameworkScriptFile": "jest-extended"
+  "setupFilesAfterEnv": ["jest-extended"]
 }
 ```
 
@@ -145,7 +145,7 @@ Then in your Jest config:
 
 ```json
 "jest": {
-  "setupTestFrameworkScriptFile": "./testSetup.js"
+  "setupFilesAfterEnv": ["./testSetup.js"]
 }
 ```
 


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
I update the documentation file.
<!-- Why are these changes necessary? Link any related issues -->
### Why
According to the recent version of jest and the [official documentation](https://jestjs.io/docs/en/configuration#setupfilesafterenv-array) the setupTestFrameworkScriptFile property was deprecated and it's replaced by setupFilesAfterEnv.
<!-- If necessary add any additional notes on the implementation -->
### Notes

### Housekeeping

- [ ] Unit tests
- [X] Documentation is up to date
- [ ] No additional lint warnings
- [ ] Add yourself to contributors list (`yarn contributor`)
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
