### PR TITLE
Disable semantic commits in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", ":semanticCommitsDisabled"],
   "lockFileMaintenance": { "enabled": true, "automerge": true },
   "rangeStrategy": "replace",
   "postUpdateOptions": ["yarnDedupeHighest"]


### PR DESCRIPTION
Currently, only Renovate is using semantic commits. We should either merge this and not do semantic commits at all -- or enforce semantic commits across the board (probably with https://github.com/marketplace/semantic-pull-requests and https://commitizen-tools.github.io/commitizen/). It is confusing to have a mix of both.