### PR TITLE
add geo (toBeGeoLatitude, toBeGeoLongitude)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/parser": "^5.30.6",
     "babel-jest": "^29.0.0",
     "babel-jest-assertions": "^0.1.0",
+    "check-geographic-coordinates": "^0.0.10",
     "eslint": "^8.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^3.2.5",

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -18,6 +18,8 @@ export { toBeFalse } from './toBeFalse';
 export { toBeFinite } from './toBeFinite';
 export { toBeFrozen } from './toBeFrozen';
 export { toBeFunction } from './toBeFunction';
+export { toBeGeoLatitude } from './toBeGeoLatitude';
+export { toBeGeoLongitude } from './toBeGeoLongitude';
 export { toBeHexadecimal } from './toBeHexadecimal';
 export { toBeInteger } from './toBeInteger';
 export { toBeNaN } from './toBeNaN';

--- a/src/matchers/toBeGeoLatitude.js
+++ b/src/matchers/toBeGeoLatitude.js
@@ -1,0 +1,21 @@
+import { latitude } from 'check-geographic-coordinates';
+
+export function toBeGeoLatitude(actual) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const passMessage =
+    matcherHint('.not.toBeGeoLatitude', 'received', '') +
+    '\n\n' +
+    'Expected value to not be of type latitude, received:\n' +
+    `  ${printReceived(actual)}`;
+
+  const failMessage =
+    matcherHint('.toBeGeoLatitude', 'received', '') +
+    '\n\n' +
+    'Expected value to be of type latitude, received:\n' +
+    `  ${printReceived(actual)}`;
+
+  const pass = latitude(actual) ? true : false;
+
+  return { pass, message: () => (pass ? passMessage : failMessage) };
+}

--- a/src/matchers/toBeGeoLongitude.js
+++ b/src/matchers/toBeGeoLongitude.js
@@ -1,0 +1,21 @@
+import { longitude } from 'check-geographic-coordinates';
+
+export function toBeGeoLongitude(actual) {
+  const { matcherHint, printReceived } = this.utils;
+
+  const passMessage =
+    matcherHint('.not.toBeGeoLongitude', 'received', '') +
+    '\n\n' +
+    'Expected value to not be of type longitude, received:\n' +
+    `  ${printReceived(actual)}`;
+
+  const failMessage =
+    matcherHint('.toBeGeoLongitude', 'received', '') +
+    '\n\n' +
+    'Expected value to be of type longitude, received:\n' +
+    `  ${printReceived(actual)}`;
+
+  const pass = longitude(actual) ? true : false;
+
+  return { pass, message: () => (pass ? passMessage : failMessage) };
+}

