### PR TITLE
fix: remove disguised type assertion

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,16 +6,12 @@ declare namespace jest {
     /**
      * Note: Currently unimplemented
      * Passing assertion
-     *
-     * @param {String} message
      */
     pass(message: string): R;
 
     /**
      * Note: Currently unimplemented
      * Failing assertion
-     *
-     * @param {String} message
      */
     fail(message: string): never;
 
@@ -26,7 +22,6 @@ declare namespace jest {
 
     /**
      * Use .toBeOneOf when checking if a value is a member of a given Array.
-     * @param {Array.<*>} members
      */
     toBeOneOf<E = any>(members: E[]): R;
 
@@ -37,7 +32,6 @@ declare namespace jest {
 
     /**
      * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
-     * @param {Function} predicate
      */
     toSatisfy<E = any>(predicate: (x: E) => boolean): R;
 
@@ -48,61 +42,51 @@ declare namespace jest {
 
     /**
      * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
-     * @param {Number} x
      */
     toBeArrayOfSize(x: number): R;
 
     /**
      * Use `.toBeAfter` when checking if a date occurs after `date`.
-     * @param {Date} date
      */
     toBeAfter(date: Date): R;
 
     /**
      * Use `.toBeBefore` when checking if a date occurs before `date`.
-     * @param {Date} date
      */
     toBeBefore(date: Date): R;
 
     /**
      * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
-     * @param {Array.<*>} members
      */
     toIncludeAllMembers<E = any>(members: E[]): R;
 
     /**
      * Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
-     * @param {Array.<*>} members
      */
     toIncludeAllPartialMembers<E = any>(members: E[]): R;
 
     /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
-     * @param {Array.<*>} members
      */
     toIncludeAnyMembers<E = any>(members: E[]): R;
 
     /**
      * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
-     * @param {Array.<*>} members
      */
     toIncludeSameMembers<E = any>(members: E[]): R;
 
     /**
      * Use `.toPartiallyContain` when checking if any array value matches the partial member.
-     * @param {*} member
      */
     toPartiallyContain<E = any>(member: E): R;
 
     /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
-     * @param {Function} predicate
      */
     toSatisfyAll<E = any>(predicate: (x: E) => boolean): R;
 
     /**
      * Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns `true` for any matching value in an array.
-     * @param {Function} predicate
      */
     toSatisfyAny(predicate: (x: any) => boolean): R;
 
@@ -150,8 +134,6 @@ declare namespace jest {
      * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
      *
      * Note: Required Jest version >=23
-     *
-     * @param {Mock} mock
      */
     toHaveBeenCalledBefore(mock: jest.Mock): R;
 
@@ -159,8 +141,6 @@ declare namespace jest {
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
      *
      * Note: Required Jest version >=23
-     *
-     * @param {Mock} mock
      */
     toHaveBeenCalledAfter(mock: jest.Mock): R;
 
@@ -206,9 +186,6 @@ declare namespace jest {
 
     /**
      * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
-     *
-     * @param {Number} start
-     * @param {Number} end
      */
     toBeWithin(start: number, end: number): R;
 
@@ -224,85 +201,61 @@ declare namespace jest {
 
     /**
      * Use `.toContainKey` when checking if an object contains the provided key.
-     *
-     * @param {String} key
      */
     toContainKey<E = any>(key: keyof E | string): R;
 
     /**
      * Use `.toContainKeys` when checking if an object has all of the provided keys.
-     *
-     * @param {Array.<String>} keys
      */
     toContainKeys<E = any>(keys: (keyof E | string)[]): R;
 
     /**
      * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
-     *
-     * @param {Array.<String>} keys
      */
     toContainAllKeys<E = any>(keys: (keyof E | string)[]): R;
 
     /**
      * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
-     *
-     * @param {Array.<String>} keys
      */
     toContainAnyKeys<E = any>(keys: (keyof E | string)[]): R;
 
     /**
      * Use `.toContainValue` when checking if an object contains the provided value.
-     *
-     * @param {*} value
      */
     toContainValue<E = any>(value: E): R;
 
     /**
      * Use `.toContainValues` when checking if an object contains all of the provided values.
-     *
-     * @param {Array.<*>} values
      */
     toContainValues<E = any>(values: E[]): R;
 
     /**
      * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
-     *
-     * @param {Array.<*>} values
      */
     toContainAllValues<E = any>(values: E[]): R;
 
     /**
      * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
-     *
-     * @param {Array.<*>} values
      */
     toContainAnyValues<E = any>(values: E[]): R;
 
     /**
      * Use `.toContainEntry` when checking if an object contains the provided entry.
-     *
-     * @param {Array.<String, String>} entry
      */
     toContainEntry<E = any>(entry: [keyof E, E[keyof E]]): R;
 
     /**
      * Use `.toContainEntries` when checking if an object contains all of the provided entries.
-     *
-     * @param {Array.<Array.<keyof E, E[keyof E]>>} entries
      */
     toContainEntries<E = any>(entries: [keyof E, E[keyof E]][]): R;
 
     /**
      * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
-     *
-     * @param {Array.<Array.<keyof E, E[keyof E]>>} entries
      */
     toContainAllEntries<E = any>(entries: [keyof E, E[keyof E]][]): R;
 
     /**
      * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
-     *
-     * @param {Array.<Array.<keyof E, E[keyof E]>>} entries
      */
     toContainAnyEntries<E = any>(entries: [keyof E, E[keyof E]][]): R;
 
@@ -338,52 +291,36 @@ declare namespace jest {
 
     /**
      * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
-     *
-     * @param {String} string
      */
     toEqualCaseInsensitive(string: string): R;
 
     /**
      * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
-     *
-     * @param {String} prefix
      */
     toStartWith(prefix: string): R;
 
     /**
      * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
-     *
-     * @param {String} suffix
      */
     toEndWith(suffix: string): R;
 
     /**
      * Use `.toInclude` when checking if a `String` includes the given `String` substring.
-     *
-     * @param {String} substring
      */
     toInclude(substring: string): R;
 
     /**
      * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
-     *
-     * @param {String} substring
-     * @param {Number} times
      */
     toIncludeRepeated(substring: string, times: number): R;
 
     /**
      * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
-     *
-     * @param {Array.<String>} substring
      */
     toIncludeMultiple(substring: string[]): R;
 
     /**
      * Use `.toThrowWithMessage` when checking if a callback function throws an error of a given type with a given error message.
-     *
-     * @param {Function} type
-     * @param {String | RegExp} message
      */
     toThrowWithMessage(type: Function, message: string | RegExp): R;
 
@@ -394,27 +331,21 @@ declare namespace jest {
 
     /**
      * Use `.toBeBetween` when checking if a date occurs between `startDate` and `endDate`.
-     * @param {Date} startDate
-     * @param {Date} endDate
      */
     toBeBetween(startDate: Date, endDate: Date): R;
 
     /**
      * Use `.toBeBeforeOrEqualTo` when checking if a date equals to or occurs before `date`.
-     * @param {Date} date
      */
     toBeBeforeOrEqualTo(date: Date): R;
 
     /**
      * Use `.toBeAfterOrEqualTo` when checking if a date equals to or occurs after `date`.
-     * @param {Date} date
      */
     toBeAfterOrEqualTo(date: Date): R;
 
     /**
      * Use `.toEqualIgnoringWhitespace` when checking if a `String` is equal (===) to given `String` ignoring white-space.
-     *
-     * @param {String} string
      */
     toEqualIgnoringWhitespace(string: string): R;
   }
@@ -424,16 +355,12 @@ declare namespace jest {
     /**
      * Note: Currently unimplemented
      * Passing assertion
-     *
-     * @param {String} message
      */
     pass(message: string): any;
 
     /**
      * Note: Currently unimplemented
      * Failing assertion
-     *
-     * @param {String} message
      */
     fail(message: string): any;
 
@@ -444,7 +371,6 @@ declare namespace jest {
 
     /**
      * Use .toBeOneOf when checking if a value is a member of a given Array.
-     * @param {Array.<*>} members
      */
     toBeOneOf<E = any>(members: E[]): any;
 
@@ -455,7 +381,6 @@ declare namespace jest {
 
     /**
      * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
-     * @param {Function} predicate
      */
     toSatisfy<E = any>(predicate: (x: E) => boolean): any;
 
@@ -466,55 +391,46 @@ declare namespace jest {
 
     /**
      * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
-     * @param {Number} x
      */
     toBeArrayOfSize(x: number): any;
 
     /**
      * Use `.toBeAfter` when checking if a date occurs after `date`.
-     * @param {Date} date
      */
     toBeAfter(date: Date): any;
 
     /**
      * Use `.toBeBefore` when checking if a date occurs before `date`.
-     * @param {Date} date
      */
     toBeBefore(date: Date): any;
 
     /**
      * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
-     * @param {Array.<*>} members
      */
     toIncludeAllMembers<E = any>(members: E[]): any;
 
     /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
-     * @param {Array.<*>} members
      */
     toIncludeAnyMembers<E = any>(members: E[]): any;
 
     /**
      * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
-     * @param {Array.<*>} members
      */
     toIncludeSameMembers<E = any>(members: E[]): any;
 
     /**
      * Use `.toPartiallyContain` when checking if any array value matches the partial member.
-     * @param {*} member
      */
     toPartiallyContain<E = any>(member: E): any;
-    
+
     /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
-     * @param {Function} predicate
      */
     toSatisfyAll<E = any>(predicate: (x: E) => boolean): any;
 
     /**
      * Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns `true` for any matching value in an array.
-     * @param {Function} predicate
      */
     toSatisfyAny(predicate: (x: any) => boolean): any;
 
@@ -562,8 +478,6 @@ declare namespace jest {
      * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
      *
      * Note: Required Jest version >=23
-     *
-     * @param {Mock} mock
      */
     toHaveBeenCalledBefore(mock: jest.Mock): any;
 
@@ -571,8 +485,6 @@ declare namespace jest {
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
      *
      * Note: Required Jest version >=23
-     *
-     * @param {Mock} mock
      */
     toHaveBeenCalledAfter(mock: jest.Mock): any;
 
@@ -619,8 +531,6 @@ declare namespace jest {
     /**
      * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
      *
-     * @param {Number} start
-     * @param {Number} end
      */
     toBeWithin(start: number, end: number): any;
 
@@ -631,85 +541,61 @@ declare namespace jest {
 
     /**
      * Use `.toContainKey` when checking if an object contains the provided key.
-     *
-     * @param {String} key
      */
     toContainKey(key: string): any;
 
     /**
      * Use `.toContainKeys` when checking if an object has all of the provided keys.
-     *
-     * @param {Array.<String>} keys
      */
     toContainKeys<E = any>(keys: (keyof E | string)[]): any;
 
     /**
      * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
-     *
-     * @param {Array.<String>} keys
      */
     toContainAllKeys<E = any>(keys: (keyof E | string)[]): any;
 
     /**
      * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
-     *
-     * @param {Array.<String>} keys
      */
     toContainAnyKeys<E = any>(keys: (keyof E | string)[]): any;
 
     /**
      * Use `.toContainValue` when checking if an object contains the provided value.
-     *
-     * @param {*} value
      */
     toContainValue<E = any>(value: E): any;
 
     /**
      * Use `.toContainValues` when checking if an object contains all of the provided values.
-     *
-     * @param {Array.<*>} values
      */
     toContainValues<E = any>(values: E[]): any;
 
     /**
      * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
-     *
-     * @param {Array.<*>} values
      */
     toContainAllValues<E = any>(values: E[]): any;
 
     /**
      * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
-     *
-     * @param {Array.<*>} values
      */
     toContainAnyValues<E = any>(values: E[]): any;
 
     /**
      * Use `.toContainEntry` when checking if an object contains the provided entry.
-     *
-     * @param {Array.<[keyof E, E[keyof E]>} entry
      */
     toContainEntry<E = any>(entry: [keyof E, E[keyof E]]): any;
 
     /**
      * Use `.toContainEntries` when checking if an object contains all of the provided entries.
-     *
-     * @param {Array.<Array.<keyof E, E[keyof E]>>} entries
      */
     toContainEntries<E = any>(entries: [keyof E, E[keyof E]][]): any;
 
     /**
      * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
-     *
-     * @param {Array.<Array.<keyof E, E[keyof E]>>} entries
      */
     toContainAllEntries<E = any>(entries: [keyof E, E[keyof E]][]): any;
 
     /**
      * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
-     *
-     * @param {Array.<Array.<keyof E, E[keyof E]>>} entries
      */
     toContainAnyEntries<E = any>(entries: [keyof E, E[keyof E]][]): any;
 
@@ -745,52 +631,36 @@ declare namespace jest {
 
     /**
      * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
-     *
-     * @param {String} string
      */
     toEqualCaseInsensitive(string: string): any;
 
     /**
      * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
-     *
-     * @param {String} prefix
      */
     toStartWith(prefix: string): any;
 
     /**
      * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
-     *
-     * @param {String} suffix
      */
     toEndWith(suffix: string): any;
 
     /**
      * Use `.toInclude` when checking if a `String` includes the given `String` substring.
-     *
-     * @param {String} substring
      */
     toInclude(substring: string): any;
 
     /**
      * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
-     *
-     * @param {String} substring
-     * @param {Number} times
      */
     toIncludeRepeated(substring: string, times: number): any;
 
     /**
      * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
-     *
-     * @param {Array.<String>} substring
      */
     toIncludeMultiple(substring: string[]): any;
 
     /**
      * Use `.toThrowWithMessage` when checking if a callback function throws an error of a given type with a given error message.
-     *
-     * @param {Function} type
-     * @param {String | RegExp} message
      */
     toThrowWithMessage(type: Function, message: string | RegExp): any;
 
@@ -806,27 +676,21 @@ declare namespace jest {
 
     /**
      * Use `.toBeBetween` when checking if a date occurs between `startDate` and `endDate`.
-     * @param {Date} startDate
-     * @param {Date} endDate
      */
     toBeBetween(startDate: Date, endDate: Date): any;
 
     /**
      * Use `.toBeBeforeOrEqualTo` when checking if a date equals to or occurs before `date`.
-     * @param {Date} date
      */
     toBeBeforeOrEqualTo(date: Date): any;
 
     /**
      * Use `.toBeAfterOrEqualTo` when checking if a date equals to or occurs after `date`.
-     * @param {Date} date
      */
     toBeAfterOrEqualTo(date: Date): any;
 
     /**
      * Use `.toEqualIgnoringWhitespace` when checking if a `String` is equal (===) to given `String` ignoring white-space.
-     *
-     * @param {String} string
      */
     toEqualIgnoringWhitespace(string: string): any;
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace jest {
   // noinspection JSUnusedGlobalSymbols
-  interface Matchers<R> {
+  interface Matchers<R, T> {
     /**
      * Note: Currently unimplemented
      * Passing assertion
@@ -23,7 +23,7 @@ declare namespace jest {
     /**
      * Use .toBeOneOf when checking if a value is a member of a given Array.
      */
-    toBeOneOf<E = any>(members: E[]): R;
+    toBeOneOf(members: T[]): R;
 
     /**
      * Use `.toBeNil` when checking a value is `null` or `undefined`.
@@ -33,7 +33,7 @@ declare namespace jest {
     /**
      * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
      */
-    toSatisfy<E = any>(predicate: (x: E) => boolean): R;
+    toSatisfy(predicate: (x: T) => boolean): R;
 
     /**
      * Use `.toBeArray` when checking if a value is an `Array`.
@@ -58,37 +58,37 @@ declare namespace jest {
     /**
      * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
      */
-    toIncludeAllMembers<E = any>(members: E[]): R;
+    toIncludeAllMembers(members: T): R;
 
     /**
      * Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
      */
-    toIncludeAllPartialMembers<E = any>(members: E[]): R;
+    toIncludeAllPartialMembers(members: T): R;
 
     /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
      */
-    toIncludeAnyMembers<E = any>(members: E[]): R;
+    toIncludeAnyMembers(members: T): R;
 
     /**
      * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
      */
-    toIncludeSameMembers<E = any>(members: E[]): R;
+    toIncludeSameMembers(members: T): R;
 
     /**
      * Use `.toPartiallyContain` when checking if any array value matches the partial member.
      */
-    toPartiallyContain<E = any>(member: E): R;
+    toPartiallyContain(member: Partial<T extends Array<infer U> ? U : never>): R;
 
     /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
      */
-    toSatisfyAll<E = any>(predicate: (x: E) => boolean): R;
+    toSatisfyAll(predicate: (x: T extends Array<infer U> ? U : never) => boolean): R;
 
     /**
      * Use `.toSatisfyAny` when you want to use a custom matcher by supplying a predicate function that returns `true` for any matching value in an array.
      */
-    toSatisfyAny(predicate: (x: any) => boolean): R;
+    toSatisfyAny(predicate: (x: T extends Array<infer U> ? U : never) => boolean): R;
 
     /**
      * Use `.toBeBoolean` when checking if a value is a `Boolean`.
@@ -135,14 +135,14 @@ declare namespace jest {
      *
      * Note: Required Jest version >=23
      */
-    toHaveBeenCalledBefore(mock: jest.Mock): R;
+    toHaveBeenCalledBefore(mock: Mock): R;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
      *
      * Note: Required Jest version >=23
      */
-    toHaveBeenCalledAfter(mock: jest.Mock): R;
+    toHaveBeenCalledAfter(mock: Mock): R;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.
@@ -202,62 +202,62 @@ declare namespace jest {
     /**
      * Use `.toContainKey` when checking if an object contains the provided key.
      */
-    toContainKey<E = any>(key: keyof E | string): R;
+    toContainKey(key: keyof T): R;
 
     /**
      * Use `.toContainKeys` when checking if an object has all of the provided keys.
      */
-    toContainKeys<E = any>(keys: (keyof E | string)[]): R;
+    toContainKeys(keys: Array<keyof T>): R;
 
     /**
      * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
      */
-    toContainAllKeys<E = any>(keys: (keyof E | string)[]): R;
+    toContainAllKeys(keys: Array<keyof T>): R;
 
     /**
      * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
      */
-    toContainAnyKeys<E = any>(keys: (keyof E | string)[]): R;
+    toContainAnyKeys(keys: Array<keyof T>): R;
 
     /**
      * Use `.toContainValue` when checking if an object contains the provided value.
      */
-    toContainValue<E = any>(value: E): R;
+    toContainValue(value: T[keyof T]): R;
 
     /**
      * Use `.toContainValues` when checking if an object contains all of the provided values.
      */
-    toContainValues<E = any>(values: E[]): R;
+    toContainValues(values: Array<T[keyof T]>): R;
 
     /**
      * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
      */
-    toContainAllValues<E = any>(values: E[]): R;
+    toContainAllValues(values: Array<T[keyof T]>): R;
 
     /**
      * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
      */
-    toContainAnyValues<E = any>(values: E[]): R;
+    toContainAnyValues(values: Array<T[keyof T]>): R;
 
     /**
      * Use `.toContainEntry` when checking if an object contains the provided entry.
      */
-    toContainEntry<E = any>(entry: [keyof E, E[keyof E]]): R;
+    toContainEntry(entry: [keyof T, T[keyof T]]): R;
 
     /**
      * Use `.toContainEntries` when checking if an object contains all of the provided entries.
      */
-    toContainEntries<E = any>(entries: [keyof E, E[keyof E]][]): R;
+    toContainEntries(entries: Array<[keyof T, T[keyof T]]>): R;
 
     /**
      * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
      */
-    toContainAllEntries<E = any>(entries: [keyof E, E[keyof E]][]): R;
+    toContainAllEntries(entries: Array<[keyof T, T[keyof T]]>): R;
 
     /**
      * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
      */
-    toContainAnyEntries<E = any>(entries: [keyof E, E[keyof E]][]): R;
+    toContainAnyEntries(entries: Array<[keyof T, T[keyof T]]>): R;
 
     /**
      * Use `.toBeExtensible` when checking if an object is extensible.
@@ -322,7 +322,7 @@ declare namespace jest {
     /**
      * Use `.toThrowWithMessage` when checking if a callback function throws an error of a given type with a given error message.
      */
-    toThrowWithMessage(type: Function, message: string | RegExp): R;
+    toThrowWithMessage(type: () => void, message: string | RegExp): R;
 
     /**
      * Use `.toBeSymbol` when checking if a value is a `Symbol`.
@@ -372,7 +372,8 @@ declare namespace jest {
     /**
      * Use .toBeOneOf when checking if a value is a member of a given Array.
      */
-    toBeOneOf<E = any>(members: E[]): any;
+    // tslint:disable-next-line: no-unnecessary-generics
+    toBeOneOf<E = any[]>(members: E[]): any;
 
     /**
      * Use `.toBeNil` when checking a value is `null` or `undefined`.
@@ -382,6 +383,7 @@ declare namespace jest {
     /**
      * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toSatisfy<E = any>(predicate: (x: E) => boolean): any;
 
     /**
@@ -407,26 +409,31 @@ declare namespace jest {
     /**
      * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toIncludeAllMembers<E = any>(members: E[]): any;
 
     /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toIncludeAnyMembers<E = any>(members: E[]): any;
 
     /**
      * Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toIncludeSameMembers<E = any>(members: E[]): any;
 
     /**
      * Use `.toPartiallyContain` when checking if any array value matches the partial member.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toPartiallyContain<E = any>(member: E): any;
 
     /**
      * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toSatisfyAll<E = any>(predicate: (x: E) => boolean): any;
 
     /**
@@ -479,14 +486,14 @@ declare namespace jest {
      *
      * Note: Required Jest version >=23
      */
-    toHaveBeenCalledBefore(mock: jest.Mock): any;
+    toHaveBeenCalledBefore(mock: Mock): any;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
      *
      * Note: Required Jest version >=23
      */
-    toHaveBeenCalledAfter(mock: jest.Mock): any;
+    toHaveBeenCalledAfter(mock: Mock): any;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.
@@ -530,7 +537,6 @@ declare namespace jest {
 
     /**
      * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
-     *
      */
     toBeWithin(start: number, end: number): any;
 
@@ -547,57 +553,68 @@ declare namespace jest {
     /**
      * Use `.toContainKeys` when checking if an object has all of the provided keys.
      */
-    toContainKeys<E = any>(keys: (keyof E | string)[]): any;
+    // tslint:disable-next-line: no-unnecessary-generics
+    toContainKeys<E = any>(keys: Array<keyof E>): any;
 
     /**
      * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
      */
-    toContainAllKeys<E = any>(keys: (keyof E | string)[]): any;
+    // tslint:disable-next-line: no-unnecessary-generics
+    toContainAllKeys<E = any>(keys: Array<keyof E>): any;
 
     /**
      * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
      */
-    toContainAnyKeys<E = any>(keys: (keyof E | string)[]): any;
+    // tslint:disable-next-line: no-unnecessary-generics
+    toContainAnyKeys<E = any>(keys: Array<keyof E>): any;
 
     /**
      * Use `.toContainValue` when checking if an object contains the provided value.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toContainValue<E = any>(value: E): any;
 
     /**
      * Use `.toContainValues` when checking if an object contains all of the provided values.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toContainValues<E = any>(values: E[]): any;
 
     /**
      * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toContainAllValues<E = any>(values: E[]): any;
 
     /**
      * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toContainAnyValues<E = any>(values: E[]): any;
 
     /**
      * Use `.toContainEntry` when checking if an object contains the provided entry.
      */
+    // tslint:disable-next-line: no-unnecessary-generics
     toContainEntry<E = any>(entry: [keyof E, E[keyof E]]): any;
 
     /**
      * Use `.toContainEntries` when checking if an object contains all of the provided entries.
      */
-    toContainEntries<E = any>(entries: [keyof E, E[keyof E]][]): any;
+    // tslint:disable-next-line: no-unnecessary-generics
+    toContainEntries<E = any>(entries: Array<[keyof E, E[keyof E]]>): any;
 
     /**
      * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
      */
-    toContainAllEntries<E = any>(entries: [keyof E, E[keyof E]][]): any;
+    // tslint:disable-next-line: no-unnecessary-generics
+    toContainAllEntries<E = any>(entries: Array<[keyof E, E[keyof E]]>): any;
 
     /**
      * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
      */
-    toContainAnyEntries<E = any>(entries: [keyof E, E[keyof E]][]): any;
+    // tslint:disable-next-line: no-unnecessary-generics
+    toContainAnyEntries<E = any>(entries: Array<[keyof E, E[keyof E]]>): any;
 
     /**
      * Use `.toBeExtensible` when checking if an object is extensible.
@@ -662,7 +679,7 @@ declare namespace jest {
     /**
      * Use `.toThrowWithMessage` when checking if a callback function throws an error of a given type with a given error message.
      */
-    toThrowWithMessage(type: Function, message: string | RegExp): any;
+    toThrowWithMessage(type: () => void, message: string | RegExp): any;
 
     /**
      * Use `.toBeEmptyObject` when checking if a value is an empty `Object`.


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

All the matchers that were using generic, weren't taking advantage of the full potential of typescript.

### Why

The vast majority of matchers related to Array, Object and Satisfy.
Doesn't take advantage of typescript's potential to be able to infer types, and because of that, the object matchers that were related to the object's key allowed passing other keys

without refactor:
![example_without_refactor](https://user-images.githubusercontent.com/54173994/150684369-41d6a76e-30f1-4cda-8345-942c92afeb54.png)

with refactor:
![example_with_refactor](https://user-images.githubusercontent.com/54173994/150684377-bec60aa9-a550-46b4-bb22-86f79f7a75a2.png)

I did this refactoring on all Object, Array and Satisfy matchers.
It was just those who used generics.

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
