### PR TITLE
Fix type parameter of 'Matchers' for jest 24.0.21

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace jest {
   // noinspection JSUnusedGlobalSymbols
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * Note: Currently unimplemented
      * Passing assertion


### PR DESCRIPTION
Fixes the typescript compile error: "All declarations of 'Matchers' must have identical type parameters."

<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

### What

Added a second type parameter to the `Matchers` interface to fix a typescript compile error of 
```
node_modules/jest-extended/types/index.d.ts:5:13 - error TS2428: All declarations of 'Matchers' must have identical type parameters.

5   interface Matchers<R> {
```

### Why
@types/jest v24.0.21 has changed the type parameters of the `Matchers` interface and this one need to match with the one of jest-extended.

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
