### PR TITLE
Mark jest peerDependency as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,5 +127,10 @@
   },
   "peerDependencies": {
     "jest": ">=27.2.5"
+  },
+  "peerDependenciesMeta": {
+    "jest": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
### What

Mark the jest dependency as optional

### Why

The module works with other runners like vitest as well, in which case, the user will not need to have jest installed to use this package.

### Notes

### Housekeeping

- [ ] Unit tests
- [x] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
