### PR TITLE
feat: add .toBeJsonMatching(expectation) matcher

### DIFF
--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -20,6 +20,7 @@ export { toBeFrozen } from './toBeFrozen';
 export { toBeFunction } from './toBeFunction';
 export { toBeHexadecimal } from './toBeHexadecimal';
 export { toBeInteger } from './toBeInteger';
+export { toBeJsonMatching } from './toBeJsonMatching';
 export { toBeNaN } from './toBeNaN';
 export { toBeNegative } from './toBeNegative';
 export { toBeNil } from './toBeNil';

--- a/src/matchers/toBeJsonMatching.js
+++ b/src/matchers/toBeJsonMatching.js
@@ -1,0 +1,25 @@
+import { matchesObject, tryParseJSON } from '../utils';
+
+export function toBeJsonMatching(actual, expected) {
+  const { printExpected, printReceived, matcherHint } = this.utils;
+
+  const parsed = tryParseJSON(actual);
+  const isValidJSON = typeof parsed !== 'undefined';
+
+  const passMessage =
+    `${matcherHint('.not.toBeJsonMatching')}\n\n` +
+    `Expected input to not be a JSON string containing:\n  ${printExpected(expected)}\n` +
+    `${isValidJSON ? `Received:\n  ${printReceived(parsed)}` : `Received invalid JSON:\n  ${printReceived(actual)}`}`;
+
+  const failMessage =
+    `${matcherHint('.toBeJsonMatching')}\n\n` +
+    `Expected input to be a JSON string containing:\n  ${printExpected(expected)}\n` +
+    `${isValidJSON ? `Received:\n  ${printReceived(parsed)}` : `Received invalid JSON:\n  ${printReceived(actual)}`}`;
+
+  const pass =
+    typeof actual === 'string' &&
+    typeof tryParseJSON(actual) !== 'undefined' &&
+    matchesObject(this.equals, tryParseJSON(actual), expected);
+
+  return { pass, message: () => (pass ? passMessage : failMessage) };
+}

