### PR TITLE
Fixes #226 - Add a '.toSatisfyAny(predicate)' custom matcher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toIncludeAnyMembers([members])](#toincludeanymembersmembers)
     - [.toIncludeSameMembers([members])](#toincludesamemembersmembers)
     - [.toSatisfyAll(predicate)](#tosatisfyallpredicate)
+    - [.toSatisfyAny(predicate)](#tosatisfyanypredicate)
   - [Boolean](#boolean)
     - [.toBeBoolean()](#tobeboolean)
     - [.toBeTrue()](#tobetrue)
@@ -329,6 +330,18 @@ test('passes when all values in array pass given predicate', () => {
 });
 ```
 
+
+#### .toSatisfyAny(predicate)
+
+Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for any value in an array.
+
+```js
+test('passes when any value in array passes given predicate', () => {
+  const isOdd = el => el % 2 === 1;
+  expect([1,2,3,4]).toSatisfyAny(isOdd);
+  expect([2,4,6,8]).not.toSatisfyAny(isOdd);
+});
+```
 ### Boolean
 
 #### .toBeBoolean()

--- a/src/matchers/toSatisfyAny/__snapshots__/index.test.js.snap
+++ b/src/matchers/toSatisfyAny/__snapshots__/index.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toSatisfyAny fails when any value satisfies predicate 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toSatisfyAny(</><green>expected</><dim>)</>
+
+Expected array to not satisfy predicate for any value:
+  <green>[Function isOdd]</>
+Received:
+  <red>[1, 2, 3, 4]</>"
+`;
+
+exports[`.toSatisfyAny fails when all values do not satisfy the predicate 1`] = `
+"<dim>expect(</><red>received</><dim>).toSatisfyAny(</><green>expected</><dim>)</>
+
+Expected array to satisfy predicate for any value:
+  <green>[Function isEven]</>
+Received:
+  <red>[1, 3, 7, 5]</>"
+`;

--- a/src/matchers/toSatisfyAny/index.js
+++ b/src/matchers/toSatisfyAny/index.js
@@ -1,0 +1,30 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+
+import predicate from './predicate';
+
+const passMessage = (actual, expected) => () =>
+  matcherHint('.not.toSatisfyAny') +
+  '\n\n' +
+  'Expected array to not satisfy predicate for any value:\n' +
+  `  ${printExpected(expected)}\n` +
+  'Received:\n' +
+  `  ${printReceived(actual)}`;
+
+const failMessage = (actual, expected) => () =>
+  matcherHint('.toSatisfyAny') +
+  '\n\n' +
+  'Expected array to satisfy predicate for any value:\n' +
+  `  ${printExpected(expected)}\n` +
+  'Received:\n' +
+  `  ${printReceived(actual)}`;
+
+export default {
+  toSatisfyAny: (actual, expected) => {
+    const pass = predicate(actual, expected);
+    if (pass) {
+      return { pass: true, message: passMessage(actual, expected) };
+    }
+
+    return { pass: false, message: failMessage(actual, expected) };
+  }
+};

--- a/src/matchers/toSatisfyAny/index.test.js
+++ b/src/matchers/toSatisfyAny/index.test.js
@@ -1,0 +1,30 @@
+import matcher from './';
+
+expect.extend(matcher);
+
+let isEven = el => el % 2 === 0;
+let isOdd = el => el % 2 === 1;
+
+describe('.toSatisfyAny', () => {
+  test('passes when any value satisfies predicate', () => {
+    expect([1, 2, 4, 6]).toSatisfyAny(isOdd);
+    expect([2, 4, 6, 8]).toSatisfyAny(isEven);
+    expect([11]).toSatisfyAny(isOdd);
+    expect([10]).toSatisfyAny(isEven);
+  });
+
+  test('fails when all values do not satisfy the predicate', () => {
+    expect(() => expect([1, 3, 7, 5]).toSatisfyAny(isEven)).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toSatisfyAny', () => {
+  test('passes when all values do not satisfy the predicate', () => {
+    expect([2, 4, 6, 8]).not.toSatisfyAny(isOdd);
+    expect([1, 5, 3, 7, 9]).not.toSatisfyAny(isEven);
+  });
+
+  test('fails when any value satisfies predicate', () => {
+    expect(() => expect([1, 2, 3, 4]).not.toSatisfyAny(isOdd)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toSatisfyAny/predicate.js
+++ b/src/matchers/toSatisfyAny/predicate.js
@@ -1,0 +1,1 @@
+export default (array, predicate) => array.some(predicate);

--- a/src/matchers/toSatisfyAny/predicate.test.js
+++ b/src/matchers/toSatisfyAny/predicate.test.js
@@ -1,0 +1,21 @@
+import predicate from './predicate';
+
+describe('toSatisfyAny', () => {
+  let isOdd = el => el % 2 === 1;
+
+  describe('returns true', () => {
+    test('when any element satisfies', () => {
+      expect(predicate([1, 2, 3, 4], isOdd)).toBe(true);
+    });
+
+    test('works for repeated elements', () => {
+      expect(predicate([1, 1, 2, 4], isOdd)).toBe(true);
+    });
+  });
+
+  describe('returns false', () => {
+    test('when all elements fail', () => {
+      expect(predicate([10, 2, 4, 6], isOdd)).toBe(false);
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -711,5 +711,11 @@ declare namespace jest {
      * @param {String | RegExp} message
      */
     toThrowWithMessage(type: Function, message: string | RegExp): any;
+
+    /**
+     * Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for any value in an array.
+     * @param {Function} predicate
+     */
+    toSatisfyAny(predicate: (x: any) => boolean): R;
   }
 }


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

### What changes are being made? (feature/bug) 

Adding 'array.toSatisfyAny(predicate)' custom matcher.

### Why are these changes necessary? Link any related issues

A new matcher is being added as requested in #226

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
