### PR TITLE
Fix toHaveBeenCalledOnceWith typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -174,7 +174,7 @@ declare namespace jest {
     /**
      * Use `.toHaveBeenCalledOnceWith` to check if a `Mock` was called exactly one time with the expected value.
      */
-    toHaveBeenCalledOnceWith(...args: any[]): R;
+    toHaveBeenCalledOnceWith(...args: unknown[]): R;
 
     /**
      * Use `.toBeNumber` when checking if a value is a `Number`.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -174,7 +174,7 @@ declare namespace jest {
     /**
      * Use `.toHaveBeenCalledOnceWith` to check if a `Mock` was called exactly one time with the expected value.
      */
-    toHaveBeenCalledOnceWith(): R;
+    toHaveBeenCalledOnceWith(...args: any[]): R;
 
     /**
      * Use `.toBeNumber` when checking if a value is a `Number`.


### PR DESCRIPTION
### What

Added missing parameters to the `toHaveBeenCalledOnce` matcher typing.

### Why

https://github.com/jest-community/jest-extended/issues/506

### Housekeeping

- [ ] Unit tests
- [X] Documentation is up to date
- [X] No additional lint warnings
- [X] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
