### PR TITLE
Fix typescript for toBeDateString and toBeHexadecimal (#381)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -131,18 +131,14 @@ declare namespace jest {
     toBeFunction(): R;
 
     /**
-    * Use `.toBeDateString` when checking if a value is a valid date string.
-    *
-    * @param {String} string
-    */
-    toBeDateString(string: string): R;
+     * Use `.toBeDateString` when checking if a value is a valid date string.
+     */
+    toBeDateString(): R;
 
     /**
      * Use `.toBeHexadecimal` when checking if a value is a valid HTML hex color.
-     *
-     * @param {String} string
      */
-    toBeHexadecimal(string: string): R;
+    toBeHexadecimal(): R;
 
     /**
      * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
@@ -414,7 +410,7 @@ declare namespace jest {
      *
      * @param {String} string
      */
-     toEqualIgnoringWhitespace(string: string): R;
+    toEqualIgnoringWhitespace(string: string): R;
   }
 
   // noinspection JSUnusedGlobalSymbols
@@ -541,18 +537,14 @@ declare namespace jest {
     toBeFunction(): any;
 
     /**
-    * Use `.toBeDateString` when checking if a value is a valid date string.
-    *
-    * @param {String} string
-    */
-    toBeDateString(string: string): any;
+     * Use `.toBeDateString` when checking if a value is a valid date string.
+     */
+    toBeDateString(): any;
 
     /**
      * Use `.toBeHexadecimal` when checking if a value is a valid HTML hex color.
-     *
-     * @param {String} string
      */
-    toBeHexadecimal(string: string): any;
+    toBeHexadecimal(): any;
 
     /**
      * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
@@ -824,6 +816,6 @@ declare namespace jest {
      *
      * @param {String} string
      */
-     toEqualIgnoringWhitespace(string: string): any;
+    toEqualIgnoringWhitespace(string: string): any;
   }
 }


### PR DESCRIPTION
### What

Remove the parameters from the typescript declarations of `toBeDateString` and `toBeHexadecimal` to match the actual implementations. Also fix the indentation of the doc comments for `toBeDateString` and declarations of `toEqualIgnoringWhitespace`.

### Why

I'm getting warnings about missing parameters in WebStorm even though the functions work fine.

### Notes

Not sure if you need unit tests for this. It's a pretty obvious fix.

### Housekeeping

- [ ] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
