### PR TITLE
chore: do not escape strings in snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
       "/node_modules/"
     ],
     "snapshotFormat": {
-      "escapeString": true,
-      "printBasicPrototype": true
+      "escapeString": false,
+      "printBasicPrototype": false
     },
     "snapshotSerializers": [
       "jest-serializer-ansi-escapes"

--- a/test/matchers/__snapshots__/toBeArrayOfSize.test.js.snap
+++ b/test/matchers/__snapshots__/toBeArrayOfSize.test.js.snap
@@ -37,7 +37,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>{}</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of 0 which is not an array 1`] = `
@@ -47,7 +47,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>0</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of NaN which is not an array 1`] = `
@@ -57,7 +57,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>NaN</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of false which is not an array 1`] = `
@@ -67,7 +67,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>false</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of null which is not an array 1`] = `
@@ -77,7 +77,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>null</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of true which is not an array 1`] = `
@@ -87,7 +87,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>true</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type of undefined which is not an array 1`] = `
@@ -97,7 +97,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>undefined</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when given type which is not an array 1`] = `
@@ -107,7 +107,7 @@ Expected value to be an array of size:
   <green>1</color>
 Received:
   value: <red>false</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;
 
 exports[`.toBeArrayOfSize fails when not given a parameter 1`] = `
@@ -127,5 +127,5 @@ Expected value to be an array of size:
   <green>5</color>
 Received:
   value: <red>undefined</color>
-  length: <red>\\"Not Accessible\\"</color>"
+  length: <red>"Not Accessible"</color>"
 `;

--- a/test/matchers/__snapshots__/toBeDateString.test.js.snap
+++ b/test/matchers/__snapshots__/toBeDateString.test.js.snap
@@ -4,12 +4,12 @@ exports[`.not.toBeDateString fails when given a date string 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeDateString()</intensity>
 
 Expected value to not be a date string received:
-  <red>\\"2018-01-01T13:00:00.000Z\\"</color>"
+  <red>"2018-01-01T13:00:00.000Z"</color>"
 `;
 
 exports[`.toBeDateString fails when not given a date string 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeDateString()</intensity>
 
 Expected value to be a date string received:
-  <red>\\"not a date\\"</color>"
+  <red>"not a date"</color>"
 `;

--- a/test/matchers/__snapshots__/toBeEmpty.test.js.snap
+++ b/test/matchers/__snapshots__/toBeEmpty.test.js.snap
@@ -4,12 +4,12 @@ exports[`.not.toBeEmpty fails when given empty string 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeEmpty()</intensity>
 
 Expected value to not be empty received:
-  <red>\\"\\"</color>"
+  <red>""</color>"
 `;
 
 exports[`.toBeEmpty fails when given non-empty string 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeEmpty()</intensity>
 
 Expected value to be empty received:
-  <red>\\"string\\"</color>"
+  <red>"string"</color>"
 `;

--- a/test/matchers/__snapshots__/toBeEmptyObject.test.js.snap
+++ b/test/matchers/__snapshots__/toBeEmptyObject.test.js.snap
@@ -11,5 +11,5 @@ exports[`.toBeEmptyObject fails when not given an empty object 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeEmptyObject()</intensity>
 
 Expected value to be an empty object, received:
-  <red>{\\"property1\\": \\"something\\"}</color>"
+  <red>{"property1": "something"}</color>"
 `;

--- a/test/matchers/__snapshots__/toBeEven.test.js.snap
+++ b/test/matchers/__snapshots__/toBeEven.test.js.snap
@@ -25,7 +25,7 @@ exports[`.toBeEven fails when not given an even number 3`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeEven()</intensity>
 
 Expected value to be an even number received:
- <red>\\"\\"</color>"
+ <red>""</color>"
 `;
 
 exports[`.toBeEven fails when not given an even number 4`] = `

--- a/test/matchers/__snapshots__/toBeExtensible.test.js.snap
+++ b/test/matchers/__snapshots__/toBeExtensible.test.js.snap
@@ -28,7 +28,7 @@ exports[`.toBeExtensible fails when not given an extensible object:  1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeExtensible()</intensity>
 
 Expected value to be extensible received:
-  <red>\\"\\"</color>"
+  <red>""</color>"
 `;
 
 exports[`.toBeExtensible fails when not given an extensible object: {} 1`] = `

--- a/test/matchers/__snapshots__/toBeHexadecimal.test.js.snap
+++ b/test/matchers/__snapshots__/toBeHexadecimal.test.js.snap
@@ -4,7 +4,7 @@ exports[`.not.toBeHexadecimal fails when given valid hexadecimal 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeHexadecimal()</intensity>
 
 Expected value to not be a hexadecimal, received:
-  <red>\\"#eeffee\\"</color>"
+  <red>"#eeffee"</color>"
 `;
 
 exports[`.toBeHexadecimal fails when given non-string 1`] = `

--- a/test/matchers/__snapshots__/toBeNil.test.js.snap
+++ b/test/matchers/__snapshots__/toBeNil.test.js.snap
@@ -11,5 +11,5 @@ exports[`.toBeNil fails when the value is not null or undefined 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeNil()</intensity>
 
 Expected value to be null or undefined, received:
-  <red>\\"value\\"</color>"
+  <red>"value"</color>"
 `;

--- a/test/matchers/__snapshots__/toBeObject.test.js.snap
+++ b/test/matchers/__snapshots__/toBeObject.test.js.snap
@@ -11,7 +11,7 @@ exports[`.toBeObject fails when not given an object:  1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeObject()</intensity>
 
 Expected value to be an object, received:
-  <red>\\"\\"</color>"
+  <red>""</color>"
 `;
 
 exports[`.toBeObject fails when not given an object: () => {} 1`] = `

--- a/test/matchers/__snapshots__/toBeOdd.test.js.snap
+++ b/test/matchers/__snapshots__/toBeOdd.test.js.snap
@@ -25,7 +25,7 @@ exports[`.toBeOdd fails when given not given an odd number 3`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeOdd()</intensity>
 
 Expected value to be odd received:
-  <red>\\"\\"</color>"
+  <red>""</color>"
 `;
 
 exports[`.toBeOdd fails when given not given an odd number 4`] = `

--- a/test/matchers/__snapshots__/toBeString.test.js.snap
+++ b/test/matchers/__snapshots__/toBeString.test.js.snap
@@ -4,21 +4,21 @@ exports[`.not.toBeString fails when given a string literal 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeString()</intensity>
 
 Expected value to not be of type string received:
-  <red>\\"\\"</color>"
+  <red>""</color>"
 `;
 
 exports[`.not.toBeString fails when given an object of type string 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeString()</intensity>
 
 Expected value to not be of type string received:
-  <red>{\\"0\\": \\"s\\", \\"1\\": \\"t\\", \\"10\\": \\"e\\", \\"2\\": \\"r\\", \\"3\\": \\"i\\", \\"4\\": \\"n\\", \\"5\\": \\"g\\", \\"6\\": \\" \\", \\"7\\": \\"t\\", \\"8\\": \\"y\\", \\"9\\": \\"p\\"}</color>"
+  <red>{"0": "s", "1": "t", "10": "e", "2": "r", "3": "i", "4": "n", "5": "g", "6": " ", "7": "t", "8": "y", "9": "p"}</color>"
 `;
 
 exports[`.toBeString fails when not given a string 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeString()</intensity>
 
 Expected value to be of type string:
-  <green>\\"type of string\\"</color>
+  <green>"type of string"</color>
 Received:
-  <red>\\"number\\"</color>"
+  <red>"number"</color>"
 `;

--- a/test/matchers/__snapshots__/toContainAllEntries.test.js.snap
+++ b/test/matchers/__snapshots__/toContainAllEntries.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toContainAllEntries fails when object only contains all of the giv
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllEntries(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not only contain all of the given entries:
-  <green>[[\\"b\\", \\"bar\\"], [\\"a\\", \\"foo\\"], [\\"c\\", \\"baz\\"]]</color>
+  <green>[["b", "bar"], ["a", "foo"], ["c", "baz"]]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainAllEntries fails when object does not only contain all of the given entries 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to only contain all of the given entries:
-  <green>[[\\"a\\", \\"foo\\"], [\\"b\\", \\"bar\\"]]</color>
+  <green>[["a", "foo"], ["b", "bar"]]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainAllKeys.test.js.snap
+++ b/test/matchers/__snapshots__/toContainAllKeys.test.js.snap
@@ -4,25 +4,25 @@ exports[`.not.toContainAllKeys fails when given object contains all keys 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all keys:
-  <green>[\\"b\\", \\"a\\"]</color>
+  <green>["b", "a"]</color>
 Received:
-  <red>[\\"a\\", \\"b\\"]</color>"
+  <red>["a", "b"]</color>"
 `;
 
 exports[`.toContainAllKeys fails when all of the object keys are matched, but there are additional keys  1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all keys:
-  <green>[\\"a\\", \\"c\\"]</color>
+  <green>["a", "c"]</color>
 Received:
-  <red>[\\"a\\", \\"b\\"]</color>"
+  <red>["a", "b"]</color>"
 `;
 
 exports[`.toContainAllKeys fails when given an empty object 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all keys:
-  <green>[\\"a\\"]</color>
+  <green>["a"]</color>
 Received:
   <red>[]</color>"
 `;
@@ -31,7 +31,7 @@ exports[`.toContainAllKeys fails when given object does not contain all keys 1`]
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all keys:
-  <green>[\\"a\\"]</color>
+  <green>["a"]</color>
 Received:
-  <red>[\\"a\\", \\"b\\"]</color>"
+  <red>["a", "b"]</color>"
 `;

--- a/test/matchers/__snapshots__/toContainAllValues.test.js.snap
+++ b/test/matchers/__snapshots__/toContainAllValues.test.js.snap
@@ -4,61 +4,61 @@ exports[`.not.toContainAllValues fails when given object contains all values inc
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all values:
-  <green>[\\"duck\\", [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]]</color>
+  <green>["duck", [{"bar": false, "foo": 0, "hello": "world"}]]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</color>"
+  <red>{"donald": "duck", "message": [{"bar": false, "foo": 0, "hello": "world"}]}</color>"
 `;
 
 exports[`.not.toContainAllValues fails when given object contains all values including objects 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all values:
-  <green>[{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}, \\"duck\\"]</color>
+  <green>[{"bar": false, "foo": 0, "hello": "world"}, "duck"]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</color>"
+  <red>{"donald": "duck", "message": {"bar": false, "foo": 0, "hello": "world"}}</color>"
 `;
 
 exports[`.not.toContainAllValues fails when given object contains primitive values 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all values:
-  <green>[\\"world\\", 0, false]</color>
+  <green>["world", 0, false]</color>
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</color>"
+  <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all primitive values 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all values:
-  <green>[\\"hello\\", 0, false]</color>
+  <green>["hello", 0, false]</color>
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</color>"
+  <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all primitive values 2`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all values:
-  <green>[\\"world\\", 0]</color>
+  <green>["world", 0]</color>
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</color>"
+  <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all values including arrays 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all values:
-  <green>[\\"duck\\", [{\\"hello\\": \\"world\\"}]]</color>
+  <green>["duck", [{"hello": "world"}]]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</color>"
+  <red>{"donald": "duck", "message": [{"bar": false, "foo": 0, "hello": "world"}]}</color>"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all values including objects 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all values:
-  <green>[{\\"hello\\": \\"world\\"}]</color>
+  <green>[{"hello": "world"}]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</color>"
+  <red>{"donald": "duck", "message": {"bar": false, "foo": 0, "hello": "world"}}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainAnyEntries.test.js.snap
+++ b/test/matchers/__snapshots__/toContainAnyEntries.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toContainAnyEntries fails when given object contains atleast one o
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyEntries(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain any of the provided entries:
-  <green>[[\\"a\\", \\"qux\\"], [\\"a\\", \\"foo\\"]]</color>
+  <green>[["a", "qux"], ["a", "foo"]]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainAnyEntries fails when given object does not contain any of the given entries 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain any of the provided entries:
-  <green>[[\\"a\\", \\"qux\\"], [\\"b\\", \\"foo\\"]]</color>
+  <green>[["a", "qux"], ["b", "foo"]]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainAnyKeys.test.js.snap
+++ b/test/matchers/__snapshots__/toContainAnyKeys.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toContainAnyKeys fails when object contains one or more keys 1`] =
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object not to contain any of the following keys:
-  <green>[\\"name\\", \\"age\\"]</color>
+  <green>["name", "age"]</color>
 Received:
-  <red>{\\"age\\": 37, \\"name\\": \\"Steve the Pirate\\"}</color>"
+  <red>{"age": 37, "name": "Steve the Pirate"}</color>"
 `;
 
 exports[`.toContainAnyKeys fails when object does not contain any keys 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAnyKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain any of the following keys:
-  <green>[\\"occupation\\"]</color>
+  <green>["occupation"]</color>
 Received:
-  <red>{\\"age\\": 37, \\"name\\": \\"Steve the Pirate\\"}</color>"
+  <red>{"age": 37, "name": "Steve the Pirate"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainAnyValues.test.js.snap
+++ b/test/matchers/__snapshots__/toContainAnyValues.test.js.snap
@@ -4,43 +4,43 @@ exports[`.not.toContainAnyValues fails when given object contains value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain any of the following values:
-  <green>[\\"baz\\"]</color>
+  <green>["baz"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.not.toContainAnyValues fails when given object contains value 2`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain any of the following values:
-  <green>[\\"foo\\", \\"bar\\"]</color>
+  <green>["foo", "bar"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainAnyValues fails when given object does not contain value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain any of the following values:
-  <green>[\\"fax\\"]</color>
+  <green>["fax"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainAnyValues fails when given object does not contain value 2`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain any of the following values:
-  <green>[\\"fax\\", \\"rom\\"]</color>
+  <green>["fax", "rom"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainAnyValues fails when given object does not contain value 3`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain any of the following values:
-  <green>[\\"dae\\", \\"mur\\", \\"zoe\\"]</color>
+  <green>["dae", "mur", "zoe"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainEntries.test.js.snap
+++ b/test/matchers/__snapshots__/toContainEntries.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toContainEntries fails when object contains all of the given entri
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainEntries(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all of the given entries:
-  <green>[[\\"b\\", \\"bar\\"], [\\"c\\", \\"baz\\"]]</color>
+  <green>[["b", "bar"], ["c", "baz"]]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainEntries fails when object does not contain all of the given entries 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainEntries(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all of the given entries:
-  <green>[\\"b\\", \\"foo\\"]</color>
+  <green>["b", "foo"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainEntry.test.js.snap
+++ b/test/matchers/__snapshots__/toContainEntry.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toContainEntry fails when object contains given entry 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainEntry(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain entry:
-  <green>[\\"b\\", \\"bar\\"]</color>
+  <green>["b", "bar"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainEntry fails when object does not contain given entry 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainEntry(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain entry:
-  <green>[\\"b\\", \\"foo\\"]</color>
+  <green>["b", "foo"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainKey.test.js.snap
+++ b/test/matchers/__snapshots__/toContainKey.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toContainKey fails when given object contains key 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainKey(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain key:
-  <green>\\"hello\\"</color>
+  <green>"hello"</color>
 Received:
-  <red>{\\"hello\\": \\"world\\"}</color>"
+  <red>{"hello": "world"}</color>"
 `;
 
 exports[`.toContainKey fails when given object does not contain key 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainKey(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain key:
-  <green>\\"missing\\"</color>
+  <green>"missing"</color>
 Received:
-  <red>{\\"hello\\": \\"world\\"}</color>"
+  <red>{"hello": "world"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainKeys.test.js.snap
+++ b/test/matchers/__snapshots__/toContainKeys.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toContainKeys fails when object contains all keys 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all keys:
-  <green>[\\"a\\", \\"b\\", \\"c\\"]</color>
+  <green>["a", "b", "c"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
 
 exports[`.toContainKeys fails when object does not contain all keys 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all keys:
-  <green>[\\"a\\", \\"d\\"]</color>
+  <green>["a", "d"]</color>
 Received:
-  <red>{\\"a\\": \\"foo\\", \\"b\\": \\"bar\\", \\"c\\": \\"baz\\"}</color>"
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainValue.test.js.snap
+++ b/test/matchers/__snapshots__/toContainValue.test.js.snap
@@ -4,52 +4,52 @@ exports[`.not.toContainValue fails when given object contains array value 1`] = 
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain value:
-  <green>[{\\"hello\\": \\"world\\"}]</color>
+  <green>[{"hello": "world"}]</color>
 Received:
-  <red>{\\"message\\": [{\\"hello\\": \\"world\\"}]}</color>"
+  <red>{"message": [{"hello": "world"}]}</color>"
 `;
 
 exports[`.not.toContainValue fails when given object contains object value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain value:
-  <green>{\\"hello\\": \\"world\\"}</color>
+  <green>{"hello": "world"}</color>
 Received:
-  <red>{\\"message\\": {\\"hello\\": \\"world\\"}}</color>"
+  <red>{"message": {"hello": "world"}}</color>"
 `;
 
 exports[`.not.toContainValue fails when given object contains primitive value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain value:
-  <green>\\"world\\"</color>
+  <green>"world"</color>
 Received:
-  <red>{\\"hello\\": \\"world\\"}</color>"
+  <red>{"hello": "world"}</color>"
 `;
 
 exports[`.toContainValue fails when given object does not contain array value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain value:
-  <green>[{\\"world\\": \\"hello\\"}]</color>
+  <green>[{"world": "hello"}]</color>
 Received:
-  <red>{\\"message\\": [{\\"hello\\": \\"world\\"}]}</color>"
+  <red>{"message": [{"hello": "world"}]}</color>"
 `;
 
 exports[`.toContainValue fails when given object does not contain object value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain value:
-  <green>{\\"world\\": \\"hello\\"}</color>
+  <green>{"world": "hello"}</color>
 Received:
-  <red>{\\"message\\": {\\"hello\\": \\"world\\"}}</color>"
+  <red>{"message": {"hello": "world"}}</color>"
 `;
 
 exports[`.toContainValue fails when given object does not contain primitive value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain value:
-  <green>\\"hello\\"</color>
+  <green>"hello"</color>
 Received:
-  <red>{\\"hello\\": \\"world\\"}</color>"
+  <red>{"hello": "world"}</color>"
 `;

--- a/test/matchers/__snapshots__/toContainValues.test.js.snap
+++ b/test/matchers/__snapshots__/toContainValues.test.js.snap
@@ -4,52 +4,52 @@ exports[`.not.toContainValues fails when given object contains all values includ
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all values:
-  <green>[\\"duck\\", [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]]</color>
+  <green>["duck", [{"bar": false, "foo": 0, "hello": "world"}]]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</color>"
+  <red>{"donald": "duck", "message": [{"bar": false, "foo": 0, "hello": "world"}]}</color>"
 `;
 
 exports[`.not.toContainValues fails when given object contains all values including objects 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all values:
-  <green>[{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}, \\"duck\\"]</color>
+  <green>[{"bar": false, "foo": 0, "hello": "world"}, "duck"]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</color>"
+  <red>{"donald": "duck", "message": {"bar": false, "foo": 0, "hello": "world"}}</color>"
 `;
 
 exports[`.not.toContainValues fails when given object contains primitive values 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to not contain all values:
-  <green>[\\"world\\", false]</color>
+  <green>["world", false]</color>
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</color>"
+  <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
 `;
 
 exports[`.toContainValues fails when given object does not contain all primitive values 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all values:
-  <green>[\\"hello\\", 0, false]</color>
+  <green>["hello", 0, false]</color>
 Received:
-  <red>{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}</color>"
+  <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
 `;
 
 exports[`.toContainValues fails when given object does not contain all values including arrays 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all values:
-  <green>[\\"duck\\", [{\\"hello\\": \\"world\\"}]]</color>
+  <green>["duck", [{"hello": "world"}]]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": [{\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}]}</color>"
+  <red>{"donald": "duck", "message": [{"bar": false, "foo": 0, "hello": "world"}]}</color>"
 `;
 
 exports[`.toContainValues fails when given object does not contain all values including objects 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all values:
-  <green>[{\\"hello\\": \\"world\\"}]</color>
+  <green>[{"hello": "world"}]</color>
 Received:
-  <red>{\\"donald\\": \\"duck\\", \\"message\\": {\\"bar\\": false, \\"foo\\": 0, \\"hello\\": \\"world\\"}}</color>"
+  <red>{"donald": "duck", "message": {"bar": false, "foo": 0, "hello": "world"}}</color>"
 `;

--- a/test/matchers/__snapshots__/toEndWith.test.js.snap
+++ b/test/matchers/__snapshots__/toEndWith.test.js.snap
@@ -4,25 +4,25 @@ exports[`.not.toEndWith fails when string ends with given suffix 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toEndWith(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to not end with:
-  <green>\\"world\\"</color>
+  <green>"world"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toEndWith fails when string does not end with the given suffix 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toEndWith(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to end with:
-  <green>\\"hello\\"</color>
+  <green>"hello"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toEndWith fails when the string is shorter than the given suffix 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toEndWith(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to end with:
-  <green>\\"hello world\\"</color>
+  <green>"hello world"</color>
 Received:
-  <red>\\"hello\\"</color>"
+  <red>"hello"</color>"
 `;

--- a/test/matchers/__snapshots__/toEqualCaseInsensitive.test.js.snap
+++ b/test/matchers/__snapshots__/toEqualCaseInsensitive.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toEqualCaseInsensitive fails if strings do not match 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toEqualCaseInsensitive(</intensity><green>expected</color><dim>)</intensity>
 
 Expected values to not be equal while ignoring case (using ===):
-  <green>\\"aaaa\\"</color>
+  <green>"aaaa"</color>
 Received:
-  <red>\\"aaaa\\"</color>"
+  <red>"aaaa"</color>"
 `;
 
 exports[`.toEqualCaseInsensitive passes if strings are equal despite case 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toEqualCaseInsensitive(</intensity><green>expected</color><dim>)</intensity>
 
 Expected values to be equal while ignoring case (using ===):
-  <green>\\"bbbb\\"</color>
+  <green>"bbbb"</color>
 Received:
-  <red>\\"aaaa\\"</color>"
+  <red>"aaaa"</color>"
 `;

--- a/test/matchers/__snapshots__/toHaveBeenCalledAfter.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledAfter.test.js.snap
@@ -66,7 +66,7 @@ Received second mock with invocationCallOrder:
 exports[`.toHaveBeenCalledAfter fails when given first value is not a jest spy or mock 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledAfter(</intensity><green>expected</color><dim>)</intensity>
 
-Matcher error: <red>\\"received\\"</color> must be a mock or spy function
+Matcher error: <red>"received"</color> must be a mock or spy function
 
 Received has type:  function
 Received has value: <red>[Function mock1]</color>"
@@ -84,7 +84,7 @@ Received second mock with invocationCallOrder:
 exports[`.toHaveBeenCalledAfter fails when given second value is not a jest spy or mock 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledAfter(</intensity><green>expected</color><dim>)</intensity>
 
-Matcher error: <green>\\"expected\\"</color> must be a mock or spy function
+Matcher error: <green>"expected"</color> must be a mock or spy function
 
 Expected has type:  function
 Expected has value: <green>[Function mock2]</color>"

--- a/test/matchers/__snapshots__/toHaveBeenCalledBefore.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledBefore.test.js.snap
@@ -75,7 +75,7 @@ Received second mock with invocationCallOrder:
 exports[`.toHaveBeenCalledBefore fails when given first value is not a jest spy or mock 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledBefore(</intensity><green>expected</color><dim>)</intensity>
 
-Matcher error: <red>\\"received\\"</color> must be a mock or spy function
+Matcher error: <red>"received"</color> must be a mock or spy function
 
 Received has type:  function
 Received has value: <red>[Function mock1]</color>"
@@ -84,7 +84,7 @@ Received has value: <red>[Function mock1]</color>"
 exports[`.toHaveBeenCalledBefore fails when given second value is not a jest spy or mock 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledBefore(</intensity><green>expected</color><dim>)</intensity>
 
-Matcher error: <green>\\"expected\\"</color> must be a mock or spy function
+Matcher error: <green>"expected"</color> must be a mock or spy function
 
 Expected has type:  function
 Expected has value: <green>[Function mock2]</color>"

--- a/test/matchers/__snapshots__/toHaveBeenCalledOnce.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledOnce.test.js.snap
@@ -23,7 +23,7 @@ Expected mock function to have been called exactly once, but it was called:
 exports[`.toHaveBeenCalledOnce fails when given value is not a jest spy or mock 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnce(</intensity><green>expected</color><dim>)</intensity>
 
-Matcher error: <red>\\"received\\"</color> must be a mock or spy function
+Matcher error: <red>"received"</color> must be a mock or spy function
 
 Received has type:  function
 Received has value: <red>[Function mock1]</color>"

--- a/test/matchers/__snapshots__/toHaveBeenCalledOnceWith.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledOnceWith.test.js.snap
@@ -3,7 +3,7 @@
 exports[`.not.toHaveBeenCalledOnceWith fails if mock was invoked exactly once with the expected value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Expected mock function to have been called any amount of times but one with <green>\\"hello\\"</color>, but it was called exactly once with <green>\\"hello\\"</color>."
+Expected mock function to have been called any amount of times but one with <green>"hello"</color>, but it was called exactly once with <green>"hello"</color>."
 `;
 
 exports[`.toHaveBeenCalledOnceWith fails if mock was invoked more than once, indicating how many times it was invoked 1`] = `
@@ -23,7 +23,7 @@ Expected mock function to have been called exactly once, but it was called:
 exports[`.toHaveBeenCalledOnceWith fails when given value is not a jest spy or mock 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Matcher error: <red>\\"received\\"</color> must be a mock or spy function
+Matcher error: <red>"received"</color> must be a mock or spy function
 
 Received has type:  function
 Received has value: <red>[Function mock1]</color>"
@@ -32,6 +32,6 @@ Received has value: <red>[Function mock1]</color>"
 exports[`.toHaveBeenCalledOnceWith fails when given value is not the expected one 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Expected mock function to have been called exactly once with <red>\\"hello\\"</color>, but it was called with:
-  <red>\\"not hello\\"</color>"
+Expected mock function to have been called exactly once with <red>"hello"</color>, but it was called with:
+  <red>"not hello"</color>"
 `;

--- a/test/matchers/__snapshots__/toInclude.test.js.snap
+++ b/test/matchers/__snapshots__/toInclude.test.js.snap
@@ -4,16 +4,16 @@ exports[`.toInclude .not.toInclude fails when a string does have a given substri
 "<dim>expect(</intensity><red>received</color><dim>).not.toInclude(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to not include:
-  <green>\\"ell\\"</color>
+  <green>"ell"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toInclude fails when a string does not have a given substring 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toInclude(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to include:
-  <green>\\"bob\\"</color>
+  <green>"bob"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;

--- a/test/matchers/__snapshots__/toIncludeAllPartialMembers.test.js.snap
+++ b/test/matchers/__snapshots__/toIncludeAllPartialMembers.test.js.snap
@@ -4,18 +4,18 @@ exports[`.not.toIncludeAllPartialMembers fails when array values matches the mem
 "<dim>expect(</intensity><red>received</color><dim>).not.toIncludeAllPartialMembers(</intensity><green>expected</color><dim>)</intensity>
 
 Expected list to not have all of the following partial members:
-  <green>[{\\"foo\\": \\"bar\\"}]</color>
+  <green>[{"foo": "bar"}]</color>
 Received:
-  <red>[{\\"hello\\": \\"world\\"}, {\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}]</color>"
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
 `;
 
 exports[`.toIncludeAllPartialMembers fails when array values do not contain any of the members of the set 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeAllPartialMembers(</intensity><green>expected</color><dim>)</intensity>
 
 Expected list to have all of the following partial members:
-  <green>[{\\"foo\\": \\"qux\\"}]</color>
+  <green>[{"foo": "qux"}]</color>
 Received:
-  <red>[{\\"hello\\": \\"world\\"}, {\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}]</color>"
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
 `;
 
 exports[`.toIncludeAllPartialMembers fails when expected object is not an array 1`] = `
@@ -24,14 +24,14 @@ exports[`.toIncludeAllPartialMembers fails when expected object is not an array 
 Expected list to have all of the following partial members:
   <green>1</color>
 Received:
-  <red>[{\\"hello\\": \\"world\\"}, {\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}]</color>"
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
 `;
 
 exports[`.toIncludeAllPartialMembers fails when given object is not an array 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeAllPartialMembers(</intensity><green>expected</color><dim>)</intensity>
 
 Expected list to have all of the following partial members:
-  <green>[{\\"foo\\": \\"bar\\"}]</color>
+  <green>[{"foo": "bar"}]</color>
 Received:
   <red>1</color>"
 `;

--- a/test/matchers/__snapshots__/toIncludeAnyMembers.test.js.snap
+++ b/test/matchers/__snapshots__/toIncludeAnyMembers.test.js.snap
@@ -4,18 +4,18 @@ exports[`.not.toIncludeAnyMembers fails when given array contains array value 1`
 "<dim>expect(</intensity><red>received</color><dim>).not.toIncludeAnyMembers(</intensity><green>expected</color><dim>)</intensity>
 
 Expected list to not include any of the following members:
-  <green>[[{\\"hello\\": \\"world\\"}], 7]</color>
+  <green>[[{"hello": "world"}], 7]</color>
 Received:
-  <red>[[{\\"hello\\": \\"world\\"}]]</color>"
+  <red>[[{"hello": "world"}]]</color>"
 `;
 
 exports[`.not.toIncludeAnyMembers fails when given array contains object value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toIncludeAnyMembers(</intensity><green>expected</color><dim>)</intensity>
 
 Expected list to not include any of the following members:
-  <green>[{\\"foo\\": \\"bar\\"}]</color>
+  <green>[{"foo": "bar"}]</color>
 Received:
-  <red>[{\\"foo\\": \\"bar\\"}]</color>"
+  <red>[{"foo": "bar"}]</color>"
 `;
 
 exports[`.not.toIncludeAnyMembers fails when given object contains primitive value 1`] = `
@@ -31,7 +31,7 @@ exports[`.toIncludeAnyMembers fails when expected object does not contain array 
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeAnyMembers(</intensity><green>expected</color><dim>)</intensity>
 
 Expected list to include any of the following members:
-  <green>\\"world\\"</color>
+  <green>"world"</color>
 Received:
   <red>[1, 2, 3]</color>"
 `;

--- a/test/matchers/__snapshots__/toIncludeMultiple.test.js.snap
+++ b/test/matchers/__snapshots__/toIncludeMultiple.test.js.snap
@@ -4,16 +4,16 @@ exports[`.not.toIncludeMultiple fails when string includes all substrings 1`] = 
 "<dim>expect(</intensity><red>received</color><dim>).not.toIncludeMultiple(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to not contain all substrings: 
-  <green>[\\"hello\\", \\"world\\"]</color>
+  <green>["hello", "world"]</color>
 Received: 
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toIncludeMultiple fails when string does not include all substrings 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeMultiple(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to contain all substrings: 
-  <green>[\\"hello\\", \\"world\\", \\"bob\\"]</color>
+  <green>["hello", "world", "bob"]</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;

--- a/test/matchers/__snapshots__/toIncludeRepeated.test.js.snap
+++ b/test/matchers/__snapshots__/toIncludeRepeated.test.js.snap
@@ -4,34 +4,34 @@ exports[`.not.toIncludeRepeated fails when given string includes given substring
 "<dim>expect(</intensity><red>received</color><dim>).not.toIncludeRepeated(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to not include repeated 1 times:
-  <green>\\"ell\\"</color>
+  <green>"ell"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.not.toIncludeRepeated fails when given string includes given substring to the given occurrences 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toIncludeRepeated(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to not include repeated 3 times:
-  <green>\\"l\\"</color>
+  <green>"l"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toIncludeRepeated fails when given string does not have a given substring the correct number of times 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeRepeated(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to include repeated 2 times:
-  <green>\\"world\\"</color>
+  <green>"world"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toIncludeRepeated fails when given string does not include given substring 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeRepeated(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to include repeated 1 times:
-  <green>\\"bob\\"</color>
+  <green>"bob"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;

--- a/test/matchers/__snapshots__/toPartiallyContain.test.js.snap
+++ b/test/matchers/__snapshots__/toPartiallyContain.test.js.snap
@@ -4,16 +4,16 @@ exports[`.toPartiallyContain .not.toPartiallyContain fails when a string does ha
 "<dim>expect(</intensity><red>received</color><dim>).not.toPartiallyContain(</intensity><green>expected</color><dim>)</intensity>
 
 Expected array not to partially contain:
-  <green>{\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}</color>
+  <green>{"baz": "qux", "foo": "bar"}</color>
 Received:
-  <red>[{\\"bax\\": \\"zax\\", \\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}]</color>"
+  <red>[{"bax": "zax", "baz": "qux", "foo": "bar"}]</color>"
 `;
 
 exports[`.toPartiallyContain fails when a string does not have a given substring 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toPartiallyContain(</intensity><green>expected</color><dim>)</intensity>
 
 Expected array to partially contain:
-  <green>{\\"baz\\": \\"qux\\", \\"foo\\": \\"bar\\"}</color>
+  <green>{"baz": "qux", "foo": "bar"}</color>
 Received:
-  <red>[{\\"a\\": 1, \\"b\\": 2}]</color>"
+  <red>[{"a": 1, "b": 2}]</color>"
 `;

--- a/test/matchers/__snapshots__/toStartWith.test.js.snap
+++ b/test/matchers/__snapshots__/toStartWith.test.js.snap
@@ -4,25 +4,25 @@ exports[`.not.toStartWith fails when string starts with given prefix 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toStartWith(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to not start with:
-  <green>\\"hello\\"</color>
+  <green>"hello"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toStartWith fails when string does not start with the given prefix 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toStartWith(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to start with:
-  <green>\\"world\\"</color>
+  <green>"world"</color>
 Received:
-  <red>\\"hello world\\"</color>"
+  <red>"hello world"</color>"
 `;
 
 exports[`.toStartWith fails when the string is shorter than the given prefix 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toStartWith(</intensity><green>expected</color><dim>)</intensity>
 
 Expected string to start with:
-  <green>\\"hello world\\"</color>
+  <green>"hello world"</color>
 Received:
-  <red>\\"hello\\"</color>"
+  <red>"hello"</color>"
 `;

--- a/test/matchers/__snapshots__/toThrowWithMessage.test.js.snap
+++ b/test/matchers/__snapshots__/toThrowWithMessage.test.js.snap
@@ -20,20 +20,20 @@ exports[`.toThrowWithMessage Async fails on rejects when error message provided 
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
 Unexpected argument for message
-Expected: \\"string\\" or \\"regexp
-Got: \\"2\\""
+Expected: "string" or "regexp
+Got: "2""
 `;
 
 exports[`.toThrowWithMessage Async fails on rejects when error type is not provided 1`] = `
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
-Expected type to be a function but instead \\"undefined\\" was found"
+Expected type to be a function but instead "undefined" was found"
 `;
 
 exports[`.toThrowWithMessage Async fails on rejects when return value is not provided 1`] = `
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
-Expected type to be a function but instead \\"undefined\\" was found"
+Expected type to be a function but instead "undefined" was found"
 `;
 
 exports[`.toThrowWithMessage Async passes on rejects when given an Error with a regex error message 1`] = `
@@ -79,7 +79,7 @@ Thrown:
 exports[`.toThrowWithMessage fails when a callback function is not a function 1`] = `
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
-Received value must be a function but instead \\"2\\" was found"
+Received value must be a function but instead "2" was found"
 `;
 
 exports[`.toThrowWithMessage fails when a callback provided doesnt throw an error 1`] = `
@@ -100,7 +100,7 @@ Thrown:
 exports[`.toThrowWithMessage fails when callback function is not provided 1`] = `
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
-Received value must be a function but instead \\"undefined\\" was found"
+Received value must be a function but instead "undefined" was found"
 `;
 
 exports[`.toThrowWithMessage fails when error message does not match expected message 1`] = `
@@ -133,14 +133,14 @@ exports[`.toThrowWithMessage fails when error message provided is not a string o
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
 Unexpected argument for message
-Expected: \\"string\\" or \\"regexp
-Got: \\"2\\""
+Expected: "string" or "regexp
+Got: "2""
 `;
 
 exports[`.toThrowWithMessage fails when error type is not provided 1`] = `
 "<dim>expect(</intensity><red>function</color><dim>).toThrowWithMessage(</intensity><green>type</color><dim>, </intensity><green>message</color><dim>)</intensity>
 
-Expected type to be a function but instead \\"undefined\\" was found"
+Expected type to be a function but instead "undefined" was found"
 `;
 
 exports[`.toThrowWithMessage passes when given an Error with a regex error message 1`] = `


### PR DESCRIPTION
Default in Jest 29, but we test on 27, 28 and 29, so need to pass config on the older versions