### PR TITLE
Fixed syntax errors in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Use `.toBeDate` when checking if a value is a `Date`.
 test('passes when value is a date', () => {
   expect(new Date()).toBeDate();
   expect('01/01/2018').not.toBeDate();
-  expect(new Date('01/01/2018').toBeDate();
+  expect(new Date('01/01/2018')).toBeDate();
   expect(undefined).not.toBeDate();
 });
 ```
@@ -391,8 +391,8 @@ Use `.toBeValidDate` when checking if a given `Date` object is valid.
 test('passes when Date is valid', () => {
   expect(new Date()).toBeValidDate();
   expect('01/01/2018').not.toBeValidDate();
-  expect(new Date('01/01/2018').toBeValidDate();
-  expect(new Date('01/90/2018').not.toBeValidDate();
+  expect(new Date('01/01/2018')).toBeValidDate();
+  expect(new Date('01/90/2018')).not.toBeValidDate();
   expect(undefined).not.toBeValidDate();
 });
 ```


### PR DESCRIPTION
Added closing bracket in the toBeDate() and toBeValidDate() examples

<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
Fixing syntax errors in documentation 

<!-- Why are these changes necessary? Link any related issues -->
### Why
Copying and pasting example code doesn't run

<!-- If necessary add any additional notes on the implementation -->
### Notes
N/A

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
