### PR TITLE
fix: add missing type in matchers toBeEmptyObject

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -388,6 +388,11 @@ declare namespace jest {
     toThrowWithMessage(type: Function, message: string | RegExp): R;
 
     /**
+     * Use `.toBeEmptyObject` when checking if a value is an empty `Object`.
+     */
+    toBeEmptyObject(): R;
+
+    /**
      * Use `.toBeSymbol` when checking if a value is a `Symbol`.
      */
     toBeSymbol(): R;
@@ -505,7 +510,7 @@ declare namespace jest {
      * @param {*} member
      */
     toPartiallyContain<E = any>(member: E): any;
-    
+
     /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
      * @param {Function} predicate


### PR DESCRIPTION
### What

Is not defined in Matchers interface.

### Why

If don't add, typescript it won't recognize this matcher.

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
