### PR TITLE
Update toHaveBeenCalledAfter to fail if second mock is never called

### DIFF
--- a/src/matchers/toHaveBeenCalledAfter.js
+++ b/src/matchers/toHaveBeenCalledAfter.js
@@ -37,7 +37,7 @@ export function toHaveBeenCalledAfter(actual, expected) {
 const smallest = ns => ns.reduce((acc, n) => (acc < n ? acc : n));
 
 const predicate = (firstInvocationCallOrder, secondInvocationCallOrder) => {
-  if (firstInvocationCallOrder.length === 0) return true;
+  if (firstInvocationCallOrder.length === 0) return false;
   if (secondInvocationCallOrder.length === 0) return false;
 
   const firstSmallest = smallest(firstInvocationCallOrder);

--- a/src/matchers/toHaveBeenCalledAfter.js
+++ b/src/matchers/toHaveBeenCalledAfter.js
@@ -1,6 +1,6 @@
 import { isJestMockOrSpy } from '../utils';
 
-export function toHaveBeenCalledAfter(actual, expected) {
+export function toHaveBeenCalledAfter(actual, expected, failIfNoFirstInvocation = true) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   if (!isJestMockOrSpy(actual)) {
@@ -13,7 +13,7 @@ export function toHaveBeenCalledAfter(actual, expected) {
 
   const firstInvocationCallOrder = actual.mock.invocationCallOrder;
   const secondInvocationCallOrder = expected.mock.invocationCallOrder;
-  const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder);
+  const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder, failIfNoFirstInvocation);
 
   const passMessage =
     matcherHint('.not.toHaveBeenCalledAfter') +
@@ -36,8 +36,8 @@ export function toHaveBeenCalledAfter(actual, expected) {
 
 const smallest = ns => ns.reduce((acc, n) => (acc < n ? acc : n));
 
-const predicate = (firstInvocationCallOrder, secondInvocationCallOrder) => {
-  if (firstInvocationCallOrder.length === 0) return false;
+const predicate = (firstInvocationCallOrder, secondInvocationCallOrder, failIfNoFirstInvocation) => {
+  if (firstInvocationCallOrder.length === 0) return !failIfNoFirstInvocation;
   if (secondInvocationCallOrder.length === 0) return false;
 
   const firstSmallest = smallest(firstInvocationCallOrder);

--- a/src/matchers/toHaveBeenCalledBefore.js
+++ b/src/matchers/toHaveBeenCalledBefore.js
@@ -1,6 +1,6 @@
 import { isJestMockOrSpy } from '../utils';
 
-export function toHaveBeenCalledBefore(actual, expected) {
+export function toHaveBeenCalledBefore(actual, expected, failIfNoSecondInvocation = true) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   if (!isJestMockOrSpy(actual)) {
@@ -13,7 +13,7 @@ export function toHaveBeenCalledBefore(actual, expected) {
 
   const firstInvocationCallOrder = actual.mock.invocationCallOrder;
   const secondInvocationCallOrder = expected.mock.invocationCallOrder;
-  const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder);
+  const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder, failIfNoSecondInvocation);
 
   const passMessage =
     matcherHint('.not.toHaveBeenCalledBefore') +
@@ -49,9 +49,9 @@ const mockCheckFailMessage = (utils, value, isReceivedValue) => () => {
 
 const smallest = ns => ns.reduce((acc, n) => (acc < n ? acc : n));
 
-const predicate = (firstInvocationCallOrder, secondInvocationCallOrder) => {
+const predicate = (firstInvocationCallOrder, secondInvocationCallOrder, failIfNoSecondInvocation) => {
   if (firstInvocationCallOrder.length === 0) return false;
-  if (secondInvocationCallOrder.length === 0) return false;
+  if (secondInvocationCallOrder.length === 0) return !failIfNoSecondInvocation;
 
   const firstSmallest = smallest(firstInvocationCallOrder);
   const secondSmallest = smallest(secondInvocationCallOrder);

--- a/src/matchers/toHaveBeenCalledBefore.js
+++ b/src/matchers/toHaveBeenCalledBefore.js
@@ -51,7 +51,7 @@ const smallest = ns => ns.reduce((acc, n) => (acc < n ? acc : n));
 
 const predicate = (firstInvocationCallOrder, secondInvocationCallOrder) => {
   if (firstInvocationCallOrder.length === 0) return false;
-  if (secondInvocationCallOrder.length === 0) return true;
+  if (secondInvocationCallOrder.length === 0) return false;
 
   const firstSmallest = smallest(firstInvocationCallOrder);
   const secondSmallest = smallest(secondInvocationCallOrder);

--- a/test/matchers/__snapshots__/toHaveBeenCalledAfter.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledAfter.test.js.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toHaveBeenCalledAfter fails when given a first mock has not been called 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledAfter(</><green>expected</><dim>)</>
-
-Expected first mock to not have been called after, invocationCallOrder:
-  <green>[]</>
-Received second mock with invocationCallOrder:
-  <red>[]</>"
-`;
-
 exports[`.not.toHaveBeenCalledAfter fails when given first mock is called after second mock 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledAfter(</><green>expected</><dim>)</>
 
@@ -25,6 +16,15 @@ Expected first mock to not have been called after, invocationCallOrder:
   <green>[26, 27, 28]</>
 Received second mock with invocationCallOrder:
   <red>[25]</>"
+`;
+
+exports[`.toHaveBeenCalledAfter fails when given first mock has not been called 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+
+Expected first mock to have been called after, invocationCallOrder:
+  <green>[]</>
+Received second mock with invocationCallOrder:
+  <red>[]</>"
 `;
 
 exports[`.toHaveBeenCalledAfter fails when given first mock is called before multiple calls to second mock 1`] = `

--- a/test/matchers/__snapshots__/toHaveBeenCalledAfter.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledAfter.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toHaveBeenCalledAfter failIfNoFirstInvocation is passed as false failed when given first mock has not been called 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+
+Expected first mock to not have been called after, invocationCallOrder:
+  <green>[]</>
+Received second mock with invocationCallOrder:
+  <red>[]</>"
+`;
+
 exports[`.not.toHaveBeenCalledAfter fails when given first mock is called after second mock 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledAfter(</><green>expected</><dim>)</>
 
@@ -16,6 +25,15 @@ Expected first mock to not have been called after, invocationCallOrder:
   <green>[26, 27, 28]</>
 Received second mock with invocationCallOrder:
   <red>[25]</>"
+`;
+
+exports[`.toHaveBeenCalledAfter failIfNoFirstInvocation is passed as true failed when given first mock has not been called 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledAfter(</><green>expected</><dim>)</>
+
+Expected first mock to have been called after, invocationCallOrder:
+  <green>[]</>
+Received second mock with invocationCallOrder:
+  <red>[]</>"
 `;
 
 exports[`.toHaveBeenCalledAfter fails when given first mock has not been called 1`] = `

--- a/test/matchers/__snapshots__/toHaveBeenCalledBefore.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledBefore.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toHaveBeenCalledBefore failIfNoSecondInvocation is passed as false fails when given first mock that has been called and a second mock that has not been called 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+
+Expected first mock to not have been called before, invocationCallOrder:
+  <green>[31]</>
+Received second mock with invocationCallOrder:
+  <red>[]</>"
+`;
+
 exports[`.not.toHaveBeenCalledBefore fails when given first mock is called before multiple calls to second mock 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledBefore(</><green>expected</><dim>)</>
 
@@ -16,6 +25,15 @@ Expected first mock to not have been called before, invocationCallOrder:
   <green>[4000]</>
 Received second mock with invocationCallOrder:
   <red>[5000]</>"
+`;
+
+exports[`.toHaveBeenCalledBefore failIfNoSecondInvocation is passed as true fails when given first mock that has been called and a second mock that has not been called 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+
+Expected first mock to have been called before, invocationCallOrder:
+  <green>[16]</>
+Received second mock with invocationCallOrder:
+  <red>[]</>"
 `;
 
 exports[`.toHaveBeenCalledBefore fails when given a first mock has not been called 1`] = `

--- a/test/matchers/__snapshots__/toHaveBeenCalledBefore.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledBefore.test.js.snap
@@ -18,15 +18,6 @@ Received second mock with invocationCallOrder:
   <red>[5000]</>"
 `;
 
-exports[`.not.toHaveBeenCalledBefore fails when given first mock that has been called and a second mock that has not been called 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveBeenCalledBefore(</><green>expected</><dim>)</>
-
-Expected first mock to not have been called before, invocationCallOrder:
-  <green>[4000]</>
-Received second mock with invocationCallOrder:
-  <red>[]</>"
-`;
-
 exports[`.toHaveBeenCalledBefore fails when given a first mock has not been called 1`] = `
 "<dim>expect(</><red>received</><dim>).toHaveBeenCalledBefore(</><green>expected</><dim>)</>
 
@@ -52,6 +43,15 @@ Expected first mock to have been called before, invocationCallOrder:
   <green>[5000, 6000, 7000]</>
 Received second mock with invocationCallOrder:
   <red>[4000]</>"
+`;
+
+exports[`.toHaveBeenCalledBefore fails when given first mock that has been called and a second mock that has not been called 1`] = `
+"<dim>expect(</><red>received</><dim>).toHaveBeenCalledBefore(</><green>expected</><dim>)</>
+
+Expected first mock to have been called before, invocationCallOrder:
+  <green>[1]</>
+Received second mock with invocationCallOrder:
+  <red>[]</>"
 `;
 
 exports[`.toHaveBeenCalledBefore fails when given first value is not a jest spy or mock 1`] = `

--- a/test/matchers/toHaveBeenCalledAfter.test.js
+++ b/test/matchers/toHaveBeenCalledAfter.test.js
@@ -85,6 +85,24 @@ describe('.toHaveBeenCalledAfter', () => {
     mock2.mock.invocationCallOrder[0] = lessThan;
     expect(mock1).toHaveBeenCalledAfter(mock2);
   });
+
+  describe('failIfNoFirstInvocation is passed as false', () => {
+    test('passes when given first mock has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      expect(mock1).toHaveBeenCalledAfter(mock2, false);
+    });
+  });
+
+  describe('failIfNoFirstInvocation is passed as true', () => {
+    test('failed when given first mock has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      expect(() => expect(mock1).toHaveBeenCalledAfter(mock2, true)).toThrowErrorMatchingSnapshot();
+    });
+  });
 });
 
 describe('.not.toHaveBeenCalledAfter', () => {
@@ -145,5 +163,23 @@ describe('.not.toHaveBeenCalledAfter', () => {
     mock1();
     mock1();
     expect(() => expect(mock1).not.toHaveBeenCalledAfter(mock2)).toThrowErrorMatchingSnapshot();
+  });
+
+  describe('failIfNoFirstInvocation is passed as false', () => {
+    test('failed when given first mock has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      expect(() => expect(mock1).not.toHaveBeenCalledAfter(mock2, false)).toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('failIfNoFirstInvocation is passed as true', () => {
+    test('passes when given first mock has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      expect(mock1).not.toHaveBeenCalledAfter(mock2, true);
+    });
   });
 });

--- a/test/matchers/toHaveBeenCalledAfter.test.js
+++ b/test/matchers/toHaveBeenCalledAfter.test.js
@@ -3,10 +3,11 @@ import * as matcher from 'src/matchers/toHaveBeenCalledAfter';
 expect.extend(matcher);
 
 describe('.toHaveBeenCalledAfter', () => {
-  test('passes when given a first mock has not been called', () => {
+  test('fails when given first mock has not been called', () => {
     const mock1 = jest.fn();
     const mock2 = jest.fn();
-    expect(mock1).toHaveBeenCalledAfter(mock2);
+
+    expect(() => expect(mock1).toHaveBeenCalledAfter(mock2)).toThrowErrorMatchingSnapshot();
   });
 
   test('fails when given first mock that has been called and a second mock that has not been called', () => {
@@ -87,12 +88,6 @@ describe('.toHaveBeenCalledAfter', () => {
 });
 
 describe('.not.toHaveBeenCalledAfter', () => {
-  test('fails when given a first mock has not been called', () => {
-    const mock1 = jest.fn();
-    const mock2 = jest.fn();
-    expect(() => expect(mock1).not.toHaveBeenCalledAfter(mock2)).toThrowErrorMatchingSnapshot();
-  });
-
   test('passes when given first mock that has been called and a second mock that has not been called', () => {
     const mock1 = jest.fn();
     const mock2 = jest.fn();

--- a/test/matchers/toHaveBeenCalledAfter.test.js
+++ b/test/matchers/toHaveBeenCalledAfter.test.js
@@ -88,6 +88,12 @@ describe('.toHaveBeenCalledAfter', () => {
 });
 
 describe('.not.toHaveBeenCalledAfter', () => {
+  test('passes when given a first mock has not been called', () => {
+    const mock1 = jest.fn();
+    const mock2 = jest.fn();
+    expect(mock1).not.toHaveBeenCalledAfter(mock2);
+  });
+
   test('passes when given first mock that has been called and a second mock that has not been called', () => {
     const mock1 = jest.fn();
     const mock2 = jest.fn();

--- a/test/matchers/toHaveBeenCalledBefore.test.js
+++ b/test/matchers/toHaveBeenCalledBefore.test.js
@@ -9,11 +9,11 @@ describe('.toHaveBeenCalledBefore', () => {
     expect(() => expect(mock1).toHaveBeenCalledBefore(mock2)).toThrowErrorMatchingSnapshot();
   });
 
-  test('passes when given first mock that has been called and a second mock that has not been called', () => {
+  test('fails when given first mock that has been called and a second mock that has not been called', () => {
     const mock1 = jest.fn();
     const mock2 = jest.fn();
     mock1();
-    expect(mock1).toHaveBeenCalledBefore(mock2);
+    expect(() => expect(mock1).toHaveBeenCalledBefore(mock2)).toThrowErrorMatchingSnapshot();
   });
 
   test('passes when given first mock is called before second mock', () => {
@@ -93,12 +93,12 @@ describe('.not.toHaveBeenCalledBefore', () => {
     expect(mock1).not.toHaveBeenCalledBefore(mock2);
   });
 
-  test('fails when given first mock that has been called and a second mock that has not been called', () => {
+  test('passes when given first mock that has been called and a second mock that has not been called', () => {
     const mock1 = jest.fn();
     const mock2 = jest.fn();
     mock1();
     mock1.mock.invocationCallOrder[0] = 4000; // amend the value for the snapshot
-    expect(() => expect(mock1).not.toHaveBeenCalledBefore(mock2)).toThrowErrorMatchingSnapshot();
+    expect(mock1).not.toHaveBeenCalledBefore(mock2);
   });
 
   test('fails when given first mock is called before second mock', () => {

--- a/test/matchers/toHaveBeenCalledBefore.test.js
+++ b/test/matchers/toHaveBeenCalledBefore.test.js
@@ -84,6 +84,28 @@ describe('.toHaveBeenCalledBefore', () => {
     const mock2 = () => {};
     expect(() => expect(mock1).toHaveBeenCalledBefore(mock2)).toThrowErrorMatchingSnapshot();
   });
+
+  describe('failIfNoSecondInvocation is passed as false', () => {
+    test('passes when given first mock that has been called and a second mock that has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      mock1();
+
+      expect(mock1).toHaveBeenCalledBefore(mock2, false);
+    });
+  });
+
+  describe('failIfNoSecondInvocation is passed as true', () => {
+    test('fails when given first mock that has been called and a second mock that has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      mock1();
+
+      expect(() => expect(mock1).toHaveBeenCalledBefore(mock2, true)).toThrowErrorMatchingSnapshot();
+    });
+  });
 });
 
 describe('.not.toHaveBeenCalledBefore', () => {
@@ -144,5 +166,27 @@ describe('.not.toHaveBeenCalledBefore', () => {
     mock1();
     mock1();
     expect(mock1).not.toHaveBeenCalledBefore(mock2);
+  });
+
+  describe('failIfNoSecondInvocation is passed as false', () => {
+    test('fails when given first mock that has been called and a second mock that has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      mock1();
+
+      expect(() => expect(mock1).not.toHaveBeenCalledBefore(mock2, false)).toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('failIfNoSecondInvocation is passed as true', () => {
+    test('passes when given first mock that has been called and a second mock that has not been called', () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      mock1();
+
+      expect(mock1).not.toHaveBeenCalledBefore(mock2, true);
+    });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -571,8 +571,9 @@ declare namespace jest {
      * Note: Required Jest version >=23
      *
      * @param {Mock} mock
+     * @param {boolean} [failIfNoSecondInvocation=true]
      */
-    toHaveBeenCalledBefore(mock: jest.Mock): any;
+    toHaveBeenCalledBefore(mock: jest.Mock, failIfNoSecondInvocation: boolean): any;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -580,8 +581,9 @@ declare namespace jest {
      * Note: Required Jest version >=23
      *
      * @param {Mock} mock
+     * @param {boolean} [failIfNoFirstInvocation=true]
      */
-    toHaveBeenCalledAfter(mock: jest.Mock): any;
+    toHaveBeenCalledAfter(mock: jest.Mock, failIfNoFirstInvocation: boolean): any;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -154,7 +154,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoSecondInvocation=true]
      */
-    toHaveBeenCalledBefore(mock: jest.Mock, failIfNoSecondInvocation): R;
+    toHaveBeenCalledBefore(mock: jest.Mock, failIfNoSecondInvocation: boolean): R;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -164,7 +164,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoFirstInvocation=true]
      */
-    toHaveBeenCalledAfter(mock: jest.Mock, failIfNoFirstInvocation): R;
+    toHaveBeenCalledAfter(mock: jest.Mock, failIfNoFirstInvocation: boolean): R;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -152,8 +152,9 @@ declare namespace jest {
      * Note: Required Jest version >=23
      *
      * @param {Mock} mock
+     * @param {boolean} [failIfNoSecondInvocation=true]
      */
-    toHaveBeenCalledBefore(mock: jest.Mock): R;
+    toHaveBeenCalledBefore(mock: jest.Mock, failIfNoSecondInvocation): R;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -161,8 +162,9 @@ declare namespace jest {
      * Note: Required Jest version >=23
      *
      * @param {Mock} mock
+     * @param {boolean} [failIfNoFirstInvocation=true]
      */
-    toHaveBeenCalledAfter(mock: jest.Mock): R;
+    toHaveBeenCalledAfter(mock: jest.Mock, failIfNoFirstInvocation): R;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.


### PR DESCRIPTION
Update toHaveBeenCalledAfter to fail if second mock is never called Update tests accordingly

✅ Closes #379 

<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What
Update toHaveBeenCalledOnce predicate to ensure tests fail if first call is not made

<!-- Why are these changes necessary? Link any related issues -->

### Why

- In #379 it is agreed that `toHaveBeenCalledOnce` should also ensure that `toHaveBeenCalled` is also true

<!-- If necessary add any additional notes on the implementation -->

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
