### PR TITLE
fix: add missing types for toPartiallyContain

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -501,6 +501,12 @@ declare namespace jest {
     toIncludeSameMembers<E = any>(members: E[]): any;
 
     /**
+     * Use `.toPartiallyContain` when checking if any array value matches the partial member.
+     * @param {*} member
+     */
+    toPartiallyContain<E = any>(member: E): any;
+    
+    /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
      * @param {Function} predicate
      */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -89,6 +89,12 @@ declare namespace jest {
     toIncludeSameMembers<E = any>(members: E[]): R;
 
     /**
+     * Use `.toPartiallyContain` when checking if any array value matches the partial member.
+     * @param {*} member
+     */
+    toPartiallyContain<E = any>(member: E): R;
+
+    /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
      * @param {Function} predicate
      */


### PR DESCRIPTION
### What
Missing types for a newly added matcher.