### PR TITLE
fix: toIncludeAllPartialMembers types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -74,7 +74,7 @@ declare namespace jest {
      * Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
      * @param {Array.<*>} members
      */
-    toIncludeAllPartialMembers(members: any[]): R;
+    toIncludeAllPartialMembers<E = any>(members: E[]): R;
 
     /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.


### PR DESCRIPTION
Fixes the faulty copy/paste [here](https://github.com/jest-community/jest-extended/commit/32afe6f9209abc5097a340ac20f56f47009e05b2#diff-093ad82a25aee498b11febf1cdcb6546e4d223ffcb49ed69cc275ac27ce0ccceR77) 😅 
