### PR TITLE
Fix toHaveBeenCalledBefore/toHaveBeenCalledAfter type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -154,7 +154,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoSecondInvocation=true]
      */
-    toHaveBeenCalledBefore(mock: jest.Mock, failIfNoSecondInvocation?: boolean): R;
+    toHaveBeenCalledBefore(mock: jest.MockInstance<any, any[]>, failIfNoSecondInvocation?: boolean): R;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -164,7 +164,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoFirstInvocation=true]
      */
-    toHaveBeenCalledAfter(mock: jest.Mock, failIfNoFirstInvocation?: boolean): R;
+    toHaveBeenCalledAfter(mock: jest.MockInstance<any, any[]>, failIfNoFirstInvocation?: boolean): R;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.
@@ -579,7 +579,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoSecondInvocation=true]
      */
-    toHaveBeenCalledBefore(mock: jest.Mock, failIfNoSecondInvocation: boolean): any;
+    toHaveBeenCalledBefore(mock: jest.MockInstance<any, any[]>, failIfNoSecondInvocation: boolean): any;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -589,7 +589,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoFirstInvocation=true]
      */
-    toHaveBeenCalledAfter(mock: jest.Mock, failIfNoFirstInvocation: boolean): any;
+    toHaveBeenCalledAfter(mock: jest.MockInstance<any, any[]>, failIfNoFirstInvocation: boolean): any;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.


### PR DESCRIPTION
<!-- What changes are being made? (feature/bug) -->
### What
I get a compiler error when passing a `jest.MockedFunction` type to `toHaveBeenCalledAfter()/toHaveBeenCalledBefore()`.

### Why

Code showing the issue.
```ts
import { func } from './some-func';
import { SomeClass } from './some-class';

const mockFunc = func as jest.MockedFunction<typeof func>;
const mockClass = SomeClass as jest.MockedClass<typeof SomeClass>;

jest.mock('./some-func');
jest.mock('./some-class');

// all of the following statements generate a compiler error
expect(jest.fn()).toHaveBeenCalledBefore(mockFunc);
expect(jest.fn()).toHaveBeenCalledBefore(mockClass);
expect(jest.fn()).toHaveBeenCalledAfter(mockFunc);
expect(jest.fn()).toHaveBeenCalledAfter(mockClass);

```

I get this compiler error.
```
 Argument of type 'MockedFunction<() => void>' is not assignable to parameter of type 'Mock<any, any>'.
  The types returned by 'mockClear().mockClear()' are incompatible between these types.
    Type 'MockedFunction<() => void>' is not assignable to type 'Mock<any, any>'.
      Type 'MockInstance<void, [()?]> & (() => void)' provides no match for the signature 'new (...args: any): any'.

12. expect(jest.fn()).toHaveBeenCalledAfter(mockFunc);
```

Changing these to `jest.MockInstance` resolves the issue and should work for all use cases as both `jest.MockedFunction` and `jest.MockedClass` extend `jest.MockInstance`.

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
