### PR TITLE
update Matchers to Matchers<R,T>

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace jest {
   // noinspection JSUnusedGlobalSymbols
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * Note: Currently unimplemented
      * Passing assertion


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What

@types/jest changed Matchers to be `Matchers<R,T>` this change is just supporting that

<!-- Why are these changes necessary? Link any related issues -->
### Why
npm build will fail for TS projects with both jest-extended@0.11.2 and @types/jest@24.0.20

<!-- If necessary add any additional notes on the implementation -->
### Notes

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
