### PR TITLE
Remove extraneous all.js file

### DIFF
--- a/all.js
+++ b/all.js
@@ -1,1 +1,0 @@
-require('./dist/all');


### PR DESCRIPTION
An extra completely unused file was added in a2904bd6b9d1ec215fcf006b00788ea90cf561bf. This removes that file.