### PR TITLE
chore: use built-in version of jest-each in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "husky": "^7.0.1",
     "import-all.macro": "^2.0.3",
     "jest": "^24.0.0",
-    "jest-each": "^24.0.0",
     "jest-watch-typeahead": "^0.6.0",
     "lint-staged": "^11.0.0",
     "prettier": "^2.3.2",

--- a/src/matchers/toBeArray/index.test.js
+++ b/src/matchers/toBeArray/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -15,7 +13,7 @@ describe('.toBeArray', () => {
 });
 
 describe('.not.toBeArray', () => {
-  each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]])(
     'passes when not given an array: %s',
     given => {
       expect(given).not.toBeArray();

--- a/src/matchers/toBeArray/predicate.test.js
+++ b/src/matchers/toBeArray/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeArray Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeArray Predicate', () => {
     expect(predicate(['an array'])).toBe(true);
   });
 
-  each([[false], [''], [0], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [''], [0], [{}], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeArrayOfSize/index.test.js
+++ b/src/matchers/toBeArrayOfSize/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -22,7 +20,7 @@ describe('.toBeArrayOfSize', () => {
     expect(() => expect(false).toBeArrayOfSize(1)).toThrowErrorMatchingSnapshot();
   });
 
-  each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]])(
     'fails when given type of %s which is not an array',
     given => {
       expect(() => expect(given).toBeArrayOfSize(1)).toThrowErrorMatchingSnapshot();
@@ -43,12 +41,9 @@ describe('.toBeArrayOfSize', () => {
 });
 
 describe('.not.toBeArrayOfSize', () => {
-  each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]]).test(
-    'passes when not given an array: %s',
-    given => {
-      expect(given).not.toBeArrayOfSize(2);
-    },
-  );
+  test.each([false, true, 0, {}, () => {}, undefined, null, NaN])('passes when not given an array: %s', given => {
+    expect(given).not.toBeArrayOfSize(2);
+  });
   {
     const size = 0;
     test(`fails when given an array of size ${size}`, () => {

--- a/src/matchers/toBeArrayOfSize/predicate.test.js
+++ b/src/matchers/toBeArrayOfSize/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeArrayOfSize Predicate', () => {
@@ -7,7 +6,7 @@ describe('toBeArrayOfSize Predicate', () => {
     expect(predicate([1, 2, 3, 4, 5], size)).toBe(true);
   });
 
-  each([
+  test.each([
     [[false], 0],
     [[''], -1],
     [[0], 6],
@@ -16,7 +15,7 @@ describe('toBeArrayOfSize Predicate', () => {
     [[undefined], 6],
     [[null], 6],
     [[NaN], 6],
-  ]).test('returns false when given: %s', (array, size) => {
+  ])('returns false when given: %s', (array, size) => {
     expect(predicate(array, size)).toBe(false);
   });
 });

--- a/src/matchers/toBeBoolean/index.test.js
+++ b/src/matchers/toBeBoolean/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -27,7 +25,7 @@ describe('.toBeBoolean', () => {
 });
 
 describe('.not.toBeBoolean', () => {
-  each([['true'], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([['true'], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'passes when item is not of type boolean: %s',
     given => {
       expect(given).not.toBeBoolean();

--- a/src/matchers/toBeBoolean/predicate.test.js
+++ b/src/matchers/toBeBoolean/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeBoolean', () => {
@@ -10,7 +9,7 @@ describe('toBeBoolean', () => {
     expect(predicate(new Boolean(false))).toBe(true);
   });
 
-  each([['false'], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([['false'], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeDate/index.test.js
+++ b/src/matchers/toBeDate/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -15,7 +13,7 @@ describe('.toBeDate', () => {
 });
 
 describe('.not.toBeDate', () => {
-  each([[false], [true], [0], [''], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [true], [0], [''], [{}], [() => {}], [undefined], [null], [NaN]])(
     'passes when not given a date: %s',
     given => {
       expect(given).not.toBeDate();

--- a/src/matchers/toBeDate/predicate.test.js
+++ b/src/matchers/toBeDate/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeDate Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeDate Predicate', () => {
     expect(predicate(new Date('12/25/2017'))).toBe(true);
   });
 
-  each([[true], [false], [''], [0], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[true], [false], [''], [0], [{}], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeEven/index.test.js
+++ b/src/matchers/toBeEven/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -9,7 +7,7 @@ describe('.toBeEven', () => {
     expect(2).toBeEven();
   });
 
-  each([[false], [true], [''], [1], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [true], [''], [1], [{}], [() => {}], [undefined], [null], [NaN]])(
     'fails when not given an even number',
     given => {
       expect(() => expect(given).toBeEven()).toThrowErrorMatchingSnapshot();
@@ -22,7 +20,7 @@ describe('.not.toBeEven', () => {
     expect(() => expect(2).not.toBeEven()).toThrowErrorMatchingSnapshot();
   });
 
-  each([[false], [true], [''], [1], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [true], [''], [1], [[]], [{}], [() => {}], [undefined], [null], [NaN]])(
     'passes when not given an even number: %s',
     given => {
       expect(given).not.toBeEven();

--- a/src/matchers/toBeEven/predicate.test.js
+++ b/src/matchers/toBeEven/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeEven Predicate', () => {
@@ -10,7 +9,7 @@ describe('toBeEven Predicate', () => {
     expect(predicate(1)).toBe(false);
   });
 
-  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeExtensible/index.test.js
+++ b/src/matchers/toBeExtensible/index.test.js
@@ -1,15 +1,13 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
 
 describe('.toBeExtensible', () => {
-  each([[{}], [[]], [() => {}]]).test('passes when given an extensible object: %s', given => {
+  test.each([{}, [], () => {}])('passes when given an extensible object: %s', given => {
     expect(given).toBeExtensible();
   });
 
-  each([[false], [''], [0], [undefined], [null], [NaN], [Object.seal({})], [Object.freeze({})]]).test(
+  test.each([[false], [''], [0], [undefined], [null], [NaN], [Object.seal({})], [Object.freeze({})]])(
     'fails when not given an extensible object: %s',
     given => {
       expect(() => expect(given).toBeExtensible()).toThrowErrorMatchingSnapshot();
@@ -18,14 +16,14 @@ describe('.toBeExtensible', () => {
 });
 
 describe('.not.toBeExtensible', () => {
-  each([[false], [''], [0], [undefined], [null], [NaN], [Object.seal({})], [Object.freeze({})]]).test(
+  test.each([[false], [''], [0], [undefined], [null], [NaN], [Object.seal({})], [Object.freeze({})]])(
     'passes when not given extensible object: %s',
     given => {
       expect(given).not.toBeExtensible();
     },
   );
 
-  each([[{}], [[]], [() => {}]]).test('fails when given an extensible object: %s', given => {
+  test.each([[{}], [[]], [() => {}]])('fails when given an extensible object: %s', given => {
     expect(() => expect(given).not.toBeExtensible()).toThrowErrorMatchingSnapshot();
   });
 });

--- a/src/matchers/toBeExtensible/predicate.test.js
+++ b/src/matchers/toBeExtensible/predicate.test.js
@@ -1,12 +1,11 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeExpected Predicate', () => {
-  each([[{}], [[]], [() => {}]]).test('returns true when given extensible object: %s', given => {
+  test.each([[{}], [[]], [() => {}]])('returns true when given extensible object: %s', given => {
     expect(predicate(given)).toBe(true);
   });
 
-  each([[false], [''], [0], [undefined], [null], [NaN], [Object.seal({})], [Object.freeze({})]]).test(
+  test.each([[false], [''], [0], [undefined], [null], [NaN], [Object.seal({})], [Object.freeze({})]])(
     'returns false when given non-extensible object: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeFalse/index.test.js
+++ b/src/matchers/toBeFalse/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -15,7 +13,7 @@ describe('.toBeFalse', () => {
 });
 
 describe('.not.toBeFalse', () => {
-  each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'passes when not given false: %s',
     given => {
       expect(given).not.toBeFalse();

--- a/src/matchers/toBeFalse/predicate.test.js
+++ b/src/matchers/toBeFalse/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeFalse Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeFalse Predicate', () => {
     expect(predicate(false)).toBe(true);
   });
 
-  each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[true], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeFunction/index.test.js
+++ b/src/matchers/toBeFunction/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -15,7 +13,7 @@ describe('.toBeFunction', () => {
 });
 
 describe('.not.toBeFunction', () => {
-  each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]]).test(
+  test.each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]])(
     'passes when not given a function: %s',
     given => {
       expect(given).not.toBeFunction();

--- a/src/matchers/toBeFunction/predicate.test.js
+++ b/src/matchers/toBeFunction/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeFunction Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeFunction Predicate', () => {
     expect(predicate(() => {})).toBe(true);
   });
 
-  each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]]).test('returns false when given: %s', given => {
+  test.each([[false], [''], [0], [{}], [[]], [undefined], [null], [NaN]])('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeNaN/index.test.js
+++ b/src/matchers/toBeNaN/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -15,7 +13,7 @@ describe('.toBeNaN', () => {
 });
 
 describe('.not.toBeNaN', () => {
-  each([[0], [1], [300], [10.5], [-50]]).test('passes when given a number: %s', given => {
+  test.each([[0], [1], [300], [10.5], [-50]])('passes when given a number: %s', given => {
     expect(given).not.toBeNaN();
   });
 

--- a/src/matchers/toBeNaN/predicate.test.js
+++ b/src/matchers/toBeNaN/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeNaN Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeNaN Predicate', () => {
     expect(predicate({})).toBe(true);
   });
 
-  each([[0], [1], [300], [10.5], [-50]]).test('returns false when given: %s', given => {
+  test.each([[0], [1], [300], [10.5], [-50]])('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeNil/index.test.js
+++ b/src/matchers/toBeNil/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -18,7 +16,7 @@ describe('.toBeNil', () => {
 });
 
 describe('.not.toBeNil', () => {
-  each([['true'], [{}], [true]]).test('passes when value is not null or undefined : %s', given => {
+  test.each([['true'], [{}], [true]])('passes when value is not null or undefined : %s', given => {
     expect(given).not.toBeNil();
   });
 

--- a/src/matchers/toBeNil/predicate.test.js
+++ b/src/matchers/toBeNil/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeNil', () => {
@@ -10,7 +9,7 @@ describe('toBeNil', () => {
     expect(predicate(null)).toBe(true);
   });
 
-  each([['false'], [['hello', 'world']], [{ hello: 'world' }]]).test('returns false when given: %s', given => {
+  test.each([['false'], [['hello', 'world']], [{ hello: 'world' }]])('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeNumber/index.test.js
+++ b/src/matchers/toBeNumber/index.test.js
@@ -1,17 +1,15 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
 
 describe('.toBeNumber', () => {
-  each`
-  number
-  ${10}
-  ${NaN}
-  ${Infinity}
-  ${-Infinity}
-  `.test('passes when given: $number', ({ number }) => {
+  test.each`
+    number
+    ${10}
+    ${NaN}
+    ${Infinity}
+    ${-Infinity}
+  `('passes when given: $number', ({ number }) => {
     expect(number).toBeNumber();
   });
 
@@ -21,7 +19,7 @@ describe('.toBeNumber', () => {
 });
 
 describe('.not.toBeNumber', () => {
-  each([[false], [true], [[]], [{}], [() => {}], [undefined], [null], ['10']]).test(
+  test.each([[false], [true], [[]], [{}], [() => {}], [undefined], [null], ['10']])(
     'passes when not given a number: %s',
     given => {
       expect(given).not.toBeNumber();

--- a/src/matchers/toBeNumber/predicate.test.js
+++ b/src/matchers/toBeNumber/predicate.test.js
@@ -1,18 +1,17 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeNumber Predicate', () => {
-  each`
+  test.each`
     number
     ${10}
     ${NaN}
     ${Infinity}
     ${-Infinity}
-  `.test('returns true when given: $number', ({ number }) => {
+  `('returns true when given: $number', ({ number }) => {
     expect(predicate(number)).toBe(true);
   });
 
-  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], ['10']]).test(
+  test.each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], ['10']])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeObject/index.test.js
+++ b/src/matchers/toBeObject/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -9,7 +7,7 @@ describe('.toBeObject', () => {
     expect({}).toBeObject();
   });
 
-  each([[false], [''], [0], [() => {}], [undefined], [NaN], [[1, 2, 3]]]).test(
+  test.each([[false], [''], [0], [() => {}], [undefined], [NaN], [[1, 2, 3]]])(
     'fails when not given an object: %s',
     given => {
       expect(() => expect(given).toBeObject()).toThrowErrorMatchingSnapshot();
@@ -18,7 +16,7 @@ describe('.toBeObject', () => {
 });
 
 describe('.not.toBeObject', () => {
-  each([[false], [''], [0], [() => {}], [undefined], [NaN], [[1, 2, 3]]]).test(
+  test.each([[false], [''], [0], [() => {}], [undefined], [NaN], [[1, 2, 3]]])(
     'passes when not given an object: %s',
     given => {
       expect(given).not.toBeObject();

--- a/src/matchers/toBeObject/predicate.test.js
+++ b/src/matchers/toBeObject/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeObject Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeObject Predicate', () => {
     expect(predicate({})).toBe(true);
   });
 
-  each([[false], [''], [0], [() => {}], [undefined], [NaN]]).test('returns false when given: %s', given => {
+  test.each([[false], [''], [0], [() => {}], [undefined], [NaN]])('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toBeOdd/index.test.js
+++ b/src/matchers/toBeOdd/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -9,7 +7,7 @@ describe('.toBeOdd', () => {
     expect(1).toBeOdd();
   });
 
-  each([[false], [true], [''], [2], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [true], [''], [2], [{}], [() => {}], [undefined], [null], [NaN]])(
     'fails when given not given an odd number',
     given => {
       expect(() => expect(given).toBeOdd()).toThrowErrorMatchingSnapshot();
@@ -18,7 +16,7 @@ describe('.toBeOdd', () => {
 });
 
 describe('.not.toBeOdd', () => {
-  each([[false], [true], [''], [2], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [true], [''], [2], [[]], [{}], [() => {}], [undefined], [null], [NaN]])(
     'passes when not given an odd number: %s',
     given => {
       expect(given).not.toBeOdd();

--- a/src/matchers/toBeOdd/predicate.test.js
+++ b/src/matchers/toBeOdd/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeOdd Predicate', () => {
@@ -10,7 +9,7 @@ describe('toBeOdd Predicate', () => {
     expect(predicate(2)).toBe(false);
   });
 
-  each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [''], [[]], [{}], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeOneOf/predicate.test.js
+++ b/src/matchers/toBeOneOf/predicate.test.js
@@ -1,19 +1,18 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('.toBeOneOf', () => {
-  each([[1], [null], [undefined], [false], ['']]).test(
+  test.each([[1], [null], [undefined], [false], ['']])(
     'returns true when primitive value: %s is in given array',
     value => {
       expect(predicate(value, [1, 2, 3, null, undefined, false, ''])).toBe(true);
     },
   );
 
-  each([[{ hello: 'world' }], [['foo']]]).test('returns true when nested value: %s is in given array', value => {
+  test.each([[{ hello: 'world' }], [['foo']]])('returns true when nested value: %s is in given array', value => {
     expect(predicate(value, [1, 2, { hello: 'world' }, ['foo']])).toBe(true);
   });
 
-  each([[0], [null], [undefined], [false], [''], [{ hello: 'world' }], [['foo']]]).test(
+  test.each([[0], [null], [undefined], [false], [''], [{ hello: 'world' }], [['foo']]])(
     'returns false when value: %s is not in given array',
     value => {
       expect(predicate(value, [1, 2, 3])).toBe(false);

--- a/src/matchers/toBePositive/index.test.js
+++ b/src/matchers/toBePositive/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -15,7 +13,7 @@ describe('.toBePositive', () => {
 });
 
 describe('.not.toBePositive', () => {
-  each([[false], [''], [-1], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN], [Infinity]]).test(
+  test.each([[false], [''], [-1], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN], [Infinity]])(
     'passes when not given a positive number: %s',
     given => {
       expect(given).not.toBePositive();

--- a/src/matchers/toBePositive/predicate.test.js
+++ b/src/matchers/toBePositive/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBePositive Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBePositive Predicate', () => {
     expect(predicate(1)).toBe(true);
   });
 
-  each([[false], [''], [-1], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN], [Infinity]]).test(
+  test.each([[false], [''], [-1], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN], [Infinity]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeString/index.test.js
+++ b/src/matchers/toBeString/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -19,7 +17,7 @@ describe('.toBeString', () => {
 });
 
 describe('.not.toBeString', () => {
-  each([[false], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'passes when not item is not of type string: %s',
     given => {
       expect(given).not.toBeString();

--- a/src/matchers/toBeString/predicate.test.js
+++ b/src/matchers/toBeString/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeString Predicate', () => {
@@ -10,7 +9,7 @@ describe('toBeString Predicate', () => {
     expect(predicate(new String('string example'))).toBe(true);
   });
 
-  each([[false], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeTrue/index.test.js
+++ b/src/matchers/toBeTrue/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -15,7 +13,7 @@ describe('.toBeTrue', () => {
 });
 
 describe('.not.toBeTrue', () => {
-  each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'passes when not given true: %s',
     given => {
       expect(given).not.toBeTrue();

--- a/src/matchers/toBeTrue/predicate.test.js
+++ b/src/matchers/toBeTrue/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeTrue Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeTrue Predicate', () => {
     expect(predicate(true)).toBe(true);
   });
 
-  each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]]).test(
+  test.each([[false], [''], [0], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
     'returns false when given: %s',
     given => {
       expect(predicate(given)).toBe(false);

--- a/src/matchers/toBeValidDate/index.test.js
+++ b/src/matchers/toBeValidDate/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import matcher from './';
 
 expect.extend(matcher);
@@ -19,7 +17,7 @@ describe('.toBeValidDate', () => {
 });
 
 describe('.not.toBeValidDate', () => {
-  each([
+  test.each([
     [new Date('01/90/2018')],
     [new Date('32/01/2018')],
     [false],
@@ -31,7 +29,7 @@ describe('.not.toBeValidDate', () => {
     [undefined],
     [null],
     [NaN],
-  ]).test('passes when not given a date: %s', given => {
+  ])('passes when not given a date: %s', given => {
     expect(given).not.toBeValidDate();
   });
 

--- a/src/matchers/toBeValidDate/predicate.test.js
+++ b/src/matchers/toBeValidDate/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toBeDate Predicate', () => {
@@ -6,7 +5,7 @@ describe('toBeDate Predicate', () => {
     expect(predicate(new Date('12/25/2017'))).toBe(true);
   });
 
-  each([
+  test.each([
     [new Date('01/90/2018')],
     [new Date('32/01/2018')],
     [true],
@@ -18,7 +17,7 @@ describe('toBeDate Predicate', () => {
     [undefined],
     [null],
     [NaN],
-  ]).test('returns false when given: %s', given => {
+  ])('returns false when given: %s', given => {
     expect(predicate(given)).toBe(false);
   });
 });

--- a/src/matchers/toContainValue/predicate.test.js
+++ b/src/matchers/toContainValue/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toContainValue Predicate', () => {
@@ -7,7 +6,7 @@ describe('toContainValue Predicate', () => {
   const deepArray = { message: [{ hello: 'world' }] };
 
   describe('returns true', () => {
-    each([['world'], [false], [undefined], [null], [''], [0]]).test(
+    test.each([['world'], [false], [undefined], [null], [''], [0]])(
       'when given object contains primitive value: %s',
       value => {
         expect(predicate(shallow, value)).toBe(true);
@@ -24,7 +23,7 @@ describe('toContainValue Predicate', () => {
   });
 
   describe('returns false', () => {
-    each([['world'], [false], [undefined], [null], [''], [0]]).test(
+    test.each([['world'], [false], [undefined], [null], [''], [0]])(
       'when given object does not contain primitive value: %s',
       value => {
         expect(predicate({}, value)).toBe(false);

--- a/src/matchers/toIncludeAnyMembers/predicate.test.js
+++ b/src/matchers/toIncludeAnyMembers/predicate.test.js
@@ -1,4 +1,3 @@
-import each from 'jest-each';
 import predicate from './predicate';
 
 describe('toIncludeAnyMembers Predicate', () => {
@@ -6,7 +5,7 @@ describe('toIncludeAnyMembers Predicate', () => {
   const shallow = { hello: 'world' };
 
   describe('returns true', () => {
-    each([['world'], [false], [undefined], [null], [''], [0]]).test(
+    test.each([['world'], [false], [undefined], [null], [''], [0]])(
       'when given array contains primitive value: %s',
       given => {
         expect(predicate([given], array)).toBe(true);

--- a/src/utils/index.test.js
+++ b/src/utils/index.test.js
@@ -1,5 +1,3 @@
-import each from 'jest-each';
-
 import { contains, determinePropertyMessage } from './';
 
 describe('Utils', () => {
@@ -8,11 +6,11 @@ describe('Utils', () => {
     const array = [1, 0, '', 'hello', false, true, undefined, null, NaN, fn, { foo: 'bar' }, ['foo']];
     const testRows = array.map(item => [item]);
 
-    each(testRows).test('returns true when array contains given value: %s', value => {
+    test.each(testRows)('returns true when array contains given value: %s', value => {
       expect(contains(array, value)).toBe(true);
     });
 
-    each(testRows).test('returns false when array does not contain given value: %s', value => {
+    test.each(testRows)('returns false when array does not contain given value: %s', value => {
       expect(contains([], value)).toBe(false);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3466,7 +3466,7 @@ jest-docblock@^24.3.0:
   dependencies:
     detect-newline "^2.1.0"
 
-jest-each@^24.0.0, jest-each@^24.9.0:
+jest-each@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-24.9.0.tgz#eb2da602e2a610898dbc5f1f6df3ba86b55f8b05"
   integrity sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==


### PR DESCRIPTION
Jest ships with `test.each` - let's use that instead of explicit `test-each` dependency