### PR TITLE
Ignore .idea directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "jest": {
     "testEnvironment": "node",
     "testPathIgnorePatterns": [
+      ".idea",
       "examples",
       "/node_modules/",
       "/fixtures/",


### PR DESCRIPTION
Tests can fail because of things staged in .idea when using Jetbrains products. For example,

```
Snapshot Summary
 › 2 snapshot files obsolete from 2 test suites. To remove them all, run `yarn test -u`.
   ↳   • .idea/shelf/Uncommitted_changes_before_rebase_[Default]2/toBeSymbol.test.ts.snap
       • .idea/shelf/Uncommitted_changes_before_rebase_[Default]2/toBeTrue.test.ts.snap
```

We should have Jest ignore that directory.