### PR TITLE
Fix typings of `toThrowWithMessage`, support unconstructable errors

### DIFF
--- a/src/matchers/toThrowWithMessage.js
+++ b/src/matchers/toThrowWithMessage.js
@@ -85,9 +85,19 @@ export function toThrowWithMessage(callbackOrPromiseReturn, type, message) {
   }
 
   const pass = predicate(error, type, message);
+  const messageStr = message.toString();
+  let expectedError;
+  try {
+    expectedError = new type(messageStr);
+  } catch (err) {
+    const name = type.name;
+    expectedError = new Error();
+    expectedError.name = name;
+    expectedError.message = messageStr;
+  }
   if (pass) {
-    return { pass: true, message: passMessage(utils, error, new type(message)) };
+    return { pass: true, message: passMessage(utils, error, expectedError) };
   }
 
-  return { pass: false, message: failMessage(utils, error, new type(message)) };
+  return { pass: false, message: failMessage(utils, error, expectedError) };
 }

--- a/test/matchers/__snapshots__/toThrowWithMessage.test.js.snap
+++ b/test/matchers/__snapshots__/toThrowWithMessage.test.js.snap
@@ -56,6 +56,26 @@ Thrown:
 "
 `;
 
+exports[`.toThrowWithMessage Async passes with an unconstructable error given a regex message 1`] = `
+"<dim>expect(</intensity><red>function</color><dim>).not.toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
+
+Expected not to throw:
+  <green>[UnconstructableError: /42/]</color>
+Thrown:
+  <red>[UnconstructableError: 42]</color>
+"
+`;
+
+exports[`.toThrowWithMessage Async passes with an unconstructable error given a string message 1`] = `
+"<dim>expect(</intensity><red>function</color><dim>).not.toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
+
+Expected not to throw:
+  <green>[UnconstructableError: 42]</color>
+Thrown:
+  <red>[UnconstructableError: 42]</color>
+"
+`;
+
 exports[`.toThrowWithMessage fails when a callback function is not a function 1`] = `
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
@@ -140,5 +160,25 @@ Expected not to throw:
   <green>[TypeError: Expected message]</color>
 Thrown:
   <red>[TypeError: Expected message]</color>
