### PR TITLE
Add `vitest` info to docs

### DIFF
--- a/website/docs/getting-started/setup.md
+++ b/website/docs/getting-started/setup.md
@@ -45,7 +45,6 @@ To automatically extend `expect` with all matchers, you can use
 ```javascript
 import {expect} from "vitest";
 import * as matchers from "jest-extended";
-
 expect.extend(matchers);
 ```
 

--- a/website/docs/getting-started/setup.md
+++ b/website/docs/getting-started/setup.md
@@ -37,3 +37,24 @@ To automatically extend `expect` with all matchers, you can use
   "setupFilesAfterEnv": ["jest-extended/all"]
 }
 ```
+
+## Use with `vitest`
+
+`jest-extended` works with `vitest` because their `expect.extend` API is compatible. In your setup script:
+
+```javascript
+import {expect} from "vitest";
+import * as matchers from "jest-extended";
+
+expect.extend(matchers);
+```
+
+Add this setup script to your `vitest.config.js`:
+
+```javascript
+export default defineConfig({
+  test: {
+    setupFiles: ["./testSetup.js"],
+  },
+});
+```


### PR DESCRIPTION
### What

Add docs for `vitest` integration. Reference: https://vitest.dev/api/#expect-extend

### Why

It's generally useful for `vitest` users

### Notes

### Housekeeping

- [x] Documentation is up to date