### PR TITLE
Add Node 12 to engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "jest-get-type": "^22.4.3",
     "jest-matcher-utils": "^22.0.0"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "lint-staged": {
     "*.js": [
       "yarn prettier",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jest-matcher-utils": "^22.0.0"
   },
   "engines": {
-    "node": ">=12"
+    "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What

Document library is targetting Node 12 and newer using `engines`.

<!-- Why are these changes necessary? Link any related issues -->
### Why

Since GH Actions only test Node 12 and above, and we're talking about 12 and above for Babel settings, we should explicitly document this was our target.
