### PR TITLE
Move @types/jest to be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "license": "MIT",
   "repository": "jest-community/jest-extended",
   "devDependencies": {
-    "@types/jest": "^23.3.2",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.1",
@@ -59,6 +58,7 @@
     "pretty-format": "^22.1.0"
   },
   "dependencies": {
+    "@types/jest": "^23.3.2",
     "expect": "^24.1.0",
     "jest-get-type": "^22.4.3",
     "jest-matcher-utils": "^22.0.0"


### PR DESCRIPTION
Bug fix: TS can't compile unless `@types/jest` is somehow hoisted by another package.

Since jest-extended uses the jest types on its d.ts file, which is packed on the tarball, it actually requires @types/jest as a production dependency, and not a dev-dependency.

