### PR TITLE
Make Jest dependencies peer dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,6 @@ Head over to [here](https://hacktoberfest.digitalocean.com/sign_up/register) to 
   - `index.test.js` - Test suite that uses the new matcher and make sure it passes.
   - `predicate.js` - The function that tests the actual value meets the expected value / behavior.
   - `predicate.test.js` - Tests for the predicate both true/false cases must be covered.
-- [`jest-matchers-utils`](https://github.com/facebook/jest/tree/master/packages/jest-matcher-utils) is being used for syntax highlighting of error messages.
-  - See the Jest docs for an [example usage](https://facebook.github.io/jest/docs/en/expect.html#thisutils)
-- Jest's [`expect`](https://github.com/facebook/jest/tree/master/packages/expect) package is being used to access their deep `equals` function.
-  - `import { equals } from 'expect/build/jasmineUtils';`
 - Docs for the new matcher should be updated in the API section of the `README.md` to no longer say `Unimplemented`.
 - Type definitions for the new matchers should be added to `types/index.d.ts`.
 

--- a/package.json
+++ b/package.json
@@ -54,10 +54,8 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "expect": "^26.6.2",
     "jest-diff": "^27.2.5",
-    "jest-get-type": "^27.0.6",
-    "jest-matcher-utils": "^27.2.4"
+    "jest-get-type": "^27.0.6"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -60,6 +60,14 @@
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
   },
+  "peerDependencies": {
+    "@types/jest": ">= 22.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/jest": {
+      "optional": true
+    }
+  },
   "lint-staged": {
     "*.js": "eslint --fix",
     "*.md": "prettier --write"

--- a/src/matchers/toBeAfter/index.js
+++ b/src/matchers/toBeAfter/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (received, after) => () =>
-  matcherHint('.not.toBeAfter', 'received', '') +
+const passMessage = (utils, received, after) => () =>
+  utils.matcherHint('.not.toBeAfter', 'received', '') +
   '\n\n' +
-  `Expected date to be after ${printReceived(after)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be after ${utils.printReceived(after)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = (received, after) => () =>
-  matcherHint('.toBeAfter', 'received', '') +
+const failMessage = (utils, received, after) => () =>
+  utils.matcherHint('.toBeAfter', 'received', '') +
   '\n\n' +
-  `Expected date to be after ${printReceived(after)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be after ${utils.printReceived(after)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
 export function toBeAfter(date, after) {
   const pass = predicate(date, after);
   if (pass) {
-    return { pass: true, message: passMessage(date, after) };
+    return { pass: true, message: passMessage(this.utils, date, after) };
   }
 
-  return { pass: false, message: failMessage(date, after) };
+  return { pass: false, message: failMessage(this.utils, date, after) };
 }

--- a/src/matchers/toBeAfterOrEqualTo/index.js
+++ b/src/matchers/toBeAfterOrEqualTo/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (received, before) => () =>
-  matcherHint('.not.toBeAfterOrEqualTo', 'received', '') +
+const passMessage = (utils, received, before) => () =>
+  utils.matcherHint('.not.toBeAfterOrEqualTo', 'received', '') +
   '\n\n' +
-  `Expected date to be after or equal to ${printReceived(before)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be after or equal to ${utils.printReceived(before)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = (received, before) => () =>
-  matcherHint('.toBeAfterOrEqualTo', 'received', '') +
+const failMessage = (utils, received, before) => () =>
+  utils.matcherHint('.toBeAfterOrEqualTo', 'received', '') +
   '\n\n' +
-  `Expected date to be after or equal to ${printReceived(before)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be after or equal to ${utils.printReceived(before)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
 export function toBeAfterOrEqualTo(date, after) {
   const pass = predicate(date, after);
   if (pass) {
-    return { pass: true, message: passMessage(date, after) };
+    return { pass: true, message: passMessage(this.utils, date, after) };
   }
 
-  return { pass: false, message: failMessage(date, after) };
+  return { pass: false, message: failMessage(this.utils, date, after) };
 }

--- a/src/matchers/toBeArray/index.js
+++ b/src/matchers/toBeArray/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeArray', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeArray', 'received', '') +
   '\n\n' +
   'Expected value to not be an array received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeArray', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeArray', 'received', '') +
   '\n\n' +
   'Expected value to be an array received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeArray(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeArrayOfSize/index.js
+++ b/src/matchers/toBeArrayOfSize/index.js
@@ -1,31 +1,30 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import { determinePropertyMessage } from '../../utils';
 
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  `${matcherHint('.not.toBeArrayOfSize')}
+const passMessage = (utils, actual, expected) => () =>
+  `${utils.matcherHint('.not.toBeArrayOfSize')}
 
 Expected value to not be an array of size:
-  ${printExpected(expected)}
+  ${utils.printExpected(expected)}
 Received:
-  value: ${printReceived(actual)}
-  length: ${printReceived(determinePropertyMessage(actual, 'length'))}`;
+  value: ${utils.printReceived(actual)}
+  length: ${utils.printReceived(determinePropertyMessage(actual, 'length'))}`;
 
-const failMessage = (actual, expected) => () =>
-  `${matcherHint('.toBeArrayOfSize')}
+const failMessage = (utils, actual, expected) => () =>
+  `${utils.matcherHint('.toBeArrayOfSize')}
 
 Expected value to be an array of size:
-  ${printExpected(expected)}
+  ${utils.printExpected(expected)}
 Received:
-  value: ${printReceived(actual)}
-  length: ${printReceived(determinePropertyMessage(actual, 'length'))}`;
+  value: ${utils.printReceived(actual)}
+  length: ${utils.printReceived(determinePropertyMessage(actual, 'length'))}`;
 
 export function toBeArrayOfSize(actual, expected) {
   const pass = predicate(actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toBeBefore/index.js
+++ b/src/matchers/toBeBefore/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (received, before) => () =>
-  matcherHint('.not.toBeBefore', 'received', '') +
+const passMessage = (utils, received, before) => () =>
+  utils.matcherHint('.not.toBeBefore', 'received', '') +
   '\n\n' +
-  `Expected date to be before ${printReceived(before)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be before ${utils.printReceived(before)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = (received, before) => () =>
-  matcherHint('.toBeBefore', 'received', '') +
+const failMessage = (utils, received, before) => () =>
+  utils.matcherHint('.toBeBefore', 'received', '') +
   '\n\n' +
-  `Expected date to be before ${printReceived(before)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be before ${utils.printReceived(before)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
 export function toBeBefore(date, before) {
   const pass = predicate(date, before);
   if (pass) {
-    return { pass: true, message: passMessage(date, before) };
+    return { pass: true, message: passMessage(this.utils, date, before) };
   }
 
-  return { pass: false, message: failMessage(date, before) };
+  return { pass: false, message: failMessage(this.utils, date, before) };
 }

--- a/src/matchers/toBeBeforeOrEqualTo/index.js
+++ b/src/matchers/toBeBeforeOrEqualTo/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (received, before) => () =>
-  matcherHint('.not.toBeBeforeOrEqualTo', 'received', '') +
+const passMessage = (utils, received, before) => () =>
+  utils.matcherHint('.not.toBeBeforeOrEqualTo', 'received', '') +
   '\n\n' +
-  `Expected date to be before or equal to ${printReceived(before)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be before or equal to ${utils.printReceived(before)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = (received, before) => () =>
-  matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
+const failMessage = (utils, received, before) => () =>
+  utils.matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
   '\n\n' +
-  `Expected date to be before or equal to ${printReceived(before)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be before or equal to ${utils.printReceived(before)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
 export function toBeBeforeOrEqualTo(date, before) {
   const pass = predicate(date, before);
   if (pass) {
-    return { pass: true, message: passMessage(date, before) };
+    return { pass: true, message: passMessage(this.utils, date, before) };
   }
 
-  return { pass: false, message: failMessage(date, before) };
+  return { pass: false, message: failMessage(this.utils, date, before) };
 }

--- a/src/matchers/toBeBetween/index.js
+++ b/src/matchers/toBeBetween/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (received, startDate, endDate) => () =>
-  matcherHint('.not.toBeBetween', 'received', '') +
+const passMessage = (utils, received, startDate, endDate) => () =>
+  utils.matcherHint('.not.toBeBetween', 'received', '') +
   '\n\n' +
-  `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be between ${utils.printReceived(startDate)} and ${utils.printReceived(endDate)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = (received, startDate, endDate) => () =>
-  matcherHint('.toBeBetween', 'received', '') +
+const failMessage = (utils, received, startDate, endDate) => () =>
+  utils.matcherHint('.toBeBetween', 'received', '') +
   '\n\n' +
-  `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
-  `  ${printReceived(received)}`;
+  `Expected date to be between ${utils.printReceived(startDate)} and ${utils.printReceived(endDate)} but received:\n` +
+  `  ${utils.printReceived(received)}`;
 
 export function toBeBetween(date, startDate, endDate) {
   const pass = predicate(date, startDate, endDate);
   if (pass) {
-    return { pass: true, message: passMessage(date, startDate, endDate) };
+    return { pass: true, message: passMessage(this.utils, date, startDate, endDate) };
   }
 
-  return { pass: false, message: failMessage(date, startDate, endDate) };
+  return { pass: false, message: failMessage(this.utils, date, startDate, endDate) };
 }

--- a/src/matchers/toBeBoolean/index.js
+++ b/src/matchers/toBeBoolean/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeBoolean', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeBoolean', 'received', '') +
   '\n\n' +
   'Expected value to not be of type boolean, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeBoolean', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeBoolean', 'received', '') +
   '\n\n' +
   'Expected value to be of type boolean, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeBoolean(received) {
   const pass = predicate(received);
   if (pass) {
-    return { pass: true, message: passMessage(received) };
+    return { pass: true, message: passMessage(this.utils, received) };
   }
 
-  return { pass: false, message: failMessage(received) };
+  return { pass: false, message: failMessage(this.utils, received) };
 }

--- a/src/matchers/toBeDate/index.js
+++ b/src/matchers/toBeDate/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeDate', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeDate', 'received', '') +
   '\n\n' +
   'Expected value to not be a date received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeDate', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeDate', 'received', '') +
   '\n\n' +
   'Expected value to be a date received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeDate(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeDateString/index.js
+++ b/src/matchers/toBeDateString/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeDateString', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeDateString', 'received', '') +
   '\n\n' +
   'Expected value to not be a date string received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeDateString', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeDateString', 'received', '') +
   '\n\n' +
   'Expected value to be a date string received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeDateString(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeEmpty/index.js
+++ b/src/matchers/toBeEmpty/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeEmpty', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeEmpty', 'received', '') +
   '\n\n' +
   'Expected value to not be empty received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeEmpty', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeEmpty', 'received', '') +
   '\n\n' +
   'Expected value to be empty received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeEmpty(expected) {
-  const pass = predicate(expected);
+  const pass = predicate(this.equals, expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeEmpty/predicate.js
+++ b/src/matchers/toBeEmpty/predicate.js
@@ -1,5 +1,3 @@
-import { equals } from '../../utils';
-
 const isEmptyIterable = value => {
   if (typeof value[Symbol.iterator] !== 'function') {
     return false;
@@ -8,4 +6,4 @@ const isEmptyIterable = value => {
   return firstIteration.done;
 };
 
-export default value => equals({}, value) || isEmptyIterable(value);
+export default (equals, value) => equals({}, value) || isEmptyIterable(value);

--- a/src/matchers/toBeEmpty/predicate.test.js
+++ b/src/matchers/toBeEmpty/predicate.test.js
@@ -1,65 +1,66 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toBeEmpty Predicate', () => {
   describe('returns true', () => {
     test('When empty string is passed', () => {
-      expect(predicate('')).toBe(true);
+      expect(predicate(equals, '')).toBe(true);
     });
 
     test('When empty string object is passed', () => {
-      expect(predicate(new String(''))).toBe(true);
+      expect(predicate(equals, new String(''))).toBe(true);
     });
 
     test('When empty array is passed', () => {
-      expect(predicate([])).toBe(true);
+      expect(predicate(equals, [])).toBe(true);
     });
 
     test('When empty object is passed', () => {
-      expect(predicate({})).toBe(true);
+      expect(predicate(equals, {})).toBe(true);
     });
 
     test('When empty Set is passed', () => {
-      expect(predicate(new Set())).toBe(true);
+      expect(predicate(equals, new Set())).toBe(true);
     });
 
     test('When empty Map is passed', () => {
-      expect(predicate(new Map([]))).toBe(true);
+      expect(predicate(equals, new Map([]))).toBe(true);
     });
 
     test('When empty generator is passed', () => {
       function* yieldsNothing() {}
 
-      expect(predicate(yieldsNothing())).toBe(true);
+      expect(predicate(equals, yieldsNothing())).toBe(true);
     });
   });
 
   describe('return false', () => {
     test('When array with members is passed', () => {
-      expect(predicate(['1'])).toBe(false);
+      expect(predicate(equals, ['1'])).toBe(false);
     });
 
     test('When non-empty string is passed', () => {
-      expect(predicate('string')).toBe(false);
+      expect(predicate(equals, 'string')).toBe(false);
     });
 
     test('When blank string is passed', () => {
-      expect(predicate(' ')).toBe(false);
+      expect(predicate(equals, ' ')).toBe(false);
     });
 
     test('When non-empty string object is passed', () => {
-      expect(predicate(new String('string'))).toBe(false);
+      expect(predicate(equals, new String('string'))).toBe(false);
     });
 
     test('When object with members is passed', () => {
-      expect(predicate({ foo: 'bar' })).toBe(false);
+      expect(predicate(equals, { foo: 'bar' })).toBe(false);
     });
 
     test('When non-empty Set is passed', () => {
-      expect(predicate(new Set(['']))).toBe(false);
+      expect(predicate(equals, new Set(['']))).toBe(false);
     });
 
     test('When non-empty Map is passed', () => {
-      expect(predicate(new Map([['k', 'v']]))).toBe(false);
+      expect(predicate(equals, new Map([['k', 'v']]))).toBe(false);
     });
 
     test('When non-empty generator is passed', () => {
@@ -67,7 +68,7 @@ describe('toBeEmpty Predicate', () => {
         yield 'a thing';
       }
 
-      expect(predicate(yieldsSomething())).toBe(false);
+      expect(predicate(equals, yieldsSomething())).toBe(false);
     });
   });
 });

--- a/src/matchers/toBeEmptyObject/index.js
+++ b/src/matchers/toBeEmptyObject/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeEmptyObject', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeEmptyObject', 'received', '') +
   '\n\n' +
   'Expected value to not be an empty object, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeEmptyObject', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeEmptyObject', 'received', '') +
   '\n\n' +
   'Expected value to be an empty object, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeEmptyObject(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeEven/index.js
+++ b/src/matchers/toBeEven/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeEven', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeEven', 'received', '') +
   '\n\n' +
   'Expected value to not be an even number received:\n' +
-  ` ${printReceived(received)}`;
+  ` ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeEven', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeEven', 'received', '') +
   '\n\n' +
   'Expected value to be an even number received:\n' +
-  ` ${printReceived(received)}`;
+  ` ${utils.printReceived(received)}`;
 
 export function toBeEven(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeExtensible/index.js
+++ b/src/matchers/toBeExtensible/index.js
@@ -1,22 +1,20 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () => {
+const passMessage = (utils, received) => () => {
   return (
-    matcherHint('.not.toBeExtensible', 'received', '') +
+    utils.matcherHint('.not.toBeExtensible', 'received', '') +
     '\n\n' +
     'Expected value to not be extensible received:\n' +
-    `  ${printExpected(received)}\n`
+    `  ${utils.printExpected(received)}\n`
   );
 };
 
-const failMessage = received => () => {
+const failMessage = (utils, received) => () => {
   return (
-    matcherHint('.toBeExtensible', 'received', '') +
+    utils.matcherHint('.toBeExtensible', 'received', '') +
     '\n\n' +
     'Expected value to be extensible received:\n' +
-    `  ${printReceived(received)}`
+    `  ${utils.printReceived(received)}`
   );
 };
 
@@ -24,6 +22,6 @@ export function toBeExtensible(expected) {
   const pass = predicate(expected);
   return {
     pass,
-    message: pass ? passMessage(expected) : failMessage(expected),
+    message: pass ? passMessage(this.utils, expected) : failMessage(this.utils, expected),
   };
 }

--- a/src/matchers/toBeFalse/index.js
+++ b/src/matchers/toBeFalse/index.js
@@ -1,26 +1,24 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeFalse', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeFalse', 'received', '') +
   '\n\n' +
   'Expected value to not be false received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeFalse', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeFalse', 'received', '') +
   '\n\n' +
   'Expected value to be false:\n' +
-  `  ${printExpected(false)}\n` +
+  `  ${utils.printExpected(false)}\n` +
   'Received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeFalse(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeFinite/index.js
+++ b/src/matchers/toBeFinite/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeFinite', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeFinite', 'received', '') +
   '\n\n' +
   'Expected value to not be finite received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeFinite', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeFinite', 'received', '') +
   '\n\n' +
   'Expected value to be finite received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeFinite(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeFrozen/index.js
+++ b/src/matchers/toBeFrozen/index.js
@@ -1,16 +1,16 @@
-import { matcherHint } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = () => matcherHint('.not.toBeFrozen', 'received', '') + '\n\n' + 'Expected object to not be frozen';
+const passMessage = utils => () =>
+  utils.matcherHint('.not.toBeFrozen', 'received', '') + '\n\n' + 'Expected object to not be frozen';
 
-const failMessage = () => matcherHint('.toBeFrozen', 'received', '') + '\n\n' + 'Expected object to be frozen';
+const failMessage = utils => () =>
+  utils.matcherHint('.toBeFrozen', 'received', '') + '\n\n' + 'Expected object to be frozen';
 
 export function toBeFrozen(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage };
+    return { pass: true, message: passMessage(this.utils) };
   }
 
-  return { pass: false, message: failMessage };
+  return { pass: false, message: failMessage(this.utils) };
 }

--- a/src/matchers/toBeFunction/index.js
+++ b/src/matchers/toBeFunction/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeFunction', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeFunction', 'received', '') +
   '\n\n' +
   'Expected value to not be a function, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeFunction', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeFunction', 'received', '') +
   '\n\n' +
   'Expected to receive a function, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeFunction(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeHexadecimal/index.js
+++ b/src/matchers/toBeHexadecimal/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeHexadecimal', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeHexadecimal', 'received', '') +
   '\n\n' +
   'Expected value to not be a hexadecimal, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeHexadecimal', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeHexadecimal', 'received', '') +
   '\n\n' +
   'Expected value to be a hexadecimal, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeHexadecimal(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeInteger/index.js
+++ b/src/matchers/toBeInteger/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeInteger', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeInteger', 'received', '') +
   '\n\n' +
   'Expected value to not be an integer received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeInteger', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeInteger', 'received', '') +
   '\n\n' +
   'Expected value to be an integer received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeInteger(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeNaN/index.js
+++ b/src/matchers/toBeNaN/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeNaN', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeNaN', 'received', '') +
   '\n\n' +
   'Expected value to be a number received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeNaN', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeNaN', 'received', '') +
   '\n\n' +
   'Expected value to not be a number received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeNaN(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeNegative/index.js
+++ b/src/matchers/toBeNegative/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeNegative', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeNegative', 'received', '') +
   '\n\n' +
   'Expected value to not be a negative number received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeNegative', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeNegative', 'received', '') +
   '\n\n' +
   'Expected value to be a negative number received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeNegative(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeNil/index.js
+++ b/src/matchers/toBeNil/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeNil', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeNil', 'received', '') +
   '\n\n' +
   'Expected value not to be null or undefined, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeNil', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeNil', 'received', '') +
   '\n\n' +
   'Expected value to be null or undefined, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeNil(received) {
   const pass = predicate(received);
   if (pass) {
-    return { pass: true, message: passMessage(received) };
+    return { pass: true, message: passMessage(this.utils, received) };
   }
 
-  return { pass: false, message: failMessage(received) };
+  return { pass: false, message: failMessage(this.utils, received) };
 }

--- a/src/matchers/toBeNumber/index.js
+++ b/src/matchers/toBeNumber/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeNumber', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeNumber', 'received', '') +
   '\n\n' +
   'Expected value to not be a number received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeNumber', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeNumber', 'received', '') +
   '\n\n' +
   'Expected value to be a number received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeNumber(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeObject/index.js
+++ b/src/matchers/toBeObject/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeObject', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeObject', 'received', '') +
   '\n\n' +
   'Expected value to not be an object, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeObject', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeObject', 'received', '') +
   '\n\n' +
   'Expected value to be an object, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeObject(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeOdd/index.js
+++ b/src/matchers/toBeOdd/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeOdd', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeOdd', 'received', '') +
   '\n\n' +
   'Expected value to not be odd received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeOdd', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeOdd', 'received', '') +
   '\n\n' +
   'Expected value to be odd received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeOdd(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeOneOf/index.js
+++ b/src/matchers/toBeOneOf/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (item, list) => () =>
-  matcherHint('.not.toBeOneOf', 'item', 'list') +
+const passMessage = (utils, item, list) => () =>
+  utils.matcherHint('.not.toBeOneOf', 'item', 'list') +
   '\n\n' +
   'Expected value to not be in list:\n' +
-  `  ${printExpected(list)}\n` +
+  `  ${utils.printExpected(list)}\n` +
   'Received:\n' +
-  `  ${printReceived(item)}`;
+  `  ${utils.printReceived(item)}`;
 
-const failMessage = (item, list) => () =>
-  matcherHint('.toBeOneOf', 'item', 'list') +
+const failMessage = (utils, item, list) => () =>
+  utils.matcherHint('.toBeOneOf', 'item', 'list') +
   '\n\n' +
   'Expected value to be in list:\n' +
-  `  ${printExpected(list)}\n` +
+  `  ${utils.printExpected(list)}\n` +
   'Received:\n' +
-  `  ${printReceived(item)}`;
+  `  ${utils.printReceived(item)}`;
 
 export function toBeOneOf(item, list) {
-  const pass = predicate(item, list);
+  const pass = predicate(this.equals, item, list);
   if (pass) {
-    return { pass: true, message: passMessage(item, list) };
+    return { pass: true, message: passMessage(this.utils, item, list) };
   }
 
-  return { pass: false, message: failMessage(item, list) };
+  return { pass: false, message: failMessage(this.utils, item, list) };
 }

--- a/src/matchers/toBeOneOf/predicate.js
+++ b/src/matchers/toBeOneOf/predicate.js
@@ -1,3 +1,3 @@
 import { contains } from '../../utils';
 
-export default (value, list) => contains(list, value);
+export default (equals, value, list) => contains(equals, list, value);

--- a/src/matchers/toBeOneOf/predicate.test.js
+++ b/src/matchers/toBeOneOf/predicate.test.js
@@ -1,21 +1,22 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('.toBeOneOf', () => {
   test.each([[1], [null], [undefined], [false], ['']])(
     'returns true when primitive value: %s is in given array',
     value => {
-      expect(predicate(value, [1, 2, 3, null, undefined, false, ''])).toBe(true);
+      expect(predicate(equals, value, [1, 2, 3, null, undefined, false, ''])).toBe(true);
     },
   );
 
   test.each([[{ hello: 'world' }], [['foo']]])('returns true when nested value: %s is in given array', value => {
-    expect(predicate(value, [1, 2, { hello: 'world' }, ['foo']])).toBe(true);
+    expect(predicate(equals, value, [1, 2, { hello: 'world' }, ['foo']])).toBe(true);
   });
 
   test.each([[0], [null], [undefined], [false], [''], [{ hello: 'world' }], [['foo']]])(
     'returns false when value: %s is not in given array',
     value => {
-      expect(predicate(value, [1, 2, 3])).toBe(false);
+      expect(predicate(equals, value, [1, 2, 3])).toBe(false);
     },
   );
 });

--- a/src/matchers/toBePositive/index.js
+++ b/src/matchers/toBePositive/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBePositive', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBePositive', 'received', '') +
   '\n\n' +
   'Expected value to not be positive received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBePositive', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBePositive', 'received', '') +
   '\n\n' +
   'Expected value to be positive received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBePositive(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeSealed/index.js
+++ b/src/matchers/toBeSealed/index.js
@@ -1,16 +1,16 @@
-import { matcherHint } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = () => () => matcherHint('.not.toBeSealed', 'received', '') + '\n\nExpected object to be not sealed';
+const passMessage = utils => () =>
+  utils.matcherHint('.not.toBeSealed', 'received', '') + '\n\nExpected object to be not sealed';
 
-const failMessage = () => () => matcherHint('.toBeSealed', 'received', '') + '\n\nExpected object to not sealed';
+const failMessage = utils => () =>
+  utils.matcherHint('.toBeSealed', 'received', '') + '\n\nExpected object to not sealed';
 
 export function toBeSealed(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage() };
+    return { pass: true, message: passMessage(this.utils) };
   }
 
-  return { pass: false, message: failMessage() };
+  return { pass: false, message: failMessage(this.utils) };
 }

--- a/src/matchers/toBeString/index.js
+++ b/src/matchers/toBeString/index.js
@@ -1,26 +1,24 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeString', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeString', 'received', '') +
   '\n\n' +
   'Expected value to not be of type string received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeString', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeString', 'received', '') +
   '\n\n' +
   'Expected value to be of type string:\n' +
-  `  ${printExpected('type of string')}\n` +
+  `  ${utils.printExpected('type of string')}\n` +
   'Received:\n' +
-  `  ${printReceived(typeof received)}`;
+  `  ${utils.printReceived(typeof received)}`;
 
 export function toBeString(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeSymbol/index.js
+++ b/src/matchers/toBeSymbol/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeSymbol', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeSymbol', 'received', '') +
   '\n\n' +
   'Expected value to not be a symbol, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeSymbol', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeSymbol', 'received', '') +
   '\n\n' +
   'Expected to receive a symbol, received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeSymbol(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeTrue/index.js
+++ b/src/matchers/toBeTrue/index.js
@@ -1,26 +1,24 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeTrue', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeTrue', 'received', '') +
   '\n\n' +
   'Expected value to not be true received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeTrue', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeTrue', 'received', '') +
   '\n\n' +
   'Expected value to be true:\n' +
-  `  ${printExpected(true)}\n` +
+  `  ${utils.printExpected(true)}\n` +
   'Received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeTrue(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeValidDate/index.js
+++ b/src/matchers/toBeValidDate/index.js
@@ -1,24 +1,22 @@
-import { matcherHint, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = received => () =>
-  matcherHint('.not.toBeValidDate', 'received', '') +
+const passMessage = (utils, received) => () =>
+  utils.matcherHint('.not.toBeValidDate', 'received', '') +
   '\n\n' +
   'Expected value to not be a valid date received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = received => () =>
-  matcherHint('.toBeValidDate', 'received', '') +
+const failMessage = (utils, received) => () =>
+  utils.matcherHint('.toBeValidDate', 'received', '') +
   '\n\n' +
   'Expected value to be a valid date received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toBeValidDate(expected) {
   const pass = predicate(expected);
   if (pass) {
-    return { pass: true, message: passMessage(expected) };
+    return { pass: true, message: passMessage(this.utils, expected) };
   }
 
-  return { pass: false, message: failMessage(expected) };
+  return { pass: false, message: failMessage(this.utils, expected) };
 }

--- a/src/matchers/toBeWithin/index.js
+++ b/src/matchers/toBeWithin/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (number, start, end) => () =>
-  matcherHint('.not.toBeWithin') +
+const passMessage = (utils, number, start, end) => () =>
+  utils.matcherHint('.not.toBeWithin') +
   '\n\n' +
   'Expected number to not be within start (inclusive) and end (exclusive):\n' +
-  `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+  `  start: ${utils.printExpected(start)}  end: ${utils.printExpected(end)}\n` +
   'Received:\n' +
-  `  ${printReceived(number)}`;
+  `  ${utils.printReceived(number)}`;
 
-const failMessage = (number, start, end) => () =>
-  matcherHint('.toBeWithin') +
+const failMessage = (utils, number, start, end) => () =>
+  utils.matcherHint('.toBeWithin') +
   '\n\n' +
   'Expected number to be within start (inclusive) and end (exclusive):\n' +
-  `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+  `  start: ${utils.printExpected(start)}  end: ${utils.printExpected(end)}\n` +
   'Received:\n' +
-  `  ${printReceived(number)}`;
+  `  ${utils.printReceived(number)}`;
 
 export function toBeWithin(number, start, end) {
   const pass = predicate(number, start, end);
   if (pass) {
-    return { pass: true, message: passMessage(number, start, end) };
+    return { pass: true, message: passMessage(this.utils, number, start, end) };
   }
 
-  return { pass: false, message: failMessage(number, start, end) };
+  return { pass: false, message: failMessage(this.utils, number, start, end) };
 }

--- a/src/matchers/toContainAllEntries/index.js
+++ b/src/matchers/toContainAllEntries/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainAllEntries') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainAllEntries') +
   '\n\n' +
   'Expected object to not only contain all of the given entries:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainAllEntries') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainAllEntries') +
   '\n\n' +
   'Expected object to only contain all of the given entries:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainAllEntries(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainAllEntries/predicate.js
+++ b/src/matchers/toContainAllEntries/predicate.js
@@ -1,9 +1,9 @@
 import toContainEntries from '../toContainEntries/predicate';
 
-export default (obj, entries) => {
+export default (equals, obj, entries) => {
   if (!obj.hasOwnProperty || entries.length != Object.keys(obj).length) {
     return false;
   }
 
-  return toContainEntries(obj, entries);
+  return toContainEntries(equals, obj, entries);
 };

--- a/src/matchers/toContainAllEntries/predicate.test.js
+++ b/src/matchers/toContainAllEntries/predicate.test.js
@@ -1,14 +1,15 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainAllEntries', () => {
   test('passes when given nested values', () => {
-    expect(predicate({ hello: { message: 'world' } }, [['hello', { message: 'world' }]])).toBe(true);
+    expect(predicate(equals, { hello: { message: 'world' } }, [['hello', { message: 'world' }]])).toBe(true);
   });
   test('passes when object only contains all of the given entries', () => {
     expect(
-      predicate(data, [
+      predicate(equals, data, [
         ['a', 'foo'],
         ['b', 'bar'],
         ['c', 'baz'],
@@ -18,7 +19,7 @@ describe('.toContainAllEntries', () => {
 
   test('fails when object does not only contain all of the given entries', () => {
     expect(
-      predicate(data, [
+      predicate(equals, data, [
         ['a', 'foo'],
         ['b', 'bar'],
       ]),
@@ -27,7 +28,7 @@ describe('.toContainAllEntries', () => {
 
   test('fails when object does not contain all of the given entries', () => {
     expect(
-      predicate(data, [
+      predicate(equals, data, [
         ['a', 'foo'],
         ['b', 'bar'],
         ['c', 'baz'],

--- a/src/matchers/toContainAllKeys/index.js
+++ b/src/matchers/toContainAllKeys/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainAllKeys') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainAllKeys') +
   '\n\n' +
   'Expected object to not contain all keys:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(Object.keys(actual))}`;
+  `  ${utils.printReceived(Object.keys(actual))}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainAllKeys') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainAllKeys') +
   '\n\n' +
   'Expected object to contain all keys:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(Object.keys(actual))}`;
+  `  ${utils.printReceived(Object.keys(actual))}`;
 
 export function toContainAllKeys(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainAllKeys/predicate.js
+++ b/src/matchers/toContainAllKeys/predicate.js
@@ -1,7 +1,7 @@
 import { contains } from '../../utils';
 
-export default (object, keys) => {
+export default (equals, object, keys) => {
   const objectKeys = Object.keys(object);
 
-  return objectKeys.length === keys.length && keys.every(key => contains(objectKeys, key));
+  return objectKeys.length === keys.length && keys.every(key => contains(equals, objectKeys, key));
 };

--- a/src/matchers/toContainAllKeys/predicate.test.js
+++ b/src/matchers/toContainAllKeys/predicate.test.js
@@ -1,25 +1,26 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 const data = { a: 'hello', b: 'world' };
 
 describe('.toContainAllKeys', () => {
   test('passes when given object contains all keys', () => {
-    expect(predicate(data, ['a', 'b'])).toBe(true);
+    expect(predicate(equals, data, ['a', 'b'])).toBe(true);
   });
 
   test('passes when given object contains all keys, regardless of order', () => {
-    expect(predicate(data, ['b', 'a'])).toBe(true);
+    expect(predicate(equals, data, ['b', 'a'])).toBe(true);
   });
 
   test('fails when given object does not contain all keys', () => {
-    expect(predicate(data, ['b'])).toBe(false);
+    expect(predicate(equals, data, ['b'])).toBe(false);
   });
 
   test('fails when given an empty object', () => {
-    expect(predicate({}, ['b'])).toBe(false);
+    expect(predicate(equals, {}, ['b'])).toBe(false);
   });
 
   test('fails when all of the object keys are matched, but there are additional keys ', () => {
-    expect(predicate(data, ['a', 'b', 'c'])).toBe(false);
+    expect(predicate(equals, data, ['a', 'b', 'c'])).toBe(false);
   });
 });

--- a/src/matchers/toContainAllValues/index.js
+++ b/src/matchers/toContainAllValues/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainAllValues') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainAllValues') +
   '\n\n' +
   'Expected object to not contain all values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainAllValues') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainAllValues') +
   '\n\n' +
   'Expected object to contain all values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainAllValues(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainAllValues/predicate.js
+++ b/src/matchers/toContainAllValues/predicate.js
@@ -1,6 +1,8 @@
 import { contains } from '../../utils';
 
-export default (object, values) => {
+export default (equals, object, values) => {
   const objectValues = Object.keys(object).map(k => object[k]);
-  return objectValues.length === values.length && objectValues.every(objectValue => contains(values, objectValue));
+  return (
+    objectValues.length === values.length && objectValues.every(objectValue => contains(equals, values, objectValue))
+  );
 };

--- a/src/matchers/toContainAllValues/predicate.test.js
+++ b/src/matchers/toContainAllValues/predicate.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toContainAllValues Predicate', () => {
@@ -17,33 +18,33 @@ describe('toContainAllValues Predicate', () => {
 
   describe('returns true', () => {
     test('when given object contains all primitive values', () => {
-      expect(predicate(shallow, ['world', false, 0])).toBe(true);
+      expect(predicate(equals, shallow, ['world', false, 0])).toBe(true);
     });
 
     test('when given object contains all values including objects', () => {
-      expect(predicate(deep, ['duck', { hello: 'world', foo: 0, bar: false }])).toBe(true);
+      expect(predicate(equals, deep, ['duck', { hello: 'world', foo: 0, bar: false }])).toBe(true);
     });
 
     test('when given object contains all values including arrays', () => {
-      expect(predicate(deepArray, ['duck', [{ hello: 'world', foo: 0, bar: false }]])).toBe(true);
+      expect(predicate(equals, deepArray, ['duck', [{ hello: 'world', foo: 0, bar: false }]])).toBe(true);
     });
   });
 
   describe('returns false', () => {
     test('returns false when object does not contain all values', () => {
       const o = { a: 'foo', b: 'bar', c: 'baz' };
-      expect(predicate(o, ['foo', 'bar', 'baz', 'qux'])).toBe(false);
+      expect(predicate(equals, o, ['foo', 'bar', 'baz', 'qux'])).toBe(false);
     });
     test('when given object does not contain all primitive value', () => {
-      expect(predicate(shallow, ['world', false])).toBe(false);
+      expect(predicate(equals, shallow, ['world', false])).toBe(false);
     });
 
     test('when given object does not contain all values including objects', () => {
-      expect(predicate(deep, ['made up value', 'duck', { hello: 'world', foo: 0 }])).toBe(false);
+      expect(predicate(equals, deep, ['made up value', 'duck', { hello: 'world', foo: 0 }])).toBe(false);
     });
 
     test('when given object does not contain all values including arrays', () => {
-      expect(predicate(deepArray, ['duck', 'made up value', [{ hello: 'world', foo: 0 }]])).toBe(false);
+      expect(predicate(equals, deepArray, ['duck', 'made up value', [{ hello: 'world', foo: 0 }]])).toBe(false);
     });
   });
 });

--- a/src/matchers/toContainAnyEntries/index.js
+++ b/src/matchers/toContainAnyEntries/index.js
@@ -1,27 +1,25 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (object, entries) => () =>
-  matcherHint('.not.toContainAnyEntries') +
+const passMessage = (utils, object, entries) => () =>
+  utils.matcherHint('.not.toContainAnyEntries') +
   '\n\n' +
   'Expected object to not contain any of the provided entries:\n' +
-  `  ${printExpected(entries)}\n` +
+  `  ${utils.printExpected(entries)}\n` +
   'Received:\n' +
-  `  ${printReceived(object)}`;
+  `  ${utils.printReceived(object)}`;
 
-const failMessage = (object, entries) => () =>
-  matcherHint('.toContainAnyEntries') +
+const failMessage = (utils, object, entries) => () =>
+  utils.matcherHint('.toContainAnyEntries') +
   '\n\n' +
   'Expected object to contain any of the provided entries:\n' +
-  `  ${printExpected(entries)}\n` +
+  `  ${utils.printExpected(entries)}\n` +
   'Received:\n' +
-  `  ${printReceived(object)}`;
+  `  ${utils.printReceived(object)}`;
 
 export function toContainAnyEntries(object, entries) {
-  const pass = predicate(object, entries);
+  const pass = predicate(this.equals, object, entries);
   if (pass) {
-    return { pass: true, message: passMessage(object, entries) };
+    return { pass: true, message: passMessage(this.utils, object, entries) };
   }
-  return { pass: false, message: failMessage(object, entries) };
+  return { pass: false, message: failMessage(this.utils, object, entries) };
 }

--- a/src/matchers/toContainAnyEntries/predicate.js
+++ b/src/matchers/toContainAnyEntries/predicate.js
@@ -1,6 +1,6 @@
 import { contains } from '../../utils';
 
-export default (object, entries) => {
+export default (equals, object, entries) => {
   const objectEntries = Object.keys(object).map(k => [k, object[k]]);
-  return entries.some(entry => contains(objectEntries, entry));
+  return entries.some(entry => contains(equals, objectEntries, entry));
 };

--- a/src/matchers/toContainAnyEntries/predicate.test.js
+++ b/src/matchers/toContainAnyEntries/predicate.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 const data = { a: 'foo', b: 'bar', c: 'baz' };
@@ -5,7 +6,7 @@ const data = { a: 'foo', b: 'bar', c: 'baz' };
 describe('.toContainAnyEntries', () => {
   test('passes when given object contains entries', () => {
     expect(
-      predicate(data, [
+      predicate(equals, data, [
         ['a', 'qux'],
         ['a', 'foo'],
         ['x', 'foo'],
@@ -15,7 +16,7 @@ describe('.toContainAnyEntries', () => {
 
   test('passes when given object contains entries with nested values', () => {
     expect(
-      predicate({ hello: { message: 'world' } }, [
+      predicate(equals, { hello: { message: 'world' } }, [
         ['hello', { message: 'world' }],
         ['a', 'foo'],
         ['x', 'foo'],
@@ -25,7 +26,7 @@ describe('.toContainAnyEntries', () => {
 
   test('fails when given object does not contain entries', () => {
     expect(
-      predicate(data, [
+      predicate(equals, data, [
         ['a', 'qux'],
         ['b', 'foo'],
         ['x', 'foo'],

--- a/src/matchers/toContainAnyKeys/index.js
+++ b/src/matchers/toContainAnyKeys/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainAnyKeys') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainAnyKeys') +
   '\n\n' +
   'Expected object not to contain any of the following keys:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainValue') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainValue') +
   '\n\n' +
   'Expected object to contain any of the following keys:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainAnyKeys(actual, expected) {
   const pass = predicate(actual, expected);
 
   return {
     pass: pass,
-    message: pass ? passMessage(actual, expected) : failMessage(actual, expected),
+    message: pass ? passMessage(this.utils, actual, expected) : failMessage(this.utils, actual, expected),
   };
 }

--- a/src/matchers/toContainAnyValues/index.js
+++ b/src/matchers/toContainAnyValues/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainAnyValues') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainAnyValues') +
   '\n\n' +
   'Expected object to not contain any of the following values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainAnyValues') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainAnyValues') +
   '\n\n' +
   'Expected object to contain any of the following values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainAnyValues(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainAnyValues/predicate.js
+++ b/src/matchers/toContainAnyValues/predicate.js
@@ -4,7 +4,7 @@ import { contains } from '../../utils';
  * @params {Object} object
  * @params {Array} values
  */
-export default (object, values) => {
+export default (equals, object, values) => {
   const objectValues = Object.keys(object).map(k => object[k]);
-  return values.some(value => contains(objectValues, value));
+  return values.some(value => contains(equals, objectValues, value));
 };

--- a/src/matchers/toContainAnyValues/predicate.test.js
+++ b/src/matchers/toContainAnyValues/predicate.test.js
@@ -1,17 +1,18 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('toContainAnyValues Predicate', () => {
   test('passes when object contains at least one of the given values ', () => {
-    expect(predicate(data, ['qux', 'foo'])).toBe(true);
-    expect(predicate(data, ['qux', 'bar'])).toBe(true);
-    expect(predicate(data, ['foo', 'bar'])).toBe(true);
-    expect(predicate(data, ['baz'])).toBe(true);
+    expect(predicate(equals, data, ['qux', 'foo'])).toBe(true);
+    expect(predicate(equals, data, ['qux', 'bar'])).toBe(true);
+    expect(predicate(equals, data, ['foo', 'bar'])).toBe(true);
+    expect(predicate(equals, data, ['baz'])).toBe(true);
   });
 
   test('fails when object does not contain any given values', () => {
-    expect(predicate(data, ['qux'])).toBe(false);
-    expect(predicate(data, ['qux', 'zoo'])).toBe(false);
+    expect(predicate(equals, data, ['qux'])).toBe(false);
+    expect(predicate(equals, data, ['qux', 'zoo'])).toBe(false);
   });
 });

--- a/src/matchers/toContainEntries/index.js
+++ b/src/matchers/toContainEntries/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainEntries') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainEntries') +
   '\n\n' +
   'Expected object to not contain all of the given entries:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainEntries') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainEntries') +
   '\n\n' +
   'Expected object to contain all of the given entries:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainEntries(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainEntries/predicate.js
+++ b/src/matchers/toContainEntries/predicate.js
@@ -1,3 +1,3 @@
 import toContainEntry from '../toContainEntry/predicate';
 
-export default (obj, entries) => entries.every(entry => toContainEntry(obj, entry));
+export default (equals, obj, entries) => entries.every(entry => toContainEntry(equals, obj, entry));

--- a/src/matchers/toContainEntries/predicate.test.js
+++ b/src/matchers/toContainEntries/predicate.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 const data = { a: 'foo', b: 'bar', c: 'baz' };
@@ -5,7 +6,7 @@ const data = { a: 'foo', b: 'bar', c: 'baz' };
 describe('.toContainEntries', () => {
   test('passes when object contains given entry', () => {
     expect(
-      predicate(data, [
+      predicate(equals, data, [
         ['c', 'baz'],
         ['a', 'foo'],
       ]),
@@ -13,12 +14,12 @@ describe('.toContainEntries', () => {
   });
 
   test('passes when given nested values', () => {
-    expect(predicate({ hello: { message: 'world' } }, [['hello', { message: 'world' }]])).toBe(true);
+    expect(predicate(equals, { hello: { message: 'world' } }, [['hello', { message: 'world' }]])).toBe(true);
   });
 
   test('fails when object does not contain given entry', () => {
     expect(
-      predicate(data, [
+      predicate(equals, data, [
         ['a', 'qux'],
         ['b', 'bar'],
       ]),

--- a/src/matchers/toContainEntry/index.js
+++ b/src/matchers/toContainEntry/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainEntry') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainEntry') +
   '\n\n' +
   'Expected object to not contain entry:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainEntry') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainEntry') +
   '\n\n' +
   'Expected object to contain entry:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainEntry(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainEntry/predicate.js
+++ b/src/matchers/toContainEntry/predicate.js
@@ -1,4 +1,2 @@
-import { equals } from '../../utils';
-
-export default (obj, [key, value]) =>
+export default (equals, obj, [key, value]) =>
   obj.hasOwnProperty && Object.prototype.hasOwnProperty.call(obj, key) && equals(obj[key], value);

--- a/src/matchers/toContainEntry/predicate.test.js
+++ b/src/matchers/toContainEntry/predicate.test.js
@@ -1,19 +1,20 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 const data = { a: 'foo', b: 'bar', c: 'baz' };
 
 describe('.toContainEntry', () => {
   test('passes when object contains given entry', () => {
-    expect(predicate(data, ['a', 'foo'])).toBe(true);
-    expect(predicate(data, ['b', 'bar'])).toBe(true);
-    expect(predicate(data, ['c', 'baz'])).toBe(true);
+    expect(predicate(equals, data, ['a', 'foo'])).toBe(true);
+    expect(predicate(equals, data, ['b', 'bar'])).toBe(true);
+    expect(predicate(equals, data, ['c', 'baz'])).toBe(true);
   });
 
   test('passes when object contain given entry with nested value', () => {
-    expect(predicate({ data }, ['data', data])).toBe(true);
+    expect(predicate(equals, { data }, ['data', data])).toBe(true);
   });
 
   test('fails when object does not contain given entry', () => {
-    expect(predicate(data, ['a', 'qux'])).toBe(false);
+    expect(predicate(equals, data, ['a', 'qux'])).toBe(false);
   });
 });

--- a/src/matchers/toContainKey/index.js
+++ b/src/matchers/toContainKey/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainKey') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainKey') +
   '\n\n' +
   'Expected object to not contain key:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainKey') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainKey') +
   '\n\n' +
   'Expected object to contain key:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainKey(actual, expected) {
   const pass = predicate(actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainKeys/index.js
+++ b/src/matchers/toContainKeys/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainKeys') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainKeys') +
   '\n\n' +
   'Expected object to not contain all keys:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainKeys') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainKeys') +
   '\n\n' +
   'Expected object to contain all keys:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainKeys(actual, expected) {
   const pass = predicate(actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainValue/index.js
+++ b/src/matchers/toContainValue/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainValue') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainValue') +
   '\n\n' +
   'Expected object to not contain value:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainValue') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainValue') +
   '\n\n' +
   'Expected object to contain value:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainValue(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainValue/predicate.js
+++ b/src/matchers/toContainValue/predicate.js
@@ -1,6 +1,6 @@
 import { contains } from '../../utils';
 
-export default (actual, value) => {
+export default (equals, actual, value) => {
   const objectValues = Object.keys(actual).map(k => actual[k]);
-  return contains(objectValues, value);
+  return contains(equals, objectValues, value);
 };

--- a/src/matchers/toContainValue/predicate.test.js
+++ b/src/matchers/toContainValue/predicate.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toContainValue Predicate', () => {
@@ -9,16 +10,16 @@ describe('toContainValue Predicate', () => {
     test.each([['world'], [false], [undefined], [null], [''], [0]])(
       'when given object contains primitive value: %s',
       value => {
-        expect(predicate(shallow, value)).toBe(true);
+        expect(predicate(equals, shallow, value)).toBe(true);
       },
     );
 
     test('when given object contains object value', () => {
-      expect(predicate(deep, { hello: 'world' })).toBe(true);
+      expect(predicate(equals, deep, { hello: 'world' })).toBe(true);
     });
 
     test('when given object contains array value', () => {
-      expect(predicate(deepArray, [{ hello: 'world' }])).toBe(true);
+      expect(predicate(equals, deepArray, [{ hello: 'world' }])).toBe(true);
     });
   });
 
@@ -26,16 +27,16 @@ describe('toContainValue Predicate', () => {
     test.each([['world'], [false], [undefined], [null], [''], [0]])(
       'when given object does not contain primitive value: %s',
       value => {
-        expect(predicate({}, value)).toBe(false);
+        expect(predicate(equals, {}, value)).toBe(false);
       },
     );
 
     test('when given object does not contain object value', () => {
-      expect(predicate(deep, { foo: 'bar' })).toBe(false);
+      expect(predicate(equals, deep, { foo: 'bar' })).toBe(false);
     });
 
     test('when given object does not contain array value', () => {
-      expect(predicate(deepArray, [{ bar: 'foo' }])).toBe(false);
+      expect(predicate(equals, deepArray, [{ bar: 'foo' }])).toBe(false);
     });
   });
 });

--- a/src/matchers/toContainValues/index.js
+++ b/src/matchers/toContainValues/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toContainValues') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toContainValues') +
   '\n\n' +
   'Expected object to not contain all values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toContainValues') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toContainValues') +
   '\n\n' +
   'Expected object to contain all values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toContainValues(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toContainValues/predicate.js
+++ b/src/matchers/toContainValues/predicate.js
@@ -1,6 +1,6 @@
 import { contains } from '../../utils';
 
-export default (object, values) => {
+export default (equals, object, values) => {
   const objectValues = Object.keys(object).map(k => object[k]);
-  return values.every(value => contains(objectValues, value));
+  return values.every(value => contains(equals, objectValues, value));
 };

--- a/src/matchers/toContainValues/predicate.test.js
+++ b/src/matchers/toContainValues/predicate.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toContainValue Predicate', () => {
@@ -17,29 +18,31 @@ describe('toContainValue Predicate', () => {
 
   describe('returns true', () => {
     test('when given object contains all primitive values', () => {
-      expect(predicate(shallow, ['world', false, 0])).toBe(true);
+      expect(predicate(equals, shallow, ['world', false, 0])).toBe(true);
     });
 
     test('when given object contains all values including objects', () => {
-      expect(predicate(deep, ['duck', { hello: 'world', foo: 0, bar: false }])).toBe(true);
+      expect(predicate(equals, deep, ['duck', { hello: 'world', foo: 0, bar: false }])).toBe(true);
     });
 
     test('when given object contains all values including arrays', () => {
-      expect(predicate(deepArray, ['duck', [{ hello: 'world', foo: 0, bar: false }]])).toBe(true);
+      expect(predicate(equals, deepArray, ['duck', [{ hello: 'world', foo: 0, bar: false }]])).toBe(true);
     });
   });
 
   describe('returns false', () => {
     test('when given object does not contain all primitive value', () => {
-      expect(predicate(shallow, [false, undefined])).toBe(false);
+      expect(predicate(equals, shallow, [false, undefined])).toBe(false);
     });
 
     test('when given object does not contain all values including objects', () => {
-      expect(predicate(deep, ['made up value', 'duck', { hello: 'world', foo: 0, bar: false }])).toBe(false);
+      expect(predicate(equals, deep, ['made up value', 'duck', { hello: 'world', foo: 0, bar: false }])).toBe(false);
     });
 
     test('when given object does not contain all values including arrays', () => {
-      expect(predicate(deepArray, ['duck', 'made up value', [{ hello: 'world', foo: 0, bar: false }]])).toBe(false);
+      expect(predicate(equals, deepArray, ['duck', 'made up value', [{ hello: 'world', foo: 0, bar: false }]])).toBe(
+        false,
+      );
     });
   });
 });

--- a/src/matchers/toEndWith/index.js
+++ b/src/matchers/toEndWith/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (suffix, string) => () =>
-  matcherHint('.not.toEndWith') +
+const passMessage = (utils, suffix, string) => () =>
+  utils.matcherHint('.not.toEndWith') +
   '\n\n' +
   'Expected string to not end with:\n' +
-  `  ${printExpected(suffix)}\n` +
+  `  ${utils.printExpected(suffix)}\n` +
   'Received:\n' +
-  `  ${printReceived(string)}`;
+  `  ${utils.printReceived(string)}`;
 
-const failMessage = (suffix, string) => () =>
-  matcherHint('.toEndWith') +
+const failMessage = (utils, suffix, string) => () =>
+  utils.matcherHint('.toEndWith') +
   '\n\n' +
   'Expected string to end with:\n' +
-  `  ${printExpected(suffix)}\n` +
+  `  ${utils.printExpected(suffix)}\n` +
   'Received:\n' +
-  `  ${printReceived(string)}`;
+  `  ${utils.printReceived(string)}`;
 
 export function toEndWith(string, suffix) {
   const pass = predicate(suffix, string);
   if (pass) {
-    return { pass: true, message: passMessage(suffix, string) };
+    return { pass: true, message: passMessage(this.utils, suffix, string) };
   }
 
-  return { pass: false, message: failMessage(suffix, string) };
+  return { pass: false, message: failMessage(this.utils, suffix, string) };
 }

--- a/src/matchers/toEqualCaseInsensitive/index.js
+++ b/src/matchers/toEqualCaseInsensitive/index.js
@@ -1,25 +1,24 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import predicate from './predicate';
 
-const passMessage = (received, expected) => () => {
+const passMessage = (utils, received, expected) => () => {
   return (
-    matcherHint('.not.toEqualCaseInsensitive') +
+    utils.matcherHint('.not.toEqualCaseInsensitive') +
     '\n\n' +
     'Expected values to not be equal while ignoring case (using ===):\n' +
-    `  ${printExpected(expected)}\n` +
+    `  ${utils.printExpected(expected)}\n` +
     'Received:\n' +
-    `  ${printReceived(received)}`
+    `  ${utils.printReceived(received)}`
   );
 };
 
-const failMessage = (received, expected) => () => {
+const failMessage = (utils, received, expected) => () => {
   return (
-    matcherHint('.toEqualCaseInsensitive') +
+    utils.matcherHint('.toEqualCaseInsensitive') +
     '\n\n' +
     'Expected values to be equal while ignoring case (using ===):\n' +
-    `  ${printExpected(expected)}\n` +
+    `  ${utils.printExpected(expected)}\n` +
     'Received:\n' +
-    `  ${printReceived(received)}`
+    `  ${utils.printReceived(received)}`
   );
 };
 
@@ -28,7 +27,7 @@ export function toEqualCaseInsensitive(received, expected) {
 
   return {
     pass,
-    message: pass ? passMessage(received, expected) : failMessage(received, expected),
+    message: pass ? passMessage(this.utils, received, expected) : failMessage(this.utils, received, expected),
     actual: received,
   };
 }

--- a/src/matchers/toEqualIgnoringWhitespace/index.js
+++ b/src/matchers/toEqualIgnoringWhitespace/index.js
@@ -1,26 +1,25 @@
-import { EXPECTED_COLOR, matcherHint } from 'jest-matcher-utils';
 import predicate from './predicate';
 import { printExpected, printReceived } from './print-util';
 
-const passMessage = expected => () =>
-  matcherHint('.not.toEqualIgnoringWhitespace') +
+const passMessage = (utils, expected) => () =>
+  utils.matcherHint('.not.toEqualIgnoringWhitespace') +
   '\n\n' +
   'Expected values to not be equal while ignoring white-space (using ===):\n' +
-  `Expected: not  ${EXPECTED_COLOR(expected)}\n\n`;
+  `Expected: not  ${utils.EXPECTED_COLOR(expected)}\n\n`;
 
-const failMessage = diff => () =>
-  matcherHint('.toEqualIgnoringWhitespace') +
+const failMessage = (utils, diff) => () =>
+  utils.matcherHint('.toEqualIgnoringWhitespace') +
   '\n\n' +
   'Expected values to be equal while ignoring white-space (using ===):\n' +
-  `Expected:\n  ${printExpected(diff)}\n\n` +
-  `Received:\n  ${printReceived(diff)}`;
+  `Expected:\n  ${printExpected(utils, diff)}\n\n` +
+  `Received:\n  ${printReceived(utils, diff)}`;
 
 export function toEqualIgnoringWhitespace(received, expected) {
   const { pass, diff } = predicate(received, expected);
 
   return {
     pass: pass,
-    message: pass ? passMessage(expected) : failMessage(diff),
+    message: pass ? passMessage(this.utils, expected) : failMessage(this.utils, diff),
     actual: received,
   };
 }

--- a/src/matchers/toEqualIgnoringWhitespace/print-util.js
+++ b/src/matchers/toEqualIgnoringWhitespace/print-util.js
@@ -1,5 +1,4 @@
 import { DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT } from 'jest-diff';
-import { EXPECTED_COLOR, INVERTED_COLOR, RECEIVED_COLOR } from 'jest-matcher-utils';
 
 export const tokenize = str => {
   const isWhitespace = char => /\s/.test(char);
@@ -40,22 +39,24 @@ const colorTokens = (str, color) => {
   return tokens.reduce((acc, { value, isWhitespace }) => acc + (isWhitespace ? value : color(value)), '');
 };
 
-export const printExpected = diff =>
+export const printExpected = (utils, diff) =>
   diff.reduce((acc, diffObject) => {
     const operation = diffObject[0];
     const value = diffObject[1];
 
-    if (operation === DIFF_EQUAL) return acc + colorTokens(value, EXPECTED_COLOR);
-    if (operation === DIFF_DELETE) return acc + colorTokens(value, str => INVERTED_COLOR(EXPECTED_COLOR(str)));
+    if (operation === DIFF_EQUAL) return acc + colorTokens(value, utils.EXPECTED_COLOR);
+    if (operation === DIFF_DELETE)
+      return acc + colorTokens(value, str => utils.INVERTED_COLOR(utils.EXPECTED_COLOR(str)));
     return acc;
   }, '');
 
-export const printReceived = diff =>
+export const printReceived = (utils, diff) =>
   diff.reduce((acc, diffObject) => {
     const operation = diffObject[0];
     const value = diffObject[1];
 
-    if (operation === DIFF_EQUAL) return acc + colorTokens(value, RECEIVED_COLOR);
-    if (operation === DIFF_INSERT) return acc + colorTokens(value, str => INVERTED_COLOR(RECEIVED_COLOR(str)));
+    if (operation === DIFF_EQUAL) return acc + colorTokens(value, utils.RECEIVED_COLOR);
+    if (operation === DIFF_INSERT)
+      return acc + colorTokens(value, str => utils.INVERTED_COLOR(utils.RECEIVED_COLOR(str)));
     return acc;
   }, '');

--- a/src/matchers/toHaveBeenCalledAfter/index.js
+++ b/src/matchers/toHaveBeenCalledAfter/index.js
@@ -1,53 +1,51 @@
-import { matcherHint, printExpected, printReceived, printWithType } from 'jest-matcher-utils';
-
 import { isJestMockOrSpy } from '../../utils';
 
 import predicate from './predicate';
 
-const passMessage = (firstInvocationCallOrder, secondInvocationCallOrder) => () =>
-  matcherHint('.not.toHaveBeenCalledAfter') +
+const passMessage = (utils, firstInvocationCallOrder, secondInvocationCallOrder) => () =>
+  utils.matcherHint('.not.toHaveBeenCalledAfter') +
   '\n\n' +
   'Expected first mock to not have been called after, invocationCallOrder:\n' +
-  `  ${printExpected(firstInvocationCallOrder)}\n` +
+  `  ${utils.printExpected(firstInvocationCallOrder)}\n` +
   'Received second mock with invocationCallOrder:\n' +
-  `  ${printReceived(secondInvocationCallOrder)}`;
+  `  ${utils.printReceived(secondInvocationCallOrder)}`;
 
-const failMessage = (firstInvocationCallOrder, secondInvocationCallOrder) => () =>
-  matcherHint('.toHaveBeenCalledAfter') +
+const failMessage = (utils, firstInvocationCallOrder, secondInvocationCallOrder) => () =>
+  utils.matcherHint('.toHaveBeenCalledAfter') +
   '\n\n' +
   'Expected first mock to have been called after, invocationCallOrder:\n' +
-  `  ${printExpected(firstInvocationCallOrder)}\n` +
+  `  ${utils.printExpected(firstInvocationCallOrder)}\n` +
   'Received second mock with invocationCallOrder:\n' +
-  `  ${printReceived(secondInvocationCallOrder)}`;
+  `  ${utils.printReceived(secondInvocationCallOrder)}`;
 
-const mockCheckFailMessage = (value, isReceivedValue) => () => {
+const mockCheckFailMessage = (utils, value, isReceivedValue) => () => {
   const valueKind = isReceivedValue ? 'Received' : 'Expected';
-  const valueKindPrintFunc = isReceivedValue ? printReceived : printExpected;
+  const valueKindPrintFunc = isReceivedValue ? utils.printReceived : utils.printExpected;
 
   return (
-    matcherHint('.toHaveBeenCalledAfter') +
+    utils.matcherHint('.toHaveBeenCalledAfter') +
     '\n\n' +
     `Matcher error: ${valueKindPrintFunc(valueKind.toLowerCase())} must be a mock or spy function` +
     '\n\n' +
-    printWithType(valueKind, value, valueKindPrintFunc)
+    utils.printWithType(valueKind, value, valueKindPrintFunc)
   );
 };
 
 export function toHaveBeenCalledAfter(firstMock, secondMock) {
   if (!isJestMockOrSpy(firstMock)) {
-    return { pass: false, message: mockCheckFailMessage(firstMock, true) };
+    return { pass: false, message: mockCheckFailMessage(this.utils, firstMock, true) };
   }
 
   if (!isJestMockOrSpy(secondMock)) {
-    return { pass: false, message: mockCheckFailMessage(secondMock, false) };
+    return { pass: false, message: mockCheckFailMessage(this.utils, secondMock, false) };
   }
 
   const firstInvocationCallOrder = firstMock.mock.invocationCallOrder;
   const secondInvocationCallOrder = secondMock.mock.invocationCallOrder;
   const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder);
   if (pass) {
-    return { pass: true, message: passMessage(firstInvocationCallOrder, secondInvocationCallOrder) };
+    return { pass: true, message: passMessage(this.utils, firstInvocationCallOrder, secondInvocationCallOrder) };
   }
 
-  return { pass: false, message: failMessage(firstInvocationCallOrder, secondInvocationCallOrder) };
+  return { pass: false, message: failMessage(this.utils, firstInvocationCallOrder, secondInvocationCallOrder) };
 }

--- a/src/matchers/toHaveBeenCalledBefore/index.js
+++ b/src/matchers/toHaveBeenCalledBefore/index.js
@@ -1,53 +1,51 @@
-import { matcherHint, printExpected, printReceived, printWithType } from 'jest-matcher-utils';
-
 import { isJestMockOrSpy } from '../../utils';
 
 import predicate from './predicate';
 
-const passMessage = (firstInvocationCallOrder, secondInvocationCallOrder) => () =>
-  matcherHint('.not.toHaveBeenCalledBefore') +
+const passMessage = (utils, firstInvocationCallOrder, secondInvocationCallOrder) => () =>
+  utils.matcherHint('.not.toHaveBeenCalledBefore') +
   '\n\n' +
   'Expected first mock to not have been called before, invocationCallOrder:\n' +
-  `  ${printExpected(firstInvocationCallOrder)}\n` +
+  `  ${utils.printExpected(firstInvocationCallOrder)}\n` +
   'Received second mock with invocationCallOrder:\n' +
-  `  ${printReceived(secondInvocationCallOrder)}`;
+  `  ${utils.printReceived(secondInvocationCallOrder)}`;
 
-const failMessage = (firstInvocationCallOrder, secondInvocationCallOrder) => () =>
-  matcherHint('.toHaveBeenCalledBefore') +
+const failMessage = (utils, firstInvocationCallOrder, secondInvocationCallOrder) => () =>
+  utils.matcherHint('.toHaveBeenCalledBefore') +
   '\n\n' +
   'Expected first mock to have been called before, invocationCallOrder:\n' +
-  `  ${printExpected(firstInvocationCallOrder)}\n` +
+  `  ${utils.printExpected(firstInvocationCallOrder)}\n` +
   'Received second mock with invocationCallOrder:\n' +
-  `  ${printReceived(secondInvocationCallOrder)}`;
+  `  ${utils.printReceived(secondInvocationCallOrder)}`;
 
-const mockCheckFailMessage = (value, isReceivedValue) => () => {
+const mockCheckFailMessage = (utils, value, isReceivedValue) => () => {
   const valueKind = isReceivedValue ? 'Received' : 'Expected';
-  const valueKindPrintFunc = isReceivedValue ? printReceived : printExpected;
+  const valueKindPrintFunc = isReceivedValue ? utils.printReceived : utils.printExpected;
 
   return (
-    matcherHint('.toHaveBeenCalledAfter') +
+    utils.matcherHint('.toHaveBeenCalledAfter') +
     '\n\n' +
     `Matcher error: ${valueKindPrintFunc(valueKind.toLowerCase())} must be a mock or spy function` +
     '\n\n' +
-    printWithType(valueKind, value, valueKindPrintFunc)
+    utils.printWithType(valueKind, value, valueKindPrintFunc)
   );
 };
 
 export function toHaveBeenCalledBefore(firstMock, secondMock) {
   if (!isJestMockOrSpy(firstMock)) {
-    return { pass: false, message: mockCheckFailMessage(firstMock, true) };
+    return { pass: false, message: mockCheckFailMessage(this.utils, firstMock, true) };
   }
 
   if (!isJestMockOrSpy(secondMock)) {
-    return { pass: false, message: mockCheckFailMessage(secondMock, false) };
+    return { pass: false, message: mockCheckFailMessage(this.utils, secondMock, false) };
   }
 
   const firstInvocationCallOrder = firstMock.mock.invocationCallOrder;
   const secondInvocationCallOrder = secondMock.mock.invocationCallOrder;
   const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder);
   if (pass) {
-    return { pass: true, message: passMessage(firstInvocationCallOrder, secondInvocationCallOrder) };
+    return { pass: true, message: passMessage(this.utils, firstInvocationCallOrder, secondInvocationCallOrder) };
   }
 
-  return { pass: false, message: failMessage(firstInvocationCallOrder, secondInvocationCallOrder) };
+  return { pass: false, message: failMessage(this.utils, firstInvocationCallOrder, secondInvocationCallOrder) };
 }

--- a/src/matchers/toHaveBeenCalledOnce/index.js
+++ b/src/matchers/toHaveBeenCalledOnce/index.js
@@ -1,43 +1,41 @@
-import { matcherHint, printReceived, printWithType } from 'jest-matcher-utils';
-
 import { isJestMockOrSpy } from '../../utils';
 
 import predicate from './predicate';
 
-const passMessage = () => () =>
-  matcherHint('.not.toHaveBeenCalledOnce') +
+const passMessage = utils => () =>
+  utils.matcherHint('.not.toHaveBeenCalledOnce') +
   '\n\n' +
   'Expected mock function to have been called any amount of times but one, but it was called exactly once.';
 
-const failMessage = mockFn => () => {
+const failMessage = (utils, mockFn) => () => {
   return (
-    matcherHint('.toHaveBeenCalledOnce') +
+    utils.matcherHint('.toHaveBeenCalledOnce') +
     '\n\n' +
     'Expected mock function to have been called exactly once, but it was called:\n' +
-    `  ${printReceived(mockFn.mock.calls.length)} times`
+    `  ${utils.printReceived(mockFn.mock.calls.length)} times`
   );
 };
 
-const mockCheckFailMessage = value => () => {
+const mockCheckFailMessage = (utils, value) => () => {
   return (
-    matcherHint('.toHaveBeenCalledAfter') +
+    utils.matcherHint('.toHaveBeenCalledAfter') +
     '\n\n' +
-    `Matcher error: ${printReceived('received')} must be a mock or spy function` +
+    `Matcher error: ${utils.printReceived('received')} must be a mock or spy function` +
     '\n\n' +
-    printWithType('Received', value, printReceived)
+    utils.printWithType('Received', value, utils.printReceived)
   );
 };
 
 export function toHaveBeenCalledOnce(received) {
   if (!isJestMockOrSpy(received)) {
-    return { pass: false, message: mockCheckFailMessage(received) };
+    return { pass: false, message: mockCheckFailMessage(this.utils, received) };
   }
 
   const pass = predicate(received);
 
   return {
     pass,
-    message: pass ? passMessage(received) : failMessage(received),
+    message: pass ? passMessage(this.utils, received) : failMessage(this.utils, received),
     actual: received,
   };
 }

--- a/src/matchers/toInclude/index.js
+++ b/src/matchers/toInclude/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toInclude') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toInclude') +
   '\n\n' +
   'Expected string to not include:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toInclude') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toInclude') +
   '\n\n' +
   'Expected string to include:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toInclude(actual, expected) {
   const pass = predicate(actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toIncludeAllMembers/index.js
+++ b/src/matchers/toIncludeAllMembers/index.js
@@ -1,27 +1,25 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toIncludeAllMembers') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toIncludeAllMembers') +
   '\n\n' +
   'Expected list to not have all of the following members:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toIncludeAllMembers') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toIncludeAllMembers') +
   '\n\n' +
   'Expected list to have all of the following members:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toIncludeAllMembers(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toIncludeAllMembers/predicate.js
+++ b/src/matchers/toIncludeAllMembers/predicate.js
@@ -1,5 +1,5 @@
 import { contains } from '../../utils';
 
-export default (array, set) => {
-  return Array.isArray(array) && Array.isArray(set) && set.every(val => contains(array, val));
+export default (equals, array, set) => {
+  return Array.isArray(array) && Array.isArray(set) && set.every(val => contains(equals, array, val));
 };

--- a/src/matchers/toIncludeAllMembers/predicate.test.js
+++ b/src/matchers/toIncludeAllMembers/predicate.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toIncludeAllMembers Predicate', () => {
@@ -8,21 +9,21 @@ describe('toIncludeAllMembers Predicate', () => {
 
   describe('returns true', () => {
     test('when Array contains all the same members of given set', () => {
-      expect(predicate(array1, set1)).toBe(true);
+      expect(predicate(equals, array1, set1)).toBe(true);
     });
 
     test('when Array contains all of the same nested members of given set', () => {
-      expect(predicate([{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'bar' }])).toBe(true);
+      expect(predicate(equals, [{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'bar' }])).toBe(true);
     });
   });
 
   describe('returns false', () => {
     test('when Array does not contain any of the members of given set', () => {
-      expect(predicate(array2, set2)).toBe(false);
+      expect(predicate(equals, array2, set2)).toBe(false);
     });
 
     test('when Array contains does not contain all of the same nested members of given set', () => {
-      expect(predicate([{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'qux' }])).toBe(false);
+      expect(predicate(equals, [{ hello: 'world' }, { foo: 'bar' }], [{ foo: 'qux' }])).toBe(false);
     });
   });
 });

--- a/src/matchers/toIncludeAllPartialMembers/index.js
+++ b/src/matchers/toIncludeAllPartialMembers/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toIncludeAllPartialMembers') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toIncludeAllPartialMembers') +
   '\n\n' +
   'Expected list to not have all of the following partial members:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toIncludeAllPartialMembers') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toIncludeAllPartialMembers') +
   '\n\n' +
   'Expected list to have all of the following partial members:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toIncludeAllPartialMembers(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toIncludeAllPartialMembers/predicate.js
+++ b/src/matchers/toIncludeAllPartialMembers/predicate.js
@@ -1,6 +1,6 @@
 import toContainEntries from '../toContainEntries/predicate';
 
-export default (array, set) =>
+export default (equals, array, set) =>
   Array.isArray(array) &&
   Array.isArray(set) &&
-  set.every(partial => array.some(value => toContainEntries(value, Object.entries(partial))));
+  set.every(partial => array.some(value => toContainEntries(equals, value, Object.entries(partial))));

--- a/src/matchers/toIncludeAllPartialMembers/predicate.test.js
+++ b/src/matchers/toIncludeAllPartialMembers/predicate.test.js
@@ -1,21 +1,24 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toIncludeAllPartialMembers Predicate', () => {
   describe('returns true', () => {
     test('when Array contains all of the same nested partial members of given set', () => {
-      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'bar' }])).toBe(true);
+      expect(predicate(equals, [{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'bar' }])).toBe(true);
     });
   });
 
   describe('returns false', () => {
     test('when Array contains does not contain all of the same nested partial members of given item', () => {
-      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'bar', bax: 'qux' }])).toBe(false);
+      expect(predicate(equals, [{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'bar', bax: 'qux' }])).toBe(
+        false,
+      );
     });
 
     test('when Array contains does not contain all of the same nested partial members of given set', () => {
-      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ hello: 'world' }, { foo: 'qux' }])).toBe(
-        false,
-      );
+      expect(
+        predicate(equals, [{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ hello: 'world' }, { foo: 'qux' }]),
+      ).toBe(false);
     });
   });
 });

--- a/src/matchers/toIncludeAnyMembers/index.js
+++ b/src/matchers/toIncludeAnyMembers/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toIncludeAnyMembers') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toIncludeAnyMembers') +
   '\n\n' +
   'Expected list to not include any of the following members:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toIncludeAnyMembers') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toIncludeAnyMembers') +
   '\n\n' +
   'Expected list to include any of the following members:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toIncludeAnyMembers(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toIncludeAnyMembers/predicate.js
+++ b/src/matchers/toIncludeAnyMembers/predicate.js
@@ -1,5 +1,5 @@
 import { contains } from '../../utils';
 
-export default (array, members) => {
-  return Array.isArray(array) && Array.isArray(members) && members.some(member => contains(array, member));
+export default (equals, array, members) => {
+  return Array.isArray(array) && Array.isArray(members) && members.some(member => contains(equals, array, member));
 };

--- a/src/matchers/toIncludeAnyMembers/predicate.test.js
+++ b/src/matchers/toIncludeAnyMembers/predicate.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toIncludeAnyMembers Predicate', () => {
@@ -8,30 +9,30 @@ describe('toIncludeAnyMembers Predicate', () => {
     test.each([['world'], [false], [undefined], [null], [''], [0]])(
       'when given array contains primitive value: %s',
       given => {
-        expect(predicate([given], array)).toBe(true);
+        expect(predicate(equals, [given], array)).toBe(true);
       },
     );
 
     test('when given array contains object value', () => {
-      expect(predicate([shallow, 7], [shallow])).toBe(true);
+      expect(predicate(equals, [shallow, 7], [shallow])).toBe(true);
     });
 
     test('when given object contains array value', () => {
-      expect(predicate([[shallow]], [[shallow], 7])).toBe(true);
+      expect(predicate(equals, [[shallow]], [[shallow], 7])).toBe(true);
     });
   });
 
   describe('returns false', () => {
     test('when given array does not contain primitive value', () => {
-      expect(predicate([3, 4, 5], [1])).toBe(false);
+      expect(predicate(equals, [3, 4, 5], [1])).toBe(false);
     });
 
     test('when given array does not contain object value', () => {
-      expect(predicate([3], [{ foo: 'bar' }])).toBe(false);
+      expect(predicate(equals, [3], [{ foo: 'bar' }])).toBe(false);
     });
 
     test('when given object does not contain array value', () => {
-      expect(predicate([7], [[7]])).toBe(false);
+      expect(predicate(equals, [7], [[7]])).toBe(false);
     });
   });
 });

--- a/src/matchers/toIncludeMultiple/index.js
+++ b/src/matchers/toIncludeMultiple/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toIncludeMultiple') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toIncludeMultiple') +
   '\n\n' +
   'Expected string to not contain all substrings: \n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received: \n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toIncludeMultiple') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toIncludeMultiple') +
   '\n\n' +
   'Expected string to contain all substrings: \n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toIncludeMultiple(actual, expected) {
   const pass = predicate(actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toIncludeRepeated/index.js
+++ b/src/matchers/toIncludeRepeated/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected, occurrences) => () =>
-  matcherHint('.not.toIncludeRepeated') +
+const passMessage = (utils, actual, expected, occurrences) => () =>
+  utils.matcherHint('.not.toIncludeRepeated') +
   '\n\n' +
   `Expected string to not include repeated ${occurrences} times:\n` +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected, occurrences) => () =>
-  matcherHint('.toIncludeRepeated') +
+const failMessage = (utils, actual, expected, occurrences) => () =>
+  utils.matcherHint('.toIncludeRepeated') +
   '\n\n' +
   `Expected string to include repeated ${occurrences} times:\n` +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toIncludeRepeated(actual, expected, occurrences) {
   const pass = predicate(actual, expected, occurrences);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected, occurrences) };
+    return { pass: true, message: passMessage(this.utils, actual, expected, occurrences) };
   }
 
-  return { pass: false, message: failMessage(actual, expected, occurrences) };
+  return { pass: false, message: failMessage(this.utils, actual, expected, occurrences) };
 }

--- a/src/matchers/toIncludeSameMembers/index.js
+++ b/src/matchers/toIncludeSameMembers/index.js
@@ -1,27 +1,25 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toIncludeSameMembers') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toIncludeSameMembers') +
   '\n\n' +
   'Expected list to not exactly match the members of:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toIncludeSameMembers') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toIncludeSameMembers') +
   '\n\n' +
   'Expected list to have the following members and no more:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toIncludeSameMembers(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toIncludeSameMembers/predicate.js
+++ b/src/matchers/toIncludeSameMembers/predicate.js
@@ -1,6 +1,4 @@
-import { equals } from '../../utils';
-
-const filterMatches = (first, second) =>
+const filterMatches = (equals, first, second) =>
   second.reduce((remaining, secondValue) => {
     if (remaining === null) return remaining;
 
@@ -13,12 +11,12 @@ const filterMatches = (first, second) =>
     return remaining.slice(0, index).concat(remaining.slice(index + 1));
   }, first);
 
-export default (first, second) => {
+export default (equals, first, second) => {
   if (!Array.isArray(first) || !Array.isArray(second) || first.length !== second.length) {
     return false;
   }
 
-  const remaining = filterMatches(first, second);
+  const remaining = filterMatches(equals, first, second);
 
   return !!remaining && remaining.length === 0;
 };

--- a/src/matchers/toIncludeSameMembers/predicate.test.js
+++ b/src/matchers/toIncludeSameMembers/predicate.test.js
@@ -1,53 +1,54 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('toIncludeSameMembers Predicate', () => {
   test('returns true when arrays are empty', () => {
-    expect(predicate([], [])).toBe(true);
+    expect(predicate(equals, [], [])).toBe(true);
   });
 
   test('returns true when arrays match with the same order', () => {
-    expect(predicate([1, 2, 3], [1, 2, 3])).toBe(true);
+    expect(predicate(equals, [1, 2, 3], [1, 2, 3])).toBe(true);
   });
 
   test('returns true when arrays match with reverse order', () => {
-    expect(predicate([1, 2, 3], [3, 2, 1])).toBe(true);
+    expect(predicate(equals, [1, 2, 3], [3, 2, 1])).toBe(true);
   });
 
   test('returns true when arrays match with duplicate elements and same order', () => {
-    expect(predicate([1, 2, 2], [1, 2, 2])).toBe(true);
+    expect(predicate(equals, [1, 2, 2], [1, 2, 2])).toBe(true);
   });
 
   test('returns true when arrays match with duplicate elements and reverse order', () => {
-    expect(predicate([1, 2, 2], [2, 2, 1])).toBe(true);
+    expect(predicate(equals, [1, 2, 2], [2, 2, 1])).toBe(true);
   });
 
   test('returns false when inputs are not arrays', () => {
-    expect(predicate(null, null)).toBe(false);
-    expect(predicate(null, [])).toBe(false);
-    expect(predicate([], null)).toBe(false);
+    expect(predicate(equals, null, null)).toBe(false);
+    expect(predicate(equals, null, [])).toBe(false);
+    expect(predicate(equals, [], null)).toBe(false);
   });
 
   test('returns false when arrays have different lengths', () => {
-    expect(predicate([], [1])).toBe(false);
-    expect(predicate([1], [])).toBe(false);
-    expect(predicate([1, 2, 3], [1, 2])).toBe(false);
+    expect(predicate(equals, [], [1])).toBe(false);
+    expect(predicate(equals, [1], [])).toBe(false);
+    expect(predicate(equals, [1, 2, 3], [1, 2])).toBe(false);
   });
 
   test('returns false when no elements match', () => {
-    expect(predicate([1, 2], [3, 4])).toBe(false);
+    expect(predicate(equals, [1, 2], [3, 4])).toBe(false);
   });
 
   test('returns false when only one element matches', () => {
-    expect(predicate([1, 2, 3], [3, 4, 5])).toBe(false);
+    expect(predicate(equals, [1, 2, 3], [3, 4, 5])).toBe(false);
   });
 
   test('returns false when all but one element matches', () => {
-    expect(predicate([1, 2, 3], [2, 3, 4])).toBe(false);
+    expect(predicate(equals, [1, 2, 3], [2, 3, 4])).toBe(false);
   });
 
   test('does not modify the array content', () => {
     const arr = [1, 2, 3];
-    predicate(arr, arr);
+    predicate(equals, arr, arr);
     expect(arr).toEqual([1, 2, 3]);
   });
 });

--- a/src/matchers/toPartiallyContain/index.js
+++ b/src/matchers/toPartiallyContain/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toPartiallyContain') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toPartiallyContain') +
   '\n\n' +
   'Expected array not to partially contain:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toPartiallyContain') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toPartiallyContain') +
   '\n\n' +
   'Expected array to partially contain:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toPartiallyContain(actual, expected) {
-  const pass = predicate(actual, expected);
+  const pass = predicate(this.equals, actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toPartiallyContain/predicate.js
+++ b/src/matchers/toPartiallyContain/predicate.js
@@ -1,3 +1,3 @@
 import toIncludeAllPartialMembers from '../toIncludeAllPartialMembers/predicate';
 
-export default (array, item) => toIncludeAllPartialMembers(array, [item]);
+export default (equals, array, item) => toIncludeAllPartialMembers(equals, array, [item]);

--- a/src/matchers/toPartiallyContain/predicate.test.js
+++ b/src/matchers/toPartiallyContain/predicate.test.js
@@ -1,13 +1,14 @@
+import { equals } from 'expect/build/jasmineUtils';
 import predicate from './predicate';
 
 describe('.toPartiallyContain', () => {
   const item = { foo: 'bar', baz: 'qux' };
 
   test('passes when array partially contains the given item', () => {
-    expect(predicate([{ foo: 'bar', baz: 'qux', bax: 'zax' }], item)).toBe(true);
+    expect(predicate(equals, [{ foo: 'bar', baz: 'qux', bax: 'zax' }], item)).toBe(true);
   });
 
   test('fails when array does not contain the given item', () => {
-    expect(predicate([{ a: 1, b: 2 }], item)).toBe(false);
+    expect(predicate(equals, [{ a: 1, b: 2 }], item)).toBe(false);
   });
 });

--- a/src/matchers/toReject/index.js
+++ b/src/matchers/toReject/index.js
@@ -1,17 +1,15 @@
-import { matcherHint } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = () =>
-  matcherHint('.not.toReject', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
+const passMessage = utils => () =>
+  utils.matcherHint('.not.toReject', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
 
-const failMessage = () =>
-  matcherHint('.toReject', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
+const failMessage = utils => () =>
+  utils.matcherHint('.toReject', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
 
 export async function toReject(promise) {
   const pass = await predicate(promise);
   if (pass) {
-    return { pass: true, message: passMessage };
+    return { pass: true, message: passMessage(this.utils) };
   }
-  return { pass: false, message: failMessage };
+  return { pass: false, message: failMessage(this.utils) };
 }

--- a/src/matchers/toResolve/index.js
+++ b/src/matchers/toResolve/index.js
@@ -1,17 +1,15 @@
-import { matcherHint } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = () =>
-  matcherHint('.not.toResolve', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
+const passMessage = utils => () =>
+  utils.matcherHint('.not.toResolve', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
 
-const failMessage = () =>
-  matcherHint('.toResolve', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
+const failMessage = utils => () =>
+  utils.matcherHint('.toResolve', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
 
 export async function toResolve(promise) {
   const pass = await predicate(promise);
   if (pass) {
-    return { pass: true, message: passMessage };
+    return { pass: true, message: passMessage(this.utils) };
   }
-  return { pass: false, message: failMessage };
+  return { pass: false, message: failMessage(this.utils) };
 }

--- a/src/matchers/toSatisfy/index.js
+++ b/src/matchers/toSatisfy/index.js
@@ -1,26 +1,24 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
-const passMessage = (received, expected) => () =>
-  matcherHint('.not.toSatisfy', 'received', '') +
+const passMessage = (utils, received, expected) => () =>
+  utils.matcherHint('.not.toSatisfy', 'received', '') +
   '\n\n' +
   'Expected value to not satisfy:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
-const failMessage = (received, expected) => () =>
-  matcherHint('.toSatisfy', 'received', '') +
+const failMessage = (utils, received, expected) => () =>
+  utils.matcherHint('.toSatisfy', 'received', '') +
   '\n\n' +
   'Expected value to satisfy:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(received)}`;
+  `  ${utils.printReceived(received)}`;
 
 export function toSatisfy(actual, predicate) {
   const pass = predicate(actual);
   if (pass) {
-    return { pass: true, message: passMessage(actual, predicate) };
+    return { pass: true, message: passMessage(this.utils, actual, predicate) };
   }
 
-  return { pass: false, message: failMessage(actual, predicate) };
+  return { pass: false, message: failMessage(this.utils, actual, predicate) };
 }

--- a/src/matchers/toSatisfyAll/index.js
+++ b/src/matchers/toSatisfyAll/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toSatisfyAll') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toSatisfyAll') +
   '\n\n' +
   'Expected array to not satisfy predicate for all values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toSatisfyAll') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toSatisfyAll') +
   '\n\n' +
   'Expected array to satisfy predicate for all values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toSatisfyAll(actual, expected) {
   const pass = predicate(actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toSatisfyAny/index.js
+++ b/src/matchers/toSatisfyAny/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (actual, expected) => () =>
-  matcherHint('.not.toSatisfyAny') +
+const passMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.not.toSatisfyAny') +
   '\n\n' +
   'Expected array to not satisfy predicate for any value:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
-const failMessage = (actual, expected) => () =>
-  matcherHint('.toSatisfyAny') +
+const failMessage = (utils, actual, expected) => () =>
+  utils.matcherHint('.toSatisfyAny') +
   '\n\n' +
   'Expected array to satisfy predicate for any values:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Received:\n' +
-  `  ${printReceived(actual)}`;
+  `  ${utils.printReceived(actual)}`;
 
 export function toSatisfyAny(actual, expected) {
   const pass = predicate(actual, expected);
   if (pass) {
-    return { pass: true, message: passMessage(actual, expected) };
+    return { pass: true, message: passMessage(this.utils, actual, expected) };
   }
 
-  return { pass: false, message: failMessage(actual, expected) };
+  return { pass: false, message: failMessage(this.utils, actual, expected) };
 }

--- a/src/matchers/toStartWith/index.js
+++ b/src/matchers/toStartWith/index.js
@@ -1,28 +1,26 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const passMessage = (prefix, string) => () =>
-  matcherHint('.not.toStartWith') +
+const passMessage = (utils, prefix, string) => () =>
+  utils.matcherHint('.not.toStartWith') +
   '\n\n' +
   'Expected string to not start with:\n' +
-  `  ${printExpected(prefix)}\n` +
+  `  ${utils.printExpected(prefix)}\n` +
   'Received:\n' +
-  `  ${printReceived(string)}`;
+  `  ${utils.printReceived(string)}`;
 
-const failMessage = (prefix, string) => () =>
-  matcherHint('.toStartWith') +
+const failMessage = (utils, prefix, string) => () =>
+  utils.matcherHint('.toStartWith') +
   '\n\n' +
   'Expected string to start with:\n' +
-  `  ${printExpected(prefix)}\n` +
+  `  ${utils.printExpected(prefix)}\n` +
   'Received:\n' +
-  `  ${printReceived(string)}`;
+  `  ${utils.printReceived(string)}`;
 
 export function toStartWith(string, prefix) {
   const pass = predicate(prefix, string);
   if (pass) {
-    return { pass: true, message: passMessage(prefix, string) };
+    return { pass: true, message: passMessage(this.utils, prefix, string) };
   }
 
-  return { pass: false, message: failMessage(prefix, string) };
+  return { pass: false, message: failMessage(this.utils, prefix, string) };
 }

--- a/src/matchers/toThrowWithMessage/index.js
+++ b/src/matchers/toThrowWithMessage/index.js
@@ -1,47 +1,51 @@
-import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
-
 import predicate from './predicate';
 
-const positiveHint = matcherHint('.toThrowWithMessage', 'function', 'type', { secondArgument: 'message' });
-const negativeHint = matcherHint('.not.toThrowWithMessage', 'function', 'type', { secondArgument: 'message' });
+const positiveHint = utils =>
+  utils.matcherHint('.toThrowWithMessage', 'function', 'type', { secondArgument: 'message' });
 
-const passMessage = (received, expected) => () =>
-  negativeHint +
+const negativeHint = utils =>
+  utils.matcherHint('.not.toThrowWithMessage', 'function', 'type', { secondArgument: 'message' });
+
+const passMessage = (utils, received, expected) => () =>
+  negativeHint(utils) +
   '\n\n' +
   'Expected not to throw:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Thrown:\n' +
-  `  ${printReceived(received)}\n`;
+  `  ${utils.printReceived(received)}\n`;
 
-const failMessage = (received, expected) => () =>
-  positiveHint +
+const failMessage = (utils, received, expected) => () =>
+  positiveHint(utils) +
   '\n\n' +
   'Expected to throw:\n' +
-  `  ${printExpected(expected)}\n` +
+  `  ${utils.printExpected(expected)}\n` +
   'Thrown:\n' +
-  `  ${printReceived(received)}\n`;
+  `  ${utils.printReceived(received)}\n`;
 
 export function toThrowWithMessage(callbackOrPromiseReturn, type, message) {
+  const utils = this.utils;
   const isFromReject = this && this.promise === 'rejects'; // See https://github.com/facebook/jest/pull/7621#issue-244312550
   if ((!callbackOrPromiseReturn || typeof callbackOrPromiseReturn !== 'function') && !isFromReject) {
     return {
       pass: false,
       message: () =>
-        positiveHint + '\n\n' + `Received value must be a function but instead "${callbackOrPromiseReturn}" was found`,
+        positiveHint(utils) +
+        '\n\n' +
+        `Received value must be a function but instead "${callbackOrPromiseReturn}" was found`,
     };
   }
 
   if (!type || typeof type !== 'function') {
     return {
       pass: false,
-      message: () => positiveHint + '\n\n' + `Expected type to be a function but instead "${type}" was found`,
+      message: () => positiveHint(utils) + '\n\n' + `Expected type to be a function but instead "${type}" was found`,
     };
   }
 
   if (!message) {
     return {
       pass: false,
-      message: () => positiveHint + '\n\n' + ' Message argument is required. ',
+      message: () => positiveHint(utils) + '\n\n' + ' Message argument is required. ',
     };
   }
 
@@ -49,7 +53,7 @@ export function toThrowWithMessage(callbackOrPromiseReturn, type, message) {
     return {
       pass: false,
       message: () =>
-        positiveHint +
+        positiveHint(utils) +
         '\n\n' +
         'Unexpected argument for message\n' +
         'Expected: "string" or "regexp\n' +
@@ -77,8 +81,8 @@ export function toThrowWithMessage(callbackOrPromiseReturn, type, message) {
 
   const pass = predicate(error, type, message);
   if (pass) {
-    return { pass: true, message: passMessage(error, new type(message)) };
+    return { pass: true, message: passMessage(utils, error, new type(message)) };
   }
 
-  return { pass: false, message: failMessage(error, new type(message)) };
+  return { pass: false, message: failMessage(utils, error, new type(message)) };
 }

--- a/src/matchers/toThrowWithMessage/index.test.js
+++ b/src/matchers/toThrowWithMessage/index.test.js
@@ -1,3 +1,4 @@
+import { matcherHint, printExpected, printReceived } from 'jest-matcher-utils';
 import * as matcher from './';
 const { toThrowWithMessage } = matcher;
 
@@ -5,41 +6,63 @@ expect.extend(matcher);
 
 describe('.toThrowWithMessage', () => {
   test('fails when callback function is not provided', () => {
-    const { pass, message } = toThrowWithMessage();
+    const { pass, message } = toThrowWithMessage.call({
+      utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+    });
     expect(pass).toBe(false);
     expect(message()).toMatchSnapshot();
   });
 
   test('fails when a callback function is not a function', () => {
-    const { pass, message } = toThrowWithMessage(2);
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      2,
+    );
     expect(pass).toBe(false);
     expect(message()).toMatchSnapshot();
   });
 
   test('fails when error message is not provided', () => {
     const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback, Error);
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      Error,
+    );
     expect(pass).toBe(false);
     expect(message()).toMatchSnapshot();
   });
 
   test('fails when error type is not provided', () => {
     const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback);
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+    );
     expect(pass).toBe(false);
     expect(message()).toMatchSnapshot();
   });
 
   test('fails when error message provided is not a string or regex', () => {
     const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback, Error, 2);
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      Error,
+      2,
+    );
     expect(pass).toBe(false);
     expect(message()).toMatchSnapshot();
   });
 
   test('fails when a callback provided doesnt throw an error', () => {
     const callback = () => {};
-    const { pass, message } = toThrowWithMessage(callback, Error, 'error');
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      Error,
+      'error',
+    );
     expect(pass).toBe(false);
     expect(message()).toMatchSnapshot();
   });
@@ -48,7 +71,12 @@ describe('.toThrowWithMessage', () => {
     const callback = () => {
       throw SyntaxError('Expected message');
     };
-    const { pass, message } = toThrowWithMessage(callback, TypeError, 'Expected message');
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      TypeError,
+      'Expected message',
+    );
     expect(pass).toBe(false);
     expect(message()).toMatchSnapshot();
   });
@@ -57,7 +85,12 @@ describe('.toThrowWithMessage', () => {
     const callback = () => {
       throw TypeError('Expected message');
     };
-    const { pass, message } = toThrowWithMessage(callback, TypeError, 'Expected message');
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      TypeError,
+      'Expected message',
+    );
     expect(pass).toBe(true);
     expect(message()).toMatchSnapshot();
   });
@@ -66,7 +99,12 @@ describe('.toThrowWithMessage', () => {
     const callback = () => {
       throw TypeError('Expected message');
     };
-    const { pass, message } = toThrowWithMessage(callback, TypeError, /Expected message/);
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      TypeError,
+      /Expected message/,
+    );
     expect(pass).toBe(true);
     expect(message()).toMatchSnapshot();
   });
@@ -74,39 +112,71 @@ describe('.toThrowWithMessage', () => {
   test('passes when given an Error with a string error message: end to end', () => {
     expect(() => {
       throw new TypeError('Expected message');
-    }).toThrowWithMessage(TypeError, 'Expected message');
+    }).toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      TypeError,
+      'Expected message',
+    );
   });
 
   test('passes when given an Error with a regex error message: end to end', () => {
     expect(() => {
       throw new SyntaxError('Expected message');
-    }).toThrowWithMessage(SyntaxError, /Expected message/);
+    }).toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      SyntaxError,
+      /Expected message/,
+    );
   });
 
   describe('Async', () => {
     test('fails on rejects when return value is not provided', () => {
-      const { pass, message } = toThrowWithMessage.call({ promise: 'rejects' });
+      const { pass, message } = toThrowWithMessage.call({
+        utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+        promise: 'rejects',
+      });
       expect(pass).toBe(false);
       expect(message()).toMatchSnapshot();
     });
 
     test('fails on rejects when error message is not provided', () => {
       const rejectValue = true;
-      const { pass, message } = toThrowWithMessage.call({ promise: 'rejects' }, rejectValue, Error);
+      const { pass, message } = toThrowWithMessage.call(
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
+        rejectValue,
+        Error,
+      );
       expect(pass).toBe(false);
       expect(message()).toMatchSnapshot();
     });
 
     test('fails on rejects when error type is not provided', () => {
       const rejectValue = true;
-      const { pass, message } = toThrowWithMessage.call({ promise: 'rejects' }, rejectValue);
+      const { pass, message } = toThrowWithMessage.call(
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
+        rejectValue,
+      );
       expect(pass).toBe(false);
       expect(message()).toMatchSnapshot();
     });
 
     test('fails on rejects when error message provided is not a string or regex', () => {
       const rejectValue = true;
-      const { pass, message } = toThrowWithMessage.call({ promise: 'rejects' }, rejectValue, Error, 2);
+      const { pass, message } = toThrowWithMessage.call(
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
+        rejectValue,
+        Error,
+        2,
+      );
       expect(pass).toBe(false);
       expect(message()).toMatchSnapshot();
     });
@@ -114,7 +184,10 @@ describe('.toThrowWithMessage', () => {
     test('fails on rejects when a wrong type of error is thrown', () => {
       const rejectValue = SyntaxError('Expected message');
       const { pass, message } = toThrowWithMessage.call(
-        { promise: 'rejects' },
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
         rejectValue,
         TypeError,
         'Expected message',
@@ -126,7 +199,10 @@ describe('.toThrowWithMessage', () => {
     test('passes on rejects when given an Error with a string error message', () => {
       const rejectValue = TypeError('Expected message');
       const { pass, message } = toThrowWithMessage.call(
-        { promise: 'rejects' },
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
         rejectValue,
         TypeError,
         'Expected message',
@@ -138,7 +214,10 @@ describe('.toThrowWithMessage', () => {
     test('passes on rejects when given an Error with a regex error message', () => {
       const rejectValue = new TypeError('Expected message');
       const { pass, message } = toThrowWithMessage.call(
-        { promise: 'rejects' },
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
         rejectValue,
         TypeError,
         /Expected message/,
@@ -146,6 +225,7 @@ describe('.toThrowWithMessage', () => {
       expect(pass).toBe(true);
       expect(message()).toMatchSnapshot();
     });
+
     test('passes on rejects with rejected promise when given an Error with a string error message: end to end', async () => {
       await expect(Promise.reject(new SyntaxError('Expected message'))).rejects.toThrowWithMessage(
         SyntaxError,
@@ -159,6 +239,7 @@ describe('.toThrowWithMessage', () => {
         /Expected message/,
       );
     });
+
     test('fails on rejects with resolved promise: end to end', async () => {
       expect.assertions(1);
       await expect(

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,4 @@
-import { equals } from 'expect/build/jasmineUtils';
-
-export const contains = (list, value) => {
+export const contains = (equals, list, value) => {
   return list.findIndex(item => equals(item, value)) > -1;
 };
 
@@ -11,5 +9,3 @@ export const determinePropertyMessage = (actual, property, message = 'Not Access
 export const isJestMockOrSpy = value => {
   return !!(value && value._isMockFunction === true && typeof value.mock === 'object');
 };
-
-export { equals };

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,3 +1,4 @@
+import { equals } from 'expect/build/jasmineUtils';
 import { contains, determinePropertyMessage, isJestMockOrSpy } from './';
 
 describe('Utils', () => {
@@ -7,11 +8,11 @@ describe('Utils', () => {
     const testRows = array.map(item => [item]);
 
     test.each(testRows)('returns true when array contains given value: %s', value => {
-      expect(contains(array, value)).toBe(true);
+      expect(contains(equals, array, value)).toBe(true);
     });
 
     test.each(testRows)('returns false when array does not contain given value: %s', value => {
-      expect(contains([], value)).toBe(false);
+      expect(contains(equals, [], value)).toBe(false);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,7 +18,7 @@
     "@nicolo-ribaudo/chokidar-2" "2.1.8-no-fsevents.3"
     chokidar "^3.4.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
+"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
@@ -1133,17 +1133,6 @@
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^26.6.2":
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
-  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
 "@jest/types@^27.4.2":
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
@@ -1297,13 +1286,6 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
   integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
 
-"@types/yargs@^15.0.0":
-  version "15.0.14"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
-  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
-  dependencies:
-    "@types/yargs-parser" "*"
-
 "@types/yargs@^16.0.0":
   version "16.0.4"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
@@ -1427,7 +1409,7 @@ ansi-escapes@^4.2.1, ansi-escapes@^4.3.0, ansi-escapes@^4.3.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -2006,11 +1988,6 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-diff-sequences@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
-  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
-
 diff-sequences@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.4.0.tgz#d783920ad8d06ec718a060d00196dfef25b132a5"
@@ -2336,18 +2313,6 @@ exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
-
-expect@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
-  integrity sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==
-  dependencies:
-    "@jest/types" "^26.6.2"
-    ansi-styles "^4.0.0"
-    jest-get-type "^26.3.0"
-    jest-matcher-utils "^26.6.2"
-    jest-message-util "^26.6.2"
-    jest-regex-util "^26.0.0"
 
 expect@^27.4.6:
   version "27.4.6"
@@ -2976,16 +2941,6 @@ jest-config@^27.4.7:
     pretty-format "^27.4.6"
     slash "^3.0.0"
 
-jest-diff@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
-  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^26.6.2"
-    jest-get-type "^26.3.0"
-    pretty-format "^26.6.2"
-
 jest-diff@^27.0.0, jest-diff@^27.2.5, jest-diff@^27.4.6:
   version "27.4.6"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.6.tgz#93815774d2012a2cbb6cf23f84d48c7a2618f98d"
@@ -3038,11 +2993,6 @@ jest-environment-node@^27.4.6:
     "@types/node" "*"
     jest-mock "^27.4.6"
     jest-util "^27.4.2"
-
-jest-get-type@^26.3.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
-  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-get-type@^27.0.6, jest-get-type@^27.4.0:
   version "27.4.0"
@@ -3100,17 +3050,7 @@ jest-leak-detector@^27.4.6:
     jest-get-type "^27.4.0"
     pretty-format "^27.4.6"
 
-jest-matcher-utils@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
-  integrity sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==
-  dependencies:
-    chalk "^4.0.0"
-    jest-diff "^26.6.2"
-    jest-get-type "^26.3.0"
-    pretty-format "^26.6.2"
-
-jest-matcher-utils@^27.2.4, jest-matcher-utils@^27.4.6:
+jest-matcher-utils@^27.4.6:
   version "27.4.6"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.4.6.tgz#53ca7f7b58170638590e946f5363b988775509b8"
   integrity sha512-XD4PKT3Wn1LQnRAq7ZsTI0VRuEc9OrCPFiO1XL7bftTGmfNF0DcEwMHRgqiu7NGf8ZoZDREpGrCniDkjt79WbA==
@@ -3119,21 +3059,6 @@ jest-matcher-utils@^27.2.4, jest-matcher-utils@^27.4.6:
     jest-diff "^27.4.6"
     jest-get-type "^27.4.0"
     pretty-format "^27.4.6"
-
-jest-message-util@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
-  integrity sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@jest/types" "^26.6.2"
-    "@types/stack-utils" "^2.0.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    micromatch "^4.0.2"
-    pretty-format "^26.6.2"
-    slash "^3.0.0"
-    stack-utils "^2.0.2"
 
 jest-message-util@^27.4.6:
   version "27.4.6"
@@ -3162,11 +3087,6 @@ jest-pnp-resolver@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
-
-jest-regex-util@^26.0.0:
-  version "26.0.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
-  integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
 jest-regex-util@^27.0.0, jest-regex-util@^27.4.0:
   version "27.4.0"
@@ -3593,7 +3513,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.2, micromatch@^4.0.4:
+micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -3879,16 +3799,6 @@ prettier@^2.3.2:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
   integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
-
-pretty-format@^26.6.2:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
-  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
-  dependencies:
-    "@jest/types" "^26.6.2"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^17.0.1"
 
 pretty-format@^27.0.0, pretty-format@^27.2.4, pretty-format@^27.4.6:
   version "27.4.6"
@@ -4218,7 +4128,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stack-utils@^2.0.2, stack-utils@^2.0.3:
+stack-utils@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.5.tgz#d25265fca995154659dbbfba3b49254778d2fdd5"
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
### What

Moving the Jest dependencies from dev dependencies to peer dependencies.

<!-- Why are these changes necessary? Link any related issues -->
### Why

Since jest-extended requires Jest dependencies to be hoisted by the project using it (since it's sort of like a plugin for Jest and doesn't have a have and shouldn't have a transitive dependency on Jest itself), we should make that requirement clear by marking Jest as a peer dependency. This should also serve as a resolution for the issue mentioned in #331.

<!-- If necessary add any additional notes on the implementation -->
### Notes

1. I'm not quite sure the history behind why the snapshots needed an update. If I'm reading it right, they're semantically equivalent, they just collapsed 2 adjacent `dim` tags into a single tag. I'm guessing this was improved somewhere along the way in Jest and now that the dev dependencies are fully Jest 24, we have a newer Jest version used for tests that include this improvement.
1. Should `@types/jest` be marked as an optional peer since only the jest-extended types would require that to be hoisted?
1. Should `jest-get-type` be marked as an optional peer since only `toBeValid`, `toBeDate`, and `toBeObject` require that to be hoisted?

### Housekeeping

- [x] Unit tests
- [ ] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/master/types/index.d.ts) are added/updated where relevant
