### PR TITLE
Declare matchers for use with expect.not.MATCHER (#385)

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -845,4 +845,8 @@ declare namespace jest {
      */
     toEqualIgnoringWhitespace(string: string): any;
   }
+
+  // noinspection JSUnusedGlobalSymbols
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface InverseAsymmetricMatchers extends Expect {}
 }


### PR DESCRIPTION
### What

Move asymmetric matcher declarations to a new `AsymmetricMatchers` interface and extend that to add matchers to `Expect` and `InverseAsymmetricMatchers`.

### Why

This provides autocompletion when using `expect.not`, for example:

```
const value = {
  name: 'foobar',
};
expect(value).toEqual({
  name: expect.not.toStartWith('bar')
});
```

### Notes

This may not play nicely with actual TypeScript projects, but I do not have experience with that to verify. I didn't add any unit tests since I didn't change any code. TypeScript tests would be very useful for the project as a whole.

### Housekeeping

- [ ] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