--- a/src/matchers/toPartiallyContain.js
+++ b/src/matchers/toPartiallyContain.js
@@ -1,14 +1,9 @@
-import { containsEntry } from '../utils';
+import { partiallyContains } from '../utils';
 
 export function toPartiallyContain(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const pass =
-    Array.isArray(actual) &&
-    Array.isArray([expected]) &&
-    [expected].every(partial =>
-      actual.some(value => Object.entries(partial).every(entry => containsEntry(this.equals, value, entry))),
-    );
+  const pass = partiallyContains(this.equals, actual, [expected]);
 
   return {
     pass,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,3 +12,50 @@ export const isJestMockOrSpy = value => {
 
 export const containsEntry = (equals, obj, [key, value]) =>
   obj.hasOwnProperty && Object.prototype.hasOwnProperty.call(obj, key) && equals(obj[key], value);
+
+export const partiallyContains = (equals, actual, expected) =>
+  Array.isArray(actual) &&
+  Array.isArray(expected) &&
+  expected.every(partial =>
+    actual.some(value => {
+      if (typeof partial !== 'object' || partial === null) {
+        return equals(value, partial);
+      }
+      if (Array.isArray(partial)) {
+        return partiallyContains(equals, value, partial);
+      }
+      return Object.entries(partial).every(entry => containsEntry(equals, value, entry));
+    }),
+  );
+
+export const matchesObject = (equals, actual, expected) => {
+  if (equals(actual, expected)) {
+    return true;
+  }
+  if (Array.isArray(actual) || Array.isArray(expected)) {
+    return partiallyContains(equals, actual, expected);
+  }
+  if (typeof actual === 'object' && typeof expected === 'object' && expected !== null) {
+    return Object.getOwnPropertyNames(expected).every(name => {
+      if (equals(actual[name], expected[name])) {
+        return true;
+      }
+      if (Array.isArray(actual[name]) || Array.isArray(expected[name])) {
+        return partiallyContains(equals, actual[name], expected[name]);
+      }
+      if (typeof actual[name] === 'object' && typeof expected[name] === 'object' && expected[name] !== null) {
+        return matchesObject(equals, actual[name], expected[name]);
+      }
+      return false;
+    });
+  }
+  return false;
+};
+
+export const tryParseJSON = input => {
+  try {
+    return JSON.parse(input);
+  } catch {
+    return undefined;
+  }
+};

--- a/test/matchers/__snapshots__/toBeJsonMatching.test.js.snap
+++ b/test/matchers/__snapshots__/toBeJsonMatching.test.js.snap
@@ -1,0 +1,307 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 3`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo"}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 4`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 5`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello"}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 6`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 7`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": []}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 8`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 9`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {}]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 10`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar"}]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.not.toBeJsonMatching fails when given JSON string matches expectation 11`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to not be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>null</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>[]</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 3`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": "42"}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 4`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 41}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 5`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": []}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 6`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": {}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 7`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": null}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 8`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "bar"}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 9`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": 7}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 10`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": []}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 11`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "bonjour"}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 12`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "dolly"}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 13`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": 7}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 14`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": []}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 15`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": {}}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 16`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": null}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 17`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": 7}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 18`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": {}}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 19`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [8]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 20`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, []]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 21`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "baz"}]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when given JSON string does not match expectation 22`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz", "i": "buzz"}]}</color>
+Received:
+  <red>{"a": 42, "b": "foo", "c": {"d": "hello", "e": "world"}, "f": [7, {"g": "bar", "h": "baz"}]}</color>"
+`;
+
+exports[`.toBeJsonMatching fails when the given string is not valid JSON 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeJsonMatching(</intensity><green>expected</color><dim>)</intensity>
+
+Expected input to be a JSON string containing:
+  <green>"This is not a valid JSON string"</color>
+Received invalid JSON:
+  <red>"This is not a valid JSON string"</color>"
+`;

--- a/test/matchers/toBeJsonMatching.test.js
+++ b/test/matchers/toBeJsonMatching.test.js
@@ -1,0 +1,74 @@
+import * as matcher from 'src/matchers/toBeJsonMatching';
+
+expect.extend(matcher);
+
+const string = JSON.stringify({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'bar', h: 'baz' }] });
+
+const matches = [
+  {},
+  { a: 42 },
+  { a: 42, b: 'foo' },
+  { a: 42, b: 'foo', c: {} },
+  { a: 42, b: 'foo', c: { d: 'hello' } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [] },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7] },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, {}] },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'bar' }] },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'bar', h: 'baz' }] },
+];
+
+const nonMatches = [
+  null,
+  [],
+  { a: '42' },
+  { a: 41 },
+  { a: [] },
+  { a: {} },
+  { a: null },
+  { a: 42, b: 'bar' },
+  { a: 42, b: 'foo', c: 7 },
+  { a: 42, b: 'foo', c: [] },
+  { a: 42, b: 'foo', c: { d: 'bonjour' } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'dolly' } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 7 } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: [] } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: {} } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: null } },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: 7 },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: {} },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [8] },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, []] },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'baz' }] },
+  { a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'bar', h: 'baz', i: 'buzz' }] },
+];
+
+describe('.toBeJsonMatching', () => {
+  test.each(matches)('passes when given JSON string matches expectation', expectation => {
+    expect(string).toBeJsonMatching(expectation);
+  });
+
+  test.each(nonMatches)('fails when given JSON string does not match expectation', expectation => {
+    expect(() => expect(string).toBeJsonMatching(expectation)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when the given string is not valid JSON', () => {
+    const invalid = 'This is not a valid JSON string';
+    expect(() => expect(invalid).toBeJsonMatching(invalid)).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeJsonMatching', () => {
+  test.each(nonMatches)('passes when given JSON string does not match expectation', expectation => {
+    expect(string).not.toBeJsonMatching(expectation);
+  });
+
+  test.each(matches)('fails when given JSON string matches expectation', expectation => {
+    expect(() => expect(string).not.toBeJsonMatching(expectation)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('passes when the given string is not valid JSON', () => {
+    const invalid = 'This is not a valid JSON string';
+    expect(invalid).not.toBeJsonMatching(invalid);
+  });
+});

--- a/test/utils/index.test.js
+++ b/test/utils/index.test.js
@@ -1,4 +1,4 @@
-import { contains, determinePropertyMessage, isJestMockOrSpy } from 'src/utils';
+import { contains, determinePropertyMessage, isJestMockOrSpy, tryParseJSON } from 'src/utils';
 
 let equals;
 
@@ -72,6 +72,35 @@ describe('Utils', () => {
     test('returns false if value is not a jest mock', () => {
       const fn = () => {};
       expect(isJestMockOrSpy(fn)).toBe(false);
+    });
+  });
+
+  describe('.tryParseJSON', () => {
+    test('returns undefined when the input is not valid JSON', () => {
+      const invalidJson = '<h1>This is not a valid JSON string</h1>';
+
+      expect(tryParseJSON(invalidJson)).toBeUndefined();
+    });
+
+    test('returns the expected string when the input is a valid JSON string', () => {
+      const message = 'Hello World!';
+      const validJsonString = JSON.stringify(message);
+
+      expect(tryParseJSON(validJsonString)).toBe(message);
+    });
+
+    test('returns the expected number when the input is a valid JSON number', () => {
+      const number = 42;
+      const validJsonNumber = JSON.stringify(number);
+
+      expect(tryParseJSON(validJsonNumber)).toBe(number);
+    });
+
+    test('returns the expected object when the input is a valid JSON object', () => {
+      const object = { a: 42, b: 'Hello World!' };
+      const validJsonObjet = JSON.stringify(object);
+
+      expect(tryParseJSON(validJsonObjet)).toEqual(object);
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -382,6 +382,13 @@ interface CustomMatchers<R> extends Record<string, any> {
   toIncludeMultiple(substring: readonly string[]): R;
 
   /**
+   * Use `.toBeJsonMatching` to check that a string is the JSON representation of a JavaScript object that matches a subset of the properties of the expectation.
+   *
+   * @param {*} expectation
+   */
+  toBeJsonMatching<E = unknown>(expectation: E): R;
+
+  /**
    * Use `.toThrowWithMessage` when checking if a callback function throws an error of a given type with a given error message.
    *
    * @param {Function} type
@@ -819,6 +826,13 @@ declare namespace jest {
      * @param {Array.<String>} substring
      */
     toIncludeMultiple(substring: readonly string[]): R;
+
+    /**
+     * Use `.toBeJsonMatching` to check that a string is the JSON representation of a JavaScript object that matches a subset of the properties of the expectation.
+     *
+     * @param {*} expectation
+     */
+    toBeJsonMatching<E = unknown>(expectation: E): R;
 
     /**
      * Use `.toThrowWithMessage` when checking if a callback function throws an error of a given type with a given error message.

--- a/website/docs/matchers/String.mdx
+++ b/website/docs/matchers/String.mdx
@@ -52,6 +52,28 @@ Use `.toBeDateString` when checking if a value is a valid date string.
 });`}
 </TestFile>
 
