### PR TITLE
Fix toIncludeAllPartialMembers type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,7 +74,7 @@ declare namespace jest {
      * Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
      * @param {Array.<*>} members
      */
-    toIncludeAllMembers(members: any[]): R;
+    toIncludeAllPartialMembers(members: any[]): R;
 
     /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

Fixed duplicate type definition to contain a proper one

### What

<!-- Why are these changes necessary? Link any related issues -->
It is not possible to use toIncludeAllPartialMembers in Typescript code

### Why

<!-- If necessary add any additional notes on the implementation -->

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
