### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ expect().fail('test should fail');
 
 #### .toBeEmpty()
 
-Use `.toBeEmpty` when checking if a `String` `''`, `Array` `[]`, `Object` `{}`, or `[Iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#Built-in_iterables)` is empty. Because `toBeEmpty` supports checking for emptiness of Iterables, you can use it to check whether a `Map`, or `Set` is empty, as well as checking that a generator yields no values.
+Use `.toBeEmpty` when checking if a `String` `''`, `Array` `[]`, `Object` `{}`, or [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#Built-in_iterables) is empty. Because `toBeEmpty` supports checking for emptiness of Iterables, you can use it to check whether a `Map`, or `Set` is empty, as well as checking that a generator yields no values.
 
 ```js
 test('passes when given an empty string', () => {


### PR DESCRIPTION
### What
Fix link to `Iterable` in the `toBeEmpty()` section of the readme.

### Why
It was previously this:
> `[Iterable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#Built-in_iterables)`

Now:
> [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#Built-in_iterables)

### Notes
none

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