--- a/test/matchers/__snapshots__/toBeGeoLatitude.test.js.snap
+++ b/test/matchers/__snapshots__/toBeGeoLatitude.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeGeoLatitude fails when given a latitude number 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeGeoLatitude()</intensity>
+
+Expected value to not be of type latitude, received:
+  <red>41.902783</color>"
+`;
+
+exports[`.not.toBeGeoLatitude fails when given a latitude string 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeGeoLatitude()</intensity>
+
+Expected value to not be of type latitude, received:
+  <red>"41.902783"</color>"
+`;
+
+exports[`.toBeGeoLatitude fails when not given a latitude negative number 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeGeoLatitude()</intensity>
+
+Expected value to be of type latitude, received:
+  <red>-90.1</color>"
+`;
+
+exports[`.toBeGeoLatitude fails when not given a latitude positive number 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeGeoLatitude()</intensity>
+
+Expected value to be of type latitude, received:
+  <red>90.1</color>"
+`;
+
+exports[`.toBeGeoLatitude fails when not given a latitude string 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeGeoLatitude()</intensity>
+
+Expected value to be of type latitude, received:
+  <red>"any_not_valid_latitude"</color>"
+`;

--- a/test/matchers/__snapshots__/toBeGeoLongitude.test.js.snap
+++ b/test/matchers/__snapshots__/toBeGeoLongitude.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeGeoLongitude fails when given a longitude number 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeGeoLongitude()</intensity>
+
+Expected value to not be of type longitude, received:
+  <red>12.496366</color>"
+`;
+
+exports[`.not.toBeGeoLongitude fails when given a longitude string 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeGeoLongitude()</intensity>
+
+Expected value to not be of type longitude, received:
+  <red>"12.496366"</color>"
+`;
+
+exports[`.toBeGeoLongitude fails when not given a longitude negative number 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeGeoLongitude()</intensity>
+
+Expected value to be of type longitude, received:
+  <red>-180.1</color>"
+`;
+
+exports[`.toBeGeoLongitude fails when not given a longitude positive number 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeGeoLongitude()</intensity>
+
+Expected value to be of type longitude, received:
+  <red>180.1</color>"
+`;
+
+exports[`.toBeGeoLongitude fails when not given a longitude string 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeGeoLongitude()</intensity>
+
+Expected value to be of type longitude, received:
+  <red>"any_not_valid_longitude"</color>"
+`;

--- a/test/matchers/toBeGeoLatitude.test.js
+++ b/test/matchers/toBeGeoLatitude.test.js
@@ -1,0 +1,44 @@
+import * as matcher from 'src/matchers/toBeGeoLatitude';
+
+expect.extend(matcher);
+
+const ROME = { latitude: 41.902783, longitude: 12.496366 };
+
+describe('.toBeGeoLatitude', () => {
+  test('passes when given valid latitude number', () => {
+    expect(ROME.latitude).toBeGeoLatitude();
+  });
+
+  test('passes when given valid latitude string', () => {
+    expect(`${ROME.latitude}`).toBeGeoLatitude();
+  });
+
+  test('fails when not given a latitude string', () => {
+    expect(() => expect('any_not_valid_latitude').toBeGeoLatitude()).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when not given a latitude positive number', () => {
+    expect(() => expect(90.1).toBeGeoLatitude()).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when not given a latitude negative number', () => {
+    expect(() => expect(-90.1).toBeGeoLatitude()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeGeoLatitude', () => {
+  test.each([['true'], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
+    'passes when item is not of type latitude: %s',
+    given => {
+      expect(given).not.toBeGeoLatitude();
+    },
+  );
+
+  test('fails when given a latitude number', () => {
+    expect(() => expect(ROME.latitude).not.toBeGeoLatitude()).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given a latitude string', () => {
+    expect(() => expect(`${ROME.latitude}`).not.toBeGeoLatitude()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toBeGeoLongitude.test.js
+++ b/test/matchers/toBeGeoLongitude.test.js
@@ -1,0 +1,44 @@
+import * as matcher from 'src/matchers/toBeGeoLongitude';
+
+expect.extend(matcher);
+
+const ROME = { latitude: 41.902783, longitude: 12.496366 };
+
+describe('.toBeGeoLongitude', () => {
+  test('passes when given valid longitude number', () => {
+    expect(ROME.longitude).toBeGeoLongitude();
+  });
+
+  test('passes when given valid longitude string', () => {
+    expect(`${ROME.longitude}`).toBeGeoLongitude();
+  });
+
+  test('fails when not given a longitude string', () => {
+    expect(() => expect('any_not_valid_longitude').toBeGeoLongitude()).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when not given a longitude positive number', () => {
+    expect(() => expect(180.1).toBeGeoLongitude()).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when not given a longitude negative number', () => {
+    expect(() => expect(-180.1).toBeGeoLongitude()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeGeoLongitude', () => {
+  test.each([['true'], [{}], [[]], [() => {}], [undefined], [null], [NaN]])(
+    'passes when item is not of type longitude: %s',
+    given => {
+      expect(given).not.toBeGeoLongitude();
+    },
+  );
+
+  test('fails when given a longitude number', () => {
+    expect(() => expect(ROME.longitude).not.toBeGeoLongitude()).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given a longitude string', () => {
+    expect(() => expect(`${ROME.longitude}`).not.toBeGeoLongitude()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -575,6 +575,16 @@ declare namespace jest {
     toBeFunction(): any;
 
     /**
+     * Use `.toBeGeoLatitude` when checking if a value is a `latitude`.
+     */
+    toBeGeoLatitude(): any;
+
+    /**
+     * Use `.toBeGeoLongitude` when checking if a value is a `longitude`.
+     */
+    toBeGeoLongitude(): any;
+
+    /**
      * Use `.toBeDateString` when checking if a value is a valid date string.
      */
     toBeDateString(): any;

--- a/website/docs/matchers/Geographic.mdx
+++ b/website/docs/matchers/Geographic.mdx
@@ -1,0 +1,25 @@
+import { TestFile } from '../../src/components/CustomSandpack';
+
+# Geographic
+
+### .toBeGeoLatitude()
+
+Use `.toBeGeoLatitude` when checking if a value is a `latitude`.
+
+<TestFile name="toBeGeoLatitude">
+  {`test('passes when value is a latitude', () => {
+  const ROME = { latitude: 41.902783, longitude: 12.496366 };
+  expect(ROME.latitude).toBeGeoLatitude();
+});`}
+</TestFile>
+
+### .toBeGeoLongitude()
+
+Use `.toBeGeoLongitude` when checking if a value is a `longitude`.
+
+<TestFile name="toBeGeoLongitude">
+  {`test('passes when value is a longitude', () => {
+  const ROME = { latitude: 41.902783, longitude: 12.496366 };
+  expect(ROME.longitude).toBeGeoLongitude();
+});`}
+</TestFile>

--- a/website/docs/matchers/index.md
+++ b/website/docs/matchers/index.md
@@ -105,3 +105,8 @@ sidebar_position: 1
 ## [Symbol](/docs/matchers/symbol)
 
 - [.toBeSymbol()](/docs/matchers/symbol/#tobesymbol)
+
+## [Geographic](/docs/matchers/geographic)
+
+- [.toBeGeoLatitude()](/docs/matchers/geographic/#tobegeolatitude)
+- [.toBeGeoLongitude()](/docs/matchers/geographic/#tobegeolongitude)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1840,6 +1840,11 @@ char-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-2.0.1.tgz#6dafdb25f9d3349914079f010ba8d0e6ff9cd01e"
   integrity sha512-oSvEeo6ZUD7NepqAat3RqoucZ5SeqLJgOvVIwkafu6IP3V0pO38s/ypdVUmDDK6qIIHNlYHJAKX9E7R7HoKElw==
 
+check-geographic-coordinates@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/check-geographic-coordinates/-/check-geographic-coordinates-0.0.10.tgz#10240bfead3e81ea054ad526d973ceccf46657eb"
+  integrity sha512-wgMiNEVXsvdh5TaEkwvPXgfpRyVcz8nimfiw8x/7c9sNsG/mPjB2iyKftdYv72e1KY/kHp/Vh9OZc2MHur/evw==
+
 chokidar@^3.4.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"


### PR DESCRIPTION
### What

add geographic assertions (toBeGeoLatitude, toBeGeoLongitude)

### Why

I've been using jest and jest-extended for long. Few months ago I needed to make geographic 
assertions to a project I was working on but I didn't find anything already done so I wrote 
some custom code in my project and later refactored and open sourced to a library 
(https://www.npmjs.com/package/check-geographic-coordinates). Other developers finded it useful 
and used it, some of them gave to me some feedbacks in how to improve it, but I was missing the 
most important one, the jest assertion syntax integration. So I decided to look at jest-exteded 
more in deep, not as the user I was, but as a developer and I made this PR. Looking backward 
I think I would used it directly with jest-extended. 

I hope you like it and that you find useful for other developers too. 
I'm glad to recevie any feedback from you. Thank you, Marco Verdecchia.

### Notes

Assertions based on https://www.npmjs.com/package/check-geographic-coordinates

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
