### PR TITLE
fix(toIncludeAllPartialMembers): includes all member entries

### DIFF
--- a/src/matchers/toContainAllEntries/predicate.js
+++ b/src/matchers/toContainAllEntries/predicate.js
@@ -1,9 +1,9 @@
-import { equals } from '../../utils';
+import toContainEntries from '../toContainEntries/predicate';
 
 export default (obj, entries) => {
   if (!obj.hasOwnProperty || entries.length != Object.keys(obj).length) {
     return false;
   }
 
-  return entries.every(([key, value]) => Object.prototype.hasOwnProperty.call(obj, key) && equals(obj[key], value));
+  return toContainEntries(obj, entries);
 };

--- a/src/matchers/toContainEntries/predicate.js
+++ b/src/matchers/toContainEntries/predicate.js
@@ -1,4 +1,3 @@
-import { equals } from '../../utils';
+import toContainEntry from '../toContainEntry/predicate';
 
-export default (obj, entries) =>
-  entries.every(([key, value]) => Object.prototype.hasOwnProperty.call(obj, key) && equals(obj[key], value));
+export default (obj, entries) => entries.every(entry => toContainEntry(obj, entry));

--- a/src/matchers/toIncludeAllPartialMembers/predicate.js
+++ b/src/matchers/toIncludeAllPartialMembers/predicate.js
@@ -1,6 +1,6 @@
-import toContainAnyEntries from '../toContainAnyEntries/predicate';
+import toContainEntries from '../toContainEntries/predicate';
 
 export default (array, set) =>
   Array.isArray(array) &&
   Array.isArray(set) &&
-  set.every(partial => array.some(value => toContainAnyEntries(value, Object.entries(partial))));
+  set.every(partial => array.some(value => toContainEntries(value, Object.entries(partial))));

--- a/src/matchers/toIncludeAllPartialMembers/predicate.test.js
+++ b/src/matchers/toIncludeAllPartialMembers/predicate.test.js
@@ -8,8 +8,14 @@ describe('toIncludeAllPartialMembers Predicate', () => {
   });
 
   describe('returns false', () => {
+    test('when Array contains does not contain all of the same nested partial members of given item', () => {
+      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'bar', bax: 'qux' }])).toBe(false);
+    });
+
     test('when Array contains does not contain all of the same nested partial members of given set', () => {
-      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ foo: 'qux' }])).toBe(false);
+      expect(predicate([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }], [{ hello: 'world' }, { foo: 'qux' }])).toBe(
+        false,
+      );
     });
   });
 });


### PR DESCRIPTION
### What

`toIncludeAllPartialMembers` does not check **ALL** members exists, but rather it checks **ANY**.

### Why

According to [the docs](https://github.com/jest-community/jest-extended#toincludeallpartialmembersmembers), toIncludeAllPartialMembers checks if an array contains **all** of the same partial members of a given set.

### Notes
- I noticed repeating code on the `toContainEntries` matchers, so reused existing predicates.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
