### PR TITLE
Check input is valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toResolve()](#toresolve)
     - [.toReject()](#toreject)
   - [String](#string)
+    - [.toBeJSON()](#tobejson)
     - [.toBeString()](#tobestring)
     - [.toBeHexadecimal(string)](#tobehexadecimal)
     - [.toEqualCaseInsensitive(string)](#toequalcaseinsensitivestring)
@@ -831,6 +832,23 @@ test('passes when a promise rejects', async () => {
 ```
 
 ### String
+
+### .toBeJSON()
+
+Use `.toBeJSON` to validate input is valid JSON.
+
+```js
+test('passes when value is a valid JSON', () => {
+  expect('{"key":"value"}').toBeJSON();
+  expect('[1,2,3]').toBeJSON();
+  expect({key: 'value'}).not.toBeJSON();
+  expect('{"key"}').not.toBeJSON();
+  expect('{"key":broken}').not.toBeJSON();
+  expect('hello').not.toBeJSON();
+  expect(12).not.toBeJSON();
+  expect(null).not.toBeJSON();
+});
+```
 
 #### .toBeString()
 

--- a/src/matchers/toBeJSON/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeJSON/__snapshots__/index.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeJSON fails when given a valid JSON 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeJSON(</><dim>)</>
+
+Expected value not to be valid JSON:
+  <red>\\"{\\\\\\"key\\\\\\":\\\\\\"value\\\\\\"}\\"</>
+"
+`;
+
+exports[`.toBeJSON fails when given a bad JSON 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeJSON(</><dim>)</>
+
+Expected value to be valid JSON:
+  <red>\\"{\\\\\\"key\\\\\\"}\\"</>
+  Error: Unexpected token } in JSON at position 6"
+`;

--- a/src/matchers/toBeJSON/index.js
+++ b/src/matchers/toBeJSON/index.js
@@ -16,13 +16,14 @@ export default {
     }
 
     const pass = !error;
-    const message = () => [
-      matcherHint(pass ? '.not.toBeJSON' : '.toBeJSON', 'received', ''),
-      '',
-      pass ? 'Expected value not to be valid JSON:' : 'Expected value to be valid JSON:',
-      `  ${printReceived(received)}`,
-      pass ? '' : `  Error: ${error.message}`
-    ].join('\n');
+    const message = () =>
+      [
+        matcherHint(pass ? '.not.toBeJSON' : '.toBeJSON', 'received', ''),
+        '',
+        pass ? 'Expected value not to be valid JSON:' : 'Expected value to be valid JSON:',
+        `  ${printReceived(received)}`,
+        pass ? '' : `  Error: ${error.message}`
+      ].join('\n');
 
     return {
       message,

--- a/src/matchers/toBeJSON/index.js
+++ b/src/matchers/toBeJSON/index.js
@@ -1,0 +1,32 @@
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+import isString from '../toBeString/predicate';
+
+export default {
+  toBeJSON(received) {
+    let error;
+
+    try {
+      if (!isString(received)) {
+        throw new Error(`Expected input to be a string, instead got ${received}`);
+      }
+
+      JSON.parse(received);
+    } catch (e) {
+      error = e;
+    }
+
+    const pass = !error;
+    const message = () => [
+      matcherHint(pass ? '.not.toBeJSON' : '.toBeJSON', 'received', ''),
+      '',
+      pass ? 'Expected value not to be valid JSON:' : 'Expected value to be valid JSON:',
+      `  ${printReceived(received)}`,
+      pass ? '' : `  Error: ${error.message}`
+    ].join('\n');
+
+    return {
+      message,
+      pass
+    };
+  }
+};

--- a/src/matchers/toBeJSON/index.test.js
+++ b/src/matchers/toBeJSON/index.test.js
@@ -1,0 +1,25 @@
+import each from 'jest-each';
+
+import matcher from './';
+
+expect.extend(matcher);
+
+describe('.toBeJSON', () => {
+  each([['{"key":"value"}'], ['[1,2,3]']]).test('passes when given a valid JSON input: %s', given => {
+    expect(given).toBeJSON();
+  });
+
+  test('fails when given a bad JSON', () => {
+    expect(() => expect('{"key"}').toBeJSON()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeJSON', () => {
+  each([[{ key: 'value' }], ['{"bad_json":*}'], [''], ['hello'], [12], [null]]).test('passes when given non valid JSON: %s', given => {
+    expect(given).not.toBeJSON();
+  });
+
+  test('fails when given a valid JSON', () => {
+    expect(() => expect('{"key":"value"}').not.toBeJSON()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeJSON/index.test.js
+++ b/src/matchers/toBeJSON/index.test.js
@@ -15,9 +15,12 @@ describe('.toBeJSON', () => {
 });
 
 describe('.not.toBeJSON', () => {
-  each([[{ key: 'value' }], ['{"bad_json":*}'], [''], ['hello'], [12], [null]]).test('passes when given non valid JSON: %s', given => {
-    expect(given).not.toBeJSON();
-  });
+  each([[{ key: 'value' }], ['{"bad_json":*}'], [''], ['hello'], [12], [null]]).test(
+    'passes when given non valid JSON: %s',
+    given => {
+      expect(given).not.toBeJSON();
+    }
+  );
 
   test('fails when given a valid JSON', () => {
     expect(() => expect('{"key":"value"}').not.toBeJSON()).toThrowErrorMatchingSnapshot();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -657,6 +657,11 @@ declare namespace jest {
     toReject(): any;
 
     /**
+     * Use `.toBeJSON` to validate input is valid JSON.
+     */
+    toBeJSON(): any;
+
+    /**
      * Use `.toBeString` when checking if a value is a `String`.
      */
     toBeString(): any;


### PR DESCRIPTION
<!-- What changes are being made? (feature/bug) -->
### What
New feature: Test an input is valid JSON
```js
expect('{"key":"value"}').toBeJSON()
```

<!-- Why are these changes necessary? Link any related issues -->
### Why
Could not find this feature. I use it to check certain application output and logs are in JSON format.

<!-- If necessary add any additional notes on the implementation -->
### Notes
- Does not accept non strings even if they are parsable (null, number).
- Will also print the parsing error: `Error: Unexpected token } in JSON at position 6`.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