+"
+`;
+
+exports[`.toThrowWithMessage passes with an unconstructable error given a regex message 1`] = `
+"<dim>expect(</intensity><red>function</color><dim>).not.toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
+
+Expected not to throw:
+  <green>[UnconstructableError: /42/]</color>
+Thrown:
+  <red>[UnconstructableError: 42]</color>
+"
+`;
+
+exports[`.toThrowWithMessage passes with an unconstructable error given a string message 1`] = `
+"<dim>expect(</intensity><red>function</color><dim>).not.toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
+
+Expected not to throw:
+  <green>[UnconstructableError: 42]</color>
+Thrown:
+  <red>[UnconstructableError: 42]</color>
 "
 `;

--- a/test/matchers/toThrowWithMessage.test.js
+++ b/test/matchers/toThrowWithMessage.test.js
@@ -4,6 +4,16 @@ const { toThrowWithMessage } = matcher;
 
 expect.extend(matcher);
 
+class UnconstructableError extends Error {
+  constructor(message) {
+    if (typeof message !== 'number') {
+      throw new TypeError('Expected number arg');
+    }
+    super(message.toString());
+    this.name = 'UnconstructableError';
+  }
+}
+
 describe('.toThrowWithMessage', () => {
   test('fails when callback function is not provided', () => {
     const { pass, message } = toThrowWithMessage.call({
@@ -137,6 +147,34 @@ describe('.toThrowWithMessage', () => {
     expect(message()).toMatchSnapshot();
   });
 
+  test('passes with an unconstructable error given a string message', () => {
+    const callback = () => {
+      throw new UnconstructableError(42);
+    };
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      UnconstructableError,
+      '42',
+    );
+    expect(pass).toBe(true);
+    expect(message()).toMatchSnapshot();
+  });
+
+  test('passes with an unconstructable error given a regex message', () => {
+    const callback = () => {
+      throw new UnconstructableError(42);
+    };
+    const { pass, message } = toThrowWithMessage.call(
+      { utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived } },
+      callback,
+      UnconstructableError,
+      /42/,
+    );
+    expect(pass).toBe(true);
+    expect(message()).toMatchSnapshot();
+  });
+
   test('passes when given an Error with a string error message: end to end', () => {
     expect(() => {
       throw new TypeError('Expected message');
@@ -249,6 +287,36 @@ describe('.toThrowWithMessage', () => {
         rejectValue,
         TypeError,
         /Expected message/,
+      );
+      expect(pass).toBe(true);
+      expect(message()).toMatchSnapshot();
+    });
+
+    test('passes with an unconstructable error given a string message', () => {
+      const rejectValue = new UnconstructableError(42);
+      const { pass, message } = toThrowWithMessage.call(
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
+        rejectValue,
+        UnconstructableError,
+        '42',
+      );
+      expect(pass).toBe(true);
+      expect(message()).toMatchSnapshot();
+    });
+
+    test('passes with an unconstructable error given a regex message', () => {
+      const rejectValue = new UnconstructableError(42);
+      const { pass, message } = toThrowWithMessage.call(
+        {
+          utils: { matcherHint: matcherHint, printExpected: printExpected, printReceived: printReceived },
+          promise: 'rejects',
+        },
+        rejectValue,
+        UnconstructableError,
+        /42/,
       );
       expect(pass).toBe(true);
       expect(message()).toMatchSnapshot();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -387,7 +387,7 @@ declare namespace jest {
      * @param {Function} type
      * @param {String | RegExp} message
      */
-    toThrowWithMessage(type: (...args: unknown[]) => unknown, message: string | RegExp): R;
+    toThrowWithMessage(type: new (...args: any[]) => {message: string}, message: string | RegExp): R;
 
     /**
      * Use `.toBeEmptyObject` when checking if a value is an empty `Object`.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -387,7 +387,7 @@ declare namespace jest {
      * @param {Function} type
      * @param {String | RegExp} message
      */
-    toThrowWithMessage(type: new (...args: any[]) => {message: string}, message: string | RegExp): R;
+    toThrowWithMessage(type: (new (...args: any[]) => {message: string}) | (abstract new (...args: any[]) => {message: string}) | ((...args: any[]) => {message: string}), message: string | RegExp): R;
 
     /**
      * Use `.toBeEmptyObject` when checking if a value is an empty `Object`.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -387,7 +387,13 @@ declare namespace jest {
      * @param {Function} type
      * @param {String | RegExp} message
      */
-    toThrowWithMessage(type: (new (...args: any[]) => {message: string}) | (abstract new (...args: any[]) => {message: string}) | ((...args: any[]) => {message: string}), message: string | RegExp): R;
+    toThrowWithMessage(
+      type:
+        | (new (...args: any[]) => { message: string })
+        | (abstract new (...args: any[]) => { message: string })
+        | ((...args: any[]) => { message: string }),
+      message: string | RegExp,
+    ): R;
 
     /**
      * Use `.toBeEmptyObject` when checking if a value is an empty `Object`.


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

This PR fixes typings issues noted in #472, and adds support to unconstructable errors (such as abstract classes or not taking a `message` string as first arg) to be passed as error class.

<!-- Why are these changes necessary? Link any related issues -->

### Why

See #472. Moreover, `toThrowWithMessage` was unusable with `AssertionError` from the node `assert` module.

<!-- If necessary add any additional notes on the implementation -->

### Notes

The matcher first tries to instantiate the `type` with the message (`toString`ed in case it was a regex).
If the instantiation fails, it creates a new `Error` on which it sets the `name` & `message` in order to be correctly printed as expected in the message.

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
