### PR TITLE
Feature: toBeSimilar. Check if two strings are equal irrespective of white-spaces and provide hints if not

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ If you've come here to help contribute - Thanks! Take a look at the [contributin
     - [.toInclude(substring)](#toincludesubstring)
     - [.toIncludeRepeated(substring, times)](#toincluderepeatedsubstring-times)
     - [.toIncludeMultiple([substring])](#toincludemultiplesubstring)
+    - [.toBeSimilar(substring)](#tobesimilarstring)
 - [LICENSE](#license)
 
 ## Installation
@@ -924,6 +925,28 @@ Use `.toIncludeMultiple` when checking if a `String` includes all of the given s
 test('passes when value includes all substrings', () => {
   expect('hello world').toIncludeMultiple(['world', 'hello']);
   expect('hello world').not.toIncludeMultiple(['world', 'hello', 'bob']);
+});
+```
+
+#### .toBeSimilar(string)
+
+Use `.toBeSimilar` when checking if a string is equal (===) to another string irrespective of whitespaces.
+
+```js
+test('passes if strings are equal irrespective of whitespaces', () => {
+    expect('hello world').toBeSimilar(`
+        hello
+        world
+    `);
+    expect('SELECT * FROM TABLE WHERE CONDITION').toBeSimilar(`
+        SELECT * FROM TABLE
+        WHERE CONDITION
+    `);
+    expect('.class { cssRule: value }').not.toBeSimilar(`
+        #id {
+            cssRule: value
+        }
+    `);
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "pretty-format": "^22.1.0"
   },
   "dependencies": {
+    "diff": "^4.0.2",
     "expect": "^24.1.0",
     "jest-get-type": "^22.4.3",
     "jest-matcher-utils": "^22.0.0"

--- a/src/matchers/toBeSimilar/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeSimilar/__snapshots__/index.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.toBeSimilar    should not pass if strings are not equal, not considering whitespaces 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeSimilar(</><green>expected</><dim>)</>
+
+Expected values to not be equal while ignoring whitespace (using ===):
+  <green>\\"</>
+<green>            .class {<inverse> </></>
+<green>                cssRule: value;<inverse> </></>
+<green>            }</>
+<green>        \\"</>
+
+Received:
+  <red>\\".class { cssRule: value; }\\"</>
+
+Hint:
+
+            .class { cssRule: value; }
+        "
+`;
+
+exports[`.toBeSimilar    should pass if strings are equal irrespective of whitespaces 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeSimilar(</><green>expected</><dim>)</>
+
+Expected values to be equal while ignoring whitespace (using ===):
+  <green>\\"#id { cssRule: value; }\\"</>
+
+Received:
+  <red>\\".class { cssRule: value; }\\"</>
+
+Hint:
+<red>#id</><green>.class</> { cssRule: value; }"
+`;

--- a/src/matchers/toBeSimilar/generateHints.js
+++ b/src/matchers/toBeSimilar/generateHints.js
@@ -1,0 +1,14 @@
+const { RECEIVED_COLOR: REMOVE_COLOR, EXPECTED_COLOR: ADD_COLOR } = require('jest-matcher-utils');
+
+module.exports = diff => {
+  return diff.reduce((acc, { added, removed, value }) => {
+    return (
+      acc +
+      (added
+        ? ADD_COLOR(value) //green
+        : removed
+          ? REMOVE_COLOR(value) //red
+          : value)
+    );
+  }, '');
+};

--- a/src/matchers/toBeSimilar/generateHints.test.js
+++ b/src/matchers/toBeSimilar/generateHints.test.js
@@ -1,0 +1,20 @@
+const { RECEIVED_COLOR: REMOVE_COLOR, EXPECTED_COLOR: ADD_COLOR } = require('jest-matcher-utils');
+const { diffWords } = require('diff');
+const generateHints = require('./generateHints');
+
+describe('testing generateHints', () => {
+  it.each([
+    ['SELECT * FROM TABLE', 'SELECT * RFOM TABLE', 'SELECT * ' + REMOVE_COLOR('RFOM') + ADD_COLOR('FROM') + ' TABLE'],
+    [
+      'import React from "react"',
+
+      'import {Component} from "react";',
+
+      'import ' + REMOVE_COLOR('{Component}') + ADD_COLOR('React') + ' from "react"' + REMOVE_COLOR(';')
+    ],
+    ['const a = 5;', 'const    \n' + 'a =     5', 'const a = 5' + ADD_COLOR(';')]
+  ])('generated hints must be equal to given hints', (received, expected, expectedHint) => {
+    const diff = diffWords(expected, received);
+    expect(generateHints(diff)).toEqual(expectedHint);
+  });
+});

--- a/src/matchers/toBeSimilar/index.js
+++ b/src/matchers/toBeSimilar/index.js
@@ -1,0 +1,35 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
+import predicate from './predicate';
+import generateHints from './generateHints';
+
+const passMessage = (received, expected, diff) => () =>
+  matcherHint('.not.toBeSimilar') +
+  '\n\n' +
+  'Expected values to not be equal while ignoring whitespace (using ===):\n' +
+  `  ${printExpected(expected)}\n\n` +
+  'Received:\n' +
+  `  ${printReceived(received)}\n\n` +
+  'Hint:\n' +
+  generateHints(diff);
+
+const failMessage = (received, expected, diff) => () =>
+  matcherHint('.toBeSimilar') +
+  '\n\n' +
+  'Expected values to be equal while ignoring whitespace (using ===):\n' +
+  `  ${printExpected(expected)}\n\n` +
+  'Received:\n' +
+  `  ${printReceived(received)}\n\n` +
+  'Hint:\n' +
+  generateHints(diff);
+
+export default {
+  toBeSimilar(received, expected) {
+    const { pass, diff } = predicate(received, expected);
+
+    return {
+      pass: pass,
+      message: pass ? passMessage(received, expected, diff) : failMessage(received, expected, diff),
+      actual: received
+    };
+  }
+};

--- a/src/matchers/toBeSimilar/index.test.js
+++ b/src/matchers/toBeSimilar/index.test.js
@@ -1,0 +1,73 @@
+import matcher from './.';
+
+expect.extend(matcher);
+
+describe('.toBeSimilar   ', () => {
+  test('should pass if strings are equal irrespective of whitespaces', () => {
+    expect('SELECT * from TABLE WHERE CONDITION = "5"').toBeSimilar(`
+            SELECT * from TABLE
+            WHERE CONDITION = "5"
+        `);
+
+    expect('SELECT * from TABLE WHERE CONDITION = "5"').toBeSimilar(`
+            SELECT 
+            * 
+            from 
+            TABLE 
+            WHERE 
+            CONDITION="5"
+        `);
+
+    expect(`
+            diff.forEach((diffObject) => {
+                if(diffObject.value.trim())
+                    return;
+                diffObject.added = diffObject.removed = undefined;
+            });
+        `).toBeSimilar(`
+            diff.forEach((diffObject) => {
+                if(diffObject.value.trim()) return;
+                diffObject.added = diffObject.removed = undefined;
+            });
+        `);
+
+    expect(() =>
+      expect('.class { cssRule: value; }').toBeSimilar('#id { cssRule: value; }')
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('should not pass if strings are not equal, not considering whitespaces', () => {
+    expect('SELECT * from TABLE WHERE CONDITION = "5"').not.toBeSimilar(`
+            WHERE CONDITION = "5" 
+            SELECT * from TABLE
+        `);
+
+    expect('SELECT * from TABLE WHERE CONDITION = "5"').not.toBeSimilar(`
+            SELECT * from TABLE
+            WHERE CONDITION = "555"
+        `);
+
+    expect('SELECT * from TABLE WHERE CONDITION = "5"').not.toBeSimilar(`
+            WHERE CONDITION = "5"
+        `);
+
+    expect('SELECT * from TABLE WHERE CONDITION = "5"').not.toBeSimilar(`
+            select * from table 
+               where 5condition="5"
+        `);
+
+    expect(`
+            import React from 'react';
+        `).not.toBeSimilar(`
+            import {Component} from 'react';
+        `);
+
+    expect(() =>
+      expect('.class { cssRule: value; }').not.toBeSimilar(`
+            .class { 
+                cssRule: value; 
+            }
+        `)
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/src/matchers/toBeSimilar/predicate.js
+++ b/src/matchers/toBeSimilar/predicate.js
@@ -1,0 +1,16 @@
+import { diffWords } from 'diff';
+
+export default (received, expected) => {
+  const diff = diffWords(expected, received);
+  diff.forEach(diffObject => {
+    if (diffObject.value.trim()) return;
+    diffObject.added = diffObject.removed = undefined;
+  });
+
+  const pass = diff.every(({ added, removed }) => !added && !removed);
+
+  return {
+    diff,
+    pass
+  };
+};

--- a/src/matchers/toBeSimilar/predicate.test.js
+++ b/src/matchers/toBeSimilar/predicate.test.js
@@ -1,0 +1,93 @@
+describe('toBeSimilarWith predicate', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('should return true for pass when diff does not add anything than spaces', () => {
+    jest.setMock('diff', {
+      diffWords: () => [
+        {
+          value: ' ',
+          added: true
+        },
+        {
+          value: 'select * from table'
+        },
+        {
+          value: ' \n\n ',
+          added: true
+        },
+        {
+          value: 'where condition = true'
+        }
+      ]
+    });
+    const { default: predicate } = require('./predicate');
+    const { pass, diff } = predicate('inputs A', 'input B');
+
+    expect(pass).toEqual(true);
+    expect(diff).toEqual([
+      {
+        value: ' '
+      },
+      {
+        value: 'select * from table'
+      },
+      {
+        value: ' \n\n '
+      },
+      {
+        value: 'where condition = true'
+      }
+    ]);
+  });
+
+  it('should return false for pass when diff add or remove tokens', () => {
+    jest.setMock('diff', {
+      diffWords: () => [
+        {
+          value: ' ',
+          added: true
+        },
+        {
+          value: ' ',
+          removed: true
+        },
+        {
+          value: ' '
+        },
+        {
+          value: 'token',
+          removed: true
+        },
+        {
+          value: 'newToken',
+          added: true
+        }
+      ]
+    });
+    const { default: predicate } = require('./predicate');
+    const { pass, diff } = predicate('inputs A', 'input B');
+
+    expect(pass).toEqual(false);
+    expect(diff).toEqual([
+      {
+        value: ' '
+      },
+      {
+        value: ' '
+      },
+      {
+        value: ' '
+      },
+      {
+        value: 'token',
+        removed: true
+      },
+      {
+        value: 'newToken',
+        added: true
+      }
+    ]);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -349,6 +349,13 @@ declare namespace jest {
     toIncludeMultiple(substring: string[]): R;
 
     /**
+     * Use .toBeSimilar when checking if a string is equal (===) to another string irrespective of whitespaces.
+     *
+     * @param {String} string
+     */
+    toBeSimilar(string: string): R;
+
+    /**
      * Use `.toThrowWithMessage` when checking if a callback function throws an error of a given type with a given error message.
      *
      * @param {Function} type

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,6 +1117,11 @@ diff@^3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+diff@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What
New feature: Test if two strings are equal, ignoring whitespaces in both string. 

```js
    expect('SELECT * FROM TABLE WHERE CONDITION').toBeSimilar(`
        SELECT * FROM TABLE
        WHERE CONDITION
    `);
```
And if the strings are not similar, provide hints to user regarding the differences in strings with color coding.

```js
    expect('.class { cssRule: value }').toBeSimilar(`
        #id {
            cssRule: value
        }
    `);
```

![image](https://user-images.githubusercontent.com/3319815/73473127-37586100-43b2-11ea-9c89-8da06fba164c.png)


<!-- Why are these changes necessary? Link any related issues -->
### Why
Very often we are asserting over SQL queries, JS code, CSS rules, etc which is very cumbersome due to spaces and newlines. If the strings differs, then it is very hard to rectify the expected string without any hint.

<!-- If necessary add any additional notes on the implementation -->
### Notes
Added new npm dependency `diff` to calculate differences in strings.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
