### PR TITLE
Add failing element to `satisfyAll` and `satisfyAny` error messages

### DIFF
--- a/src/matchers/toSatisfyAll.js
+++ b/src/matchers/toSatisfyAll.js
@@ -1,13 +1,18 @@
 export function toSatisfyAll(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
+  const pass = actual.every(expected);
+  const failingElement = pass ? actual.find(expected) : actual.find(a => !expected(a));
+
   const passMessage =
     matcherHint('.not.toSatisfyAll') +
     '\n\n' +
     'Expected array to not satisfy predicate for all values:\n' +
     `  ${printExpected(expected)}\n` +
     'Received:\n' +
-    `  ${printReceived(actual)}`;
+    `  ${printReceived(actual)}\n` +
+    'Failed on:\n' +
+    `  ${printReceived(failingElement)}`;
 
   const failMessage =
     matcherHint('.toSatisfyAll') +
@@ -15,9 +20,9 @@ export function toSatisfyAll(actual, expected) {
     'Expected array to satisfy predicate for all values:\n' +
     `  ${printExpected(expected)}\n` +
     'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const pass = actual.every(expected);
+    `  ${printReceived(actual)}\n` +
+    'Failed on:\n' +
+    `  ${printReceived(failingElement)}`;
 
   return { pass, message: () => (pass ? passMessage : failMessage) };
 }

--- a/src/matchers/toSatisfyAny.js
+++ b/src/matchers/toSatisfyAny.js
@@ -1,13 +1,18 @@
 export function toSatisfyAny(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
+  const pass = actual.some(expected);
+  const failingElement = pass ? actual.find(expected) : actual.find(a => !expected(a));
+
   const passMessage =
     matcherHint('.not.toSatisfyAny') +
     '\n\n' +
     'Expected array to not satisfy predicate for any value:\n' +
     `  ${printExpected(expected)}\n` +
     'Received:\n' +
-    `  ${printReceived(actual)}`;
+    `  ${printReceived(actual)}\n` +
+    'Failed on:\n' +
+    `  ${printReceived(failingElement)}`;
 
   const failMessage =
     matcherHint('.toSatisfyAny') +
@@ -15,9 +20,9 @@ export function toSatisfyAny(actual, expected) {
     'Expected array to satisfy predicate for any values:\n' +
     `  ${printExpected(expected)}\n` +
     'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const pass = actual.some(expected);
+    `  ${printReceived(actual)}\n` +
+    'Failed on:\n' +
+    `  ${printReceived(failingElement)}`;
 
   return { pass, message: () => (pass ? passMessage : failMessage) };
 }

--- a/test/matchers/__snapshots__/toSatisfyAll.test.js.snap
+++ b/test/matchers/__snapshots__/toSatisfyAll.test.js.snap
@@ -6,7 +6,9 @@ exports[`.not.toSatisfyAll fails when all values satisfy predicate 1`] = `
 Expected array to not satisfy predicate for all values:
   <green>[Function isOdd]</color>
 Received:
-  <red>[1, 3, 5, 7]</color>"
+  <red>[1, 3, 5, 7]</color>
+Failed on:
+  <red>1</color>"
 `;
 
 exports[`.toSatisfyAll fails when any value does not satisfy the predicate 1`] = `
@@ -15,5 +17,7 @@ exports[`.toSatisfyAll fails when any value does not satisfy the predicate 1`] =
 Expected array to satisfy predicate for all values:
   <green>[Function isOdd]</color>
 Received:
-  <red>[1, 3, 4, 5]</color>"
+  <red>[1, 3, 4, 5]</color>
+Failed on:
+  <red>4</color>"
 `;

--- a/test/matchers/__snapshots__/toSatisfyAny.test.js.snap
+++ b/test/matchers/__snapshots__/toSatisfyAny.test.js.snap
@@ -6,7 +6,9 @@ exports[`.not.toSatisfyAll fails when any value satisfies predicate 1`] = `
 Expected array to not satisfy predicate for any value:
   <green>[Function isOdd]</color>
 Received:
-  <red>[2, 3, 6, 8]</color>"
+  <red>[2, 3, 6, 8]</color>
+Failed on:
+  <red>3</color>"
 `;
 
 exports[`.toSatisfyAny fails when no value satisfies the predicate 1`] = `
@@ -15,5 +17,7 @@ exports[`.toSatisfyAny fails when no value satisfies the predicate 1`] = `
 Expected array to satisfy predicate for any values:
   <green>[Function isOdd]</color>
 Received:
-  <red>[2, 4, 6, 8]</color>"
+  <red>[2, 4, 6, 8]</color>
+Failed on:
+  <red>2</color>"
 `;


### PR DESCRIPTION
### What

Add failing element to `satisfyAll` and `satisfyAny` error messages

<!-- Why are these changes necessary? Link any related issues -->

### Why

This will give a clearer error message of why the assertion failed

<!-- If necessary add any additional notes on the implementation -->

### Notes

<img width="610" alt="Screenshot 2022-08-05 at 13 21 09" src="https://user-images.githubusercontent.com/5610087/183076109-866eb1f5-5571-4efc-9aa8-1e62e2411708.png">


### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
