### PR TITLE
chore: update jest-each to version shipped with jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "husky": "^7.0.1",
     "import-all.macro": "^2.0.3",
     "jest": "^24.0.0",
-    "jest-each": "^0.5.0",
+    "jest-each": "^24.0.0",
     "jest-watch-typeahead": "^0.6.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.3.2",

--- a/src/matchers/toBeArrayOfSize/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeArrayOfSize/__snapshots__/index.test.js.snap
@@ -20,7 +20,17 @@ Received:
   length: <red>\\"Not Accessible\\"</>"
 `;
 
-exports[`.toBeArrayOfSize fails when given type of [object Object] which is not an array 1`] = `
+exports[`.toBeArrayOfSize fails when given type of () => {} which is not an array 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
+
+Expected value to be an array of size:
+  <green>1</>
+Received:
+  value: <red>[Function anonymous]</>
+  length: <red>\\"Not Accessible\\"</>"
+`;
+
+exports[`.toBeArrayOfSize fails when given type of {} which is not an array 1`] = `
 "<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
 
 Expected value to be an array of size:
@@ -81,16 +91,6 @@ Received:
 `;
 
 exports[`.toBeArrayOfSize fails when given type of undefined which is not an array 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
-
-Expected value to be an array of size:
-  <green>1</>
-Received:
-  value: <red>[Function anonymous]</>
-  length: <red>\\"Not Accessible\\"</>"
-`;
-
-exports[`.toBeArrayOfSize fails when given type of undefined which is not an array 2`] = `
 "<dim>expect(</><red>received</><dim>).toBeArrayOfSize(</><green>expected</><dim>)</>
 
 Expected value to be an array of size:

--- a/src/matchers/toBeExtensible/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeExtensible/__snapshots__/index.test.js.snap
@@ -1,6 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toBeExtensible fails when given an extensible object:  1`] = `
+exports[`.not.toBeExtensible fails when given an extensible object: () => {} 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toBeExtensible(</><dim>)</>
+
+Expected value to not be extensible received:
+  <green>[Function anonymous]</>
+"
+`;
+
+exports[`.not.toBeExtensible fails when given an extensible object: [] 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBeExtensible(</><dim>)</>
 
 Expected value to not be extensible received:
@@ -8,19 +16,11 @@ Expected value to not be extensible received:
 "
 `;
 
-exports[`.not.toBeExtensible fails when given an extensible object: [object Object] 1`] = `
+exports[`.not.toBeExtensible fails when given an extensible object: {} 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBeExtensible(</><dim>)</>
 
 Expected value to not be extensible received:
   <green>{}</>
-"
-`;
-
-exports[`.not.toBeExtensible fails when given an extensible object: undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeExtensible(</><dim>)</>
-
-Expected value to not be extensible received:
-  <green>[Function anonymous]</>
 "
 `;
 
@@ -31,14 +31,14 @@ Expected value to be extensible received:
   <red>\\"\\"</>"
 `;
 
-exports[`.toBeExtensible fails when not given an extensible object: [object Object] 1`] = `
+exports[`.toBeExtensible fails when not given an extensible object: {} 1`] = `
 "<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
 
 Expected value to be extensible received:
   <red>{}</>"
 `;
 
-exports[`.toBeExtensible fails when not given an extensible object: [object Object] 2`] = `
+exports[`.toBeExtensible fails when not given an extensible object: {} 2`] = `
 "<dim>expect(</><red>received</><dim>).toBeExtensible(</><dim>)</>
 
 Expected value to be extensible received:

--- a/src/matchers/toBeObject/__snapshots__/index.test.js.snap
+++ b/src/matchers/toBeObject/__snapshots__/index.test.js.snap
@@ -14,18 +14,25 @@ Expected value to be an object, received:
   <red>\\"\\"</>"
 `;
 
+exports[`.toBeObject fails when not given an object: () => {} 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+
+Expected value to be an object, received:
+  <red>[Function anonymous]</>"
+`;
+
+exports[`.toBeObject fails when not given an object: [ 1, 2, 3 ] 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
+
+Expected value to be an object, received:
+  <red>[1, 2, 3]</>"
+`;
+
 exports[`.toBeObject fails when not given an object: 0 1`] = `
 "<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
 
 Expected value to be an object, received:
   <red>0</>"
-`;
-
-exports[`.toBeObject fails when not given an object: 1,2,3 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
-
-Expected value to be an object, received:
-  <red>[1, 2, 3]</>"
 `;
 
 exports[`.toBeObject fails when not given an object: NaN 1`] = `
@@ -43,13 +50,6 @@ Expected value to be an object, received:
 `;
 
 exports[`.toBeObject fails when not given an object: undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
-
-Expected value to be an object, received:
-  <red>[Function anonymous]</>"
-`;
-
-exports[`.toBeObject fails when not given an object: undefined 2`] = `
 "<dim>expect(</><red>received</><dim>).toBeObject(</><dim>)</>
 
 Expected value to be an object, received:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,14 +3466,7 @@ jest-docblock@^24.3.0:
   dependencies:
     detect-newline "^2.1.0"
 
-jest-each@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-0.5.0.tgz#7065a599e18349163d0dcde40f49f09df6901666"
-  integrity sha512-RPd4mCqO6tW5eJBeX/7VT7WKAy+8NpCuW/3/wFJsc9BjI55KEssYwH3nu8kOsZmEwM1MGzAprWpNw4u6V5R7Nw==
-  dependencies:
-    sprintf-js "^1.0.3"
-
-jest-each@^24.9.0:
+jest-each@^24.0.0, jest-each@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.9.0.tgz#eb2da602e2a610898dbc5f1f6df3ba86b55f8b05"
   integrity sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==
@@ -5285,11 +5278,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
-
-sprintf-js@^1.0.3:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
-  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Serialization in the version that ships with Jest is better, thus the sorting moves things around a bit