### PR TITLE
docs(typescript): add triple slash directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ If your editor does not recognise the custom `jest-extended` matchers, add a `gl
 import 'jest-extended';
 ```
 
+If the above import syntax does not work, replace it with the following:
+              
+```ts
+/// <reference types="jest-extended" />           
+```  
+              
 ## Asymmetric matchers
 
 All matchers described in the API are also asymmetrical since [jest version 23](https://jestjs.io/blog/2018/05/29/jest-23-blazing-fast-delightful-testing#custom-asymmetric-matchers):


### PR DESCRIPTION
The import statement did not work for me, but this did.

Here is the file I have that now works.

```ts
/// <reference types="jest-extended" />

/* eslint-disable @typescript-eslint/no-explicit-any */
declare module "all:part:@sanity/base/schema-type" {
  import { BaseSchemaType } from "@sanity/types"
  const anyArray: BaseSchemaType[]

  export default anyArray
}

declare var GRAPHQL_ENDPOINT: string
```

<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

<!-- Why are these changes necessary? Link any related issues -->

### Why

<!-- If necessary add any additional notes on the implementation -->

### Notes

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