+### .toBeJsonMatching(expectation)
+
+Use `.toBeJsonMatching` to check that a string is the JSON representation of an object that matches the expectation object.
+
+<TestFile name="toBeJsonMatching">
+  {`test('passes when given JSON string matches object', () => {
+  const string = JSON.stringify({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'bar', h: 'baz' }] });
+
+  expect(string).toBeJsonMatching({});
+  expect(string).toBeJsonMatching({ a: 42 });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo' });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: {} });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: { d: 'hello' } });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' } });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [] });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7] });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, {}] });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'bar' }] });
+  expect(string).toBeJsonMatching({ a: 42, b: 'foo', c: { d: 'hello', e: 'world' }, f: [7, { g: 'bar', h: 'baz' }] });
+});`}
+</TestFile>
+
 ### .toEqualCaseInsensitive(string)
 
 Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.

--- a/website/docs/matchers/index.md
+++ b/website/docs/matchers/index.md
@@ -94,6 +94,7 @@ sidebar_position: 1
 - [.toBeString()](/docs/matchers/string/#tobestring)
 - [.toBeHexadecimal(string)](/docs/matchers/string/#tobehexadecimal)
 - [.toBeDateString(string)](/docs/matchers/string/#tobedatestringstring)
+- [.toBeJsonMatching(expectation)](/docs/matchers/string/#tobejsonmatchingexpectation)
 - [.toEqualCaseInsensitive(string)](/docs/matchers/string/#toequalcaseinsensitivestring)
 - [.toStartWith(prefix)](/docs/matchers/string/#tostartwithprefix)
 - [.toEndWith(suffix)](/docs/matchers/string/#toendwithsuffix)


### PR DESCRIPTION
### What

This adds support for a new custom matcher `.toBeJsonMatching(...)`.

### Why

This matcher is useful when one wants to check that a function has been called with a JSON string that satisfies some constraints,

```js
expect(fn).toHaveBeenCalledWith(
  expect.toBeJsonMatching({ key1: 'value1' })
);
```

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
