### PR TITLE
Create pass/fail error messages only if required

### DIFF
--- a/src/matchers/toBeAfter.js
+++ b/src/matchers/toBeAfter.js
@@ -1,18 +1,19 @@
 export function toBeAfter(date, after) {
   const { printReceived, matcherHint } = this.utils;
-  const passMessage =
-    matcherHint('.not.toBeAfter', 'received', '') +
-    '\n\n' +
-    `Expected date to be after ${printReceived(after)} but received:\n` +
-    `  ${printReceived(date)}`;
-
-  const failMessage =
-    matcherHint('.toBeAfter', 'received', '') +
-    '\n\n' +
-    `Expected date to be after ${printReceived(after)} but received:\n` +
-    `  ${printReceived(date)}`;
 
   const pass = date > after;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeAfter', 'received', '') +
+          '\n\n' +
+          `Expected date to be after ${printReceived(after)} but received:\n` +
+          `  ${printReceived(date)}`
+        : matcherHint('.toBeAfter', 'received', '') +
+          '\n\n' +
+          `Expected date to be after ${printReceived(after)} but received:\n` +
+          `  ${printReceived(date)}`,
+  };
 }

--- a/src/matchers/toBeAfterOrEqualTo.js
+++ b/src/matchers/toBeAfterOrEqualTo.js
@@ -1,19 +1,19 @@
 export function toBeAfterOrEqualTo(actual, expected) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeAfterOrEqualTo', 'received', '') +
-    '\n\n' +
-    `Expected date to be after or equal to ${printReceived(expected)} but received:\n` +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeAfterOrEqualTo', 'received', '') +
-    '\n\n' +
-    `Expected date to be after or equal to ${printReceived(expected)} but received:\n` +
-    `  ${printReceived(actual)}`;
-
   const pass = actual >= expected;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeAfterOrEqualTo', 'received', '') +
+          '\n\n' +
+          `Expected date to be after or equal to ${printReceived(expected)} but received:\n` +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeAfterOrEqualTo', 'received', '') +
+          '\n\n' +
+          `Expected date to be after or equal to ${printReceived(expected)} but received:\n` +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeArray.js
+++ b/src/matchers/toBeArray.js
@@ -1,19 +1,19 @@
 export function toBeArray(expected) {
   const { matcherHint, printReceived } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeArray', 'received', '') +
-    '\n\n' +
-    'Expected value to not be an array received:\n' +
-    `  ${printReceived(expected)}`;
-
-  const failMessage =
-    matcherHint('.toBeArray', 'received', '') +
-    '\n\n' +
-    'Expected value to be an array received:\n' +
-    `  ${printReceived(expected)}`;
-
   const pass = Array.isArray(expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeArray', 'received', '') +
+          '\n\n' +
+          'Expected value to not be an array received:\n' +
+          `  ${printReceived(expected)}`
+        : matcherHint('.toBeArray', 'received', '') +
+          '\n\n' +
+          'Expected value to be an array received:\n' +
+          `  ${printReceived(expected)}`,
+  };
 }

--- a/src/matchers/toBeArrayOfSize.js
+++ b/src/matchers/toBeArrayOfSize.js
@@ -3,23 +3,25 @@ import { determinePropertyMessage } from '../utils';
 export function toBeArrayOfSize(actual, expected) {
   const { printExpected, printReceived, matcherHint } = this.utils;
 
-  const passMessage = `${matcherHint('.not.toBeArrayOfSize')}
-
-Expected value to not be an array of size:
-  ${printExpected(expected)}
-Received:
-  value: ${printReceived(actual)}
-  length: ${printReceived(determinePropertyMessage(actual, 'length'))}`;
-
-  const failMessage = `${matcherHint('.toBeArrayOfSize')}
-
-Expected value to be an array of size:
-  ${printExpected(expected)}
-Received:
-  value: ${printReceived(actual)}
-  length: ${printReceived(determinePropertyMessage(actual, 'length'))}`;
-
   const pass = Array.isArray(actual) && actual.length === expected;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeArrayOfSize') +
+          '\n\n' +
+          'Expected value to not be an array of size:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  value: ${printReceived(actual)}\n` +
+          `  length: ${printReceived(determinePropertyMessage(actual, 'length'))}`
+        : matcherHint('.toBeArrayOfSize') +
+          '\n\n' +
+          'Expected value to be an array of size:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  value: ${printReceived(actual)}\n` +
+          `  length: ${printReceived(determinePropertyMessage(actual, 'length'))}`,
+  };
 }

--- a/src/matchers/toBeBefore.js
+++ b/src/matchers/toBeBefore.js
@@ -1,18 +1,19 @@
 export function toBeBefore(actual, expected) {
   const { matcherHint, printReceived } = this.utils;
-  const passMessage =
-    matcherHint('.not.toBeBefore', 'received', '') +
-    '\n\n' +
-    `Expected date to be before ${printReceived(expected)} but received:\n` +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeBefore', 'received', '') +
-    '\n\n' +
-    `Expected date to be before ${printReceived(expected)} but received:\n` +
-    `  ${printReceived(actual)}`;
 
   const pass = actual < expected;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeBefore', 'received', '') +
+          '\n\n' +
+          `Expected date to be before ${printReceived(expected)} but received:\n` +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeBefore', 'received', '') +
+          '\n\n' +
+          `Expected date to be before ${printReceived(expected)} but received:\n` +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeBeforeOrEqualTo.js
+++ b/src/matchers/toBeBeforeOrEqualTo.js
@@ -1,19 +1,19 @@
 export function toBeBeforeOrEqualTo(actual, expected) {
   const { matcherHint, printReceived } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeBeforeOrEqualTo', 'received', '') +
-    '\n\n' +
-    `Expected date to be before or equal to ${printReceived(expected)} but received:\n` +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
-    '\n\n' +
-    `Expected date to be before or equal to ${printReceived(expected)} but received:\n` +
-    `  ${printReceived(actual)}`;
-
   const pass = actual <= expected;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeBeforeOrEqualTo', 'received', '') +
+          '\n\n' +
+          `Expected date to be before or equal to ${printReceived(expected)} but received:\n` +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
+          '\n\n' +
+          `Expected date to be before or equal to ${printReceived(expected)} but received:\n` +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeBetween.js
+++ b/src/matchers/toBeBetween.js
@@ -1,19 +1,19 @@
 export function toBeBetween(actual, startDate, endDate) {
   const { matcherHint, printReceived } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeBetween', 'received', '') +
-    '\n\n' +
-    `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeBetween', 'received', '') +
-    '\n\n' +
-    `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
-    `  ${printReceived(actual)}`;
-
   const pass = actual >= startDate && actual <= endDate;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeBetween', 'received', '') +
+          '\n\n' +
+          `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeBetween', 'received', '') +
+          '\n\n' +
+          `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeBoolean.js
+++ b/src/matchers/toBeBoolean.js
@@ -1,19 +1,19 @@
 export function toBeBoolean(actual) {
   const { matcherHint, printReceived } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeBoolean', 'received', '') +
-    '\n\n' +
-    'Expected value to not be of type boolean, received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeBoolean', 'received', '') +
-    '\n\n' +
-    'Expected value to be of type boolean, received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = typeof actual === 'boolean' || actual instanceof Boolean;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeBoolean', 'received', '') +
+          '\n\n' +
+          'Expected value to not be of type boolean, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeBoolean', 'received', '') +
+          '\n\n' +
+          'Expected value to be of type boolean, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeDate.js
+++ b/src/matchers/toBeDate.js
@@ -3,19 +3,19 @@ import { getType } from 'jest-get-type';
 export function toBeDate(actual) {
   const { matcherHint, printReceived } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeDate', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a date received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeDate', 'received', '') +
-    '\n\n' +
-    'Expected value to be a date received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = getType(actual) === 'date' && !isNaN(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeDate', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a date received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeDate', 'received', '') +
+          '\n\n' +
+          'Expected value to be a date received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeDateString.js
+++ b/src/matchers/toBeDateString.js
@@ -1,19 +1,19 @@
 export function toBeDateString(actual) {
   const { matcherHint, printReceived } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeDateString', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a date string received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeDateString', 'received', '') +
-    '\n\n' +
-    'Expected value to be a date string received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = !isNaN(Date.parse(actual));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeDateString', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a date string received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeDateString', 'received', '') +
+          '\n\n' +
+          'Expected value to be a date string received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeEmpty.js
+++ b/src/matchers/toBeEmpty.js
@@ -1,21 +1,21 @@
 export function toBeEmpty(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeEmpty', 'received', '') +
-    '\n\n' +
-    'Expected value to not be empty received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeEmpty', 'received', '') +
-    '\n\n' +
-    'Expected value to be empty received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = this.equals({}, actual) || isEmptyIterable(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeEmpty', 'received', '') +
+          '\n\n' +
+          'Expected value to not be empty received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeEmpty', 'received', '') +
+          '\n\n' +
+          'Expected value to be empty received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }
 
 const isEmptyIterable = value => {

--- a/src/matchers/toBeEmptyObject.js
+++ b/src/matchers/toBeEmptyObject.js
@@ -3,19 +3,19 @@ import { getType } from 'jest-get-type';
 export function toBeEmptyObject(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeEmptyObject', 'received', '') +
-    '\n\n' +
-    'Expected value to not be an empty object, received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeEmptyObject', 'received', '') +
-    '\n\n' +
-    'Expected value to be an empty object, received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = getType(actual) === 'object' && Object.keys(actual).length === 0;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeEmptyObject', 'received', '') +
+          '\n\n' +
+          'Expected value to not be an empty object, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeEmptyObject', 'received', '') +
+          '\n\n' +
+          'Expected value to be an empty object, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeEven.js
+++ b/src/matchers/toBeEven.js
@@ -1,21 +1,21 @@
 export function toBeEven(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeEven', 'received', '') +
-    '\n\n' +
-    'Expected value to not be an even number received:\n' +
-    ` ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeEven', 'received', '') +
-    '\n\n' +
-    'Expected value to be an even number received:\n' +
-    ` ${printReceived(actual)}`;
-
   const pass = isNumber(actual) && isEven(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeEven', 'received', '') +
+          '\n\n' +
+          'Expected value to not be an even number received:\n' +
+          ` ${printReceived(actual)}`
+        : matcherHint('.toBeEven', 'received', '') +
+          '\n\n' +
+          'Expected value to be an even number received:\n' +
+          ` ${printReceived(actual)}`,
+  };
 }
 
 const isNumber = expected => !isNaN(parseInt(expected));

--- a/src/matchers/toBeExtensible.js
+++ b/src/matchers/toBeExtensible.js
@@ -1,19 +1,19 @@
 export function toBeExtensible(actual) {
   const { matcherHint, printExpected, printReceived } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeExtensible', 'received', '') +
-    '\n\n' +
-    'Expected value to not be extensible received:\n' +
-    `  ${printExpected(actual)}\n`;
-
-  const failMessage =
-    matcherHint('.toBeExtensible', 'received', '') +
-    '\n\n' +
-    'Expected value to be extensible received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = Object.isExtensible(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeExtensible', 'received', '') +
+          '\n\n' +
+          'Expected value to not be extensible received:\n' +
+          `  ${printExpected(actual)}\n`
+        : matcherHint('.toBeExtensible', 'received', '') +
+          '\n\n' +
+          'Expected value to be extensible received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeFalse.js
+++ b/src/matchers/toBeFalse.js
@@ -1,21 +1,21 @@
 export function toBeFalse(actual) {
   const { printReceived, matcherHint, printExpected } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeFalse', 'received', '') +
-    '\n\n' +
-    'Expected value to not be false received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeFalse', 'received', '') +
-    '\n\n' +
-    'Expected value to be false:\n' +
-    `  ${printExpected(false)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual === false;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeFalse', 'received', '') +
+          '\n\n' +
+          'Expected value to not be false received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeFalse', 'received', '') +
+          '\n\n' +
+          'Expected value to be false:\n' +
+          `  ${printExpected(false)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeFinite.js
+++ b/src/matchers/toBeFinite.js
@@ -1,19 +1,19 @@
 export function toBeFinite(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeFinite', 'received', '') +
-    '\n\n' +
-    'Expected value to not be finite received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeFinite', 'received', '') +
-    '\n\n' +
-    'Expected value to be finite received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = Number.isFinite(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeFinite', 'received', '') +
+          '\n\n' +
+          'Expected value to not be finite received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeFinite', 'received', '') +
+          '\n\n' +
+          'Expected value to be finite received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeFrozen.js
+++ b/src/matchers/toBeFrozen.js
@@ -1,11 +1,13 @@
 export function toBeFrozen(actual) {
   const { matcherHint } = this.utils;
 
-  const passMessage = matcherHint('.not.toBeFrozen', 'received', '') + '\n\n' + 'Expected object to not be frozen';
-
-  const failMessage = matcherHint('.toBeFrozen', 'received', '') + '\n\n' + 'Expected object to be frozen';
-
   const pass = Object.isFrozen(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeFrozen', 'received', '') + '\n\nExpected object to not be frozen'
+        : matcherHint('.toBeFrozen', 'received', '') + '\n\nExpected object to be frozen',
+  };
 }

--- a/src/matchers/toBeFunction.js
+++ b/src/matchers/toBeFunction.js
@@ -1,19 +1,19 @@
 export function toBeFunction(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeFunction', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a function, received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeFunction', 'received', '') +
-    '\n\n' +
-    'Expected to receive a function, received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = typeof actual === 'function';
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeFunction', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a function, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeFunction', 'received', '') +
+          '\n\n' +
+          'Expected to receive a function, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeHexadecimal.js
+++ b/src/matchers/toBeHexadecimal.js
@@ -1,21 +1,21 @@
 export function toBeHexadecimal(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeHexadecimal', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a hexadecimal, received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeHexadecimal', 'received', '') +
-    '\n\n' +
-    'Expected value to be a hexadecimal, received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = longRegex.test(actual) || shortRegex.test(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeHexadecimal', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a hexadecimal, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeHexadecimal', 'received', '') +
+          '\n\n' +
+          'Expected value to be a hexadecimal, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }
 
 const longRegex = RegExp(/^#\b[a-f0-9]{6}\b/gi);

--- a/src/matchers/toBeInRange.js
+++ b/src/matchers/toBeInRange.js
@@ -5,18 +5,18 @@ export function toBeInRange(actual, min, max) {
 
   const pass = element === undefined;
 
-  const passMessage =
-    matcherHint('.not.toBeInRange') +
-    '\n\n' +
-    `Expected Array to not be in range ${printExpected(min)}, ${printExpected(max)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeInRange') +
-    '\n\n' +
-    `Expected: Array elements to be in range (${printExpected(min)}, ${printExpected(max)})\n` +
-    `Received: Array element out of range ${printReceived(element)}`;
-
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeInRange') +
+          '\n\n' +
+          `Expected Array to not be in range ${printExpected(min)}, ${printExpected(max)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeInRange') +
+          '\n\n' +
+          `Expected: Array elements to be in range (${printExpected(min)}, ${printExpected(max)})\n` +
+          `Received: Array element out of range ${printReceived(element)}`,
+  };
 }

--- a/src/matchers/toBeInteger.js
+++ b/src/matchers/toBeInteger.js
@@ -1,21 +1,21 @@
 export function toBeInteger(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeInteger', 'received', '') +
-    '\n\n' +
-    'Expected value to not be an integer received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeInteger', 'received', '') +
-    '\n\n' +
-    'Expected value to be an integer received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = isNumber(actual) && isInteger(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeInteger', 'received', '') +
+          '\n\n' +
+          'Expected value to not be an integer received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeInteger', 'received', '') +
+          '\n\n' +
+          'Expected value to be an integer received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }
 
 const isNumber = value => !isNaN(parseInt(value));

--- a/src/matchers/toBeNaN.js
+++ b/src/matchers/toBeNaN.js
@@ -1,19 +1,19 @@
 export function toBeNaN(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeNaN', 'received', '') +
-    '\n\n' +
-    'Expected value to be a number received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeNaN', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a number received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = isNaN(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeNaN', 'received', '') +
+          '\n\n' +
+          'Expected value to be a number received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeNaN', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a number received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeNegative.js
+++ b/src/matchers/toBeNegative.js
@@ -1,21 +1,21 @@
 export function toBeNegative(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeNegative', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a negative number received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeNegative', 'received', '') +
-    '\n\n' +
-    'Expected value to be a negative number received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = isNumber(actual) && isNegative(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeNegative', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a negative number received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeNegative', 'received', '') +
+          '\n\n' +
+          'Expected value to be a negative number received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }
 
 const isNumber = value => !isNaN(parseInt(value));

--- a/src/matchers/toBeNil.js
+++ b/src/matchers/toBeNil.js
@@ -1,19 +1,19 @@
 export function toBeNil(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeNil', 'received', '') +
-    '\n\n' +
-    'Expected value not to be null or undefined, received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeNil', 'received', '') +
-    '\n\n' +
-    'Expected value to be null or undefined, received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual === undefined || actual === null;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeNil', 'received', '') +
+          '\n\n' +
+          'Expected value not to be null or undefined, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeNil', 'received', '') +
+          '\n\n' +
+          'Expected value to be null or undefined, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeNumber.js
+++ b/src/matchers/toBeNumber.js
@@ -1,19 +1,19 @@
 export function toBeNumber(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeNumber', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a number received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeNumber', 'received', '') +
-    '\n\n' +
-    'Expected value to be a number received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = typeof actual === 'number';
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeNumber', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a number received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeNumber', 'received', '') +
+          '\n\n' +
+          'Expected value to be a number received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeObject.js
+++ b/src/matchers/toBeObject.js
@@ -3,19 +3,19 @@ import { getType } from 'jest-get-type';
 export function toBeObject(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeObject', 'received', '') +
-    '\n\n' +
-    'Expected value to not be an object, received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeObject', 'received', '') +
-    '\n\n' +
-    'Expected value to be an object, received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = getType(actual) === 'object';
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeObject', 'received', '') +
+          '\n\n' +
+          'Expected value to not be an object, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeObject', 'received', '') +
+          '\n\n' +
+          'Expected value to be an object, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeOdd.js
+++ b/src/matchers/toBeOdd.js
@@ -1,19 +1,19 @@
 export function toBeOdd(received) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeOdd', 'received', '') +
-    '\n\n' +
-    'Expected value to not be odd received:\n' +
-    `  ${printReceived(received)}`;
-
-  const failMessage =
-    matcherHint('.toBeOdd', 'received', '') +
-    '\n\n' +
-    'Expected value to be odd received:\n' +
-    `  ${printReceived(received)}`;
-
   const pass = !isNaN(parseInt(received)) && received % 2 === 1;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeOdd', 'received', '') +
+          '\n\n' +
+          'Expected value to not be odd received:\n' +
+          `  ${printReceived(received)}`
+        : matcherHint('.toBeOdd', 'received', '') +
+          '\n\n' +
+          'Expected value to be odd received:\n' +
+          `  ${printReceived(received)}`,
+  };
 }

--- a/src/matchers/toBeOneOf.js
+++ b/src/matchers/toBeOneOf.js
@@ -3,23 +3,23 @@ import { contains } from '../utils';
 export function toBeOneOf(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeOneOf') +
-    '\n\n' +
-    'Expected value to not be in list:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeOneOf') +
-    '\n\n' +
-    'Expected value to be in list:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = contains(this.equals, expected, actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeOneOf') +
+          '\n\n' +
+          'Expected value to not be in list:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeOneOf') +
+          '\n\n' +
+          'Expected value to be in list:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBePositive.js
+++ b/src/matchers/toBePositive.js
@@ -1,19 +1,19 @@
 export function toBePositive(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBePositive', 'received', '') +
-    '\n\n' +
-    'Expected value to not be positive received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBePositive', 'received', '') +
-    '\n\n' +
-    'Expected value to be positive received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual !== true && !isNaN(actual) && actual !== Infinity && actual > 0;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBePositive', 'received', '') +
+          '\n\n' +
+          'Expected value to not be positive received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBePositive', 'received', '') +
+          '\n\n' +
+          'Expected value to be positive received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeSealed.js
+++ b/src/matchers/toBeSealed.js
@@ -1,11 +1,13 @@
 export function toBeSealed(actual) {
   const { matcherHint } = this.utils;
 
-  const passMessage = matcherHint('.not.toBeSealed', 'received', '') + '\n\nExpected object to be not sealed';
-
-  const failMessage = matcherHint('.toBeSealed', 'received', '') + '\n\nExpected object to not sealed';
-
   const pass = Object.isSealed(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeSealed', 'received', '') + '\n\nExpected object to be not sealed'
+        : matcherHint('.toBeSealed', 'received', '') + '\n\nExpected object to not sealed',
+  };
 }

--- a/src/matchers/toBeString.js
+++ b/src/matchers/toBeString.js
@@ -1,21 +1,21 @@
 export function toBeString(expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeString', 'received', '') +
-    '\n\n' +
-    'Expected value to not be of type string received:\n' +
-    `  ${printReceived(expected)}`;
-
-  const failMessage =
-    matcherHint('.toBeString', 'received', '') +
-    '\n\n' +
-    'Expected value to be of type string:\n' +
-    `  ${printExpected('type of string')}\n` +
-    'Received:\n' +
-    `  ${printReceived(typeof expected)}`;
-
   const pass = typeof expected === 'string' || expected instanceof String;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeString', 'received', '') +
+          '\n\n' +
+          'Expected value to not be of type string received:\n' +
+          `  ${printReceived(expected)}`
+        : matcherHint('.toBeString', 'received', '') +
+          '\n\n' +
+          'Expected value to be of type string:\n' +
+          `  ${printExpected('type of string')}\n` +
+          'Received:\n' +
+          `  ${printReceived(typeof expected)}`,
+  };
 }

--- a/src/matchers/toBeSymbol.js
+++ b/src/matchers/toBeSymbol.js
@@ -1,19 +1,19 @@
 export function toBeSymbol(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeSymbol', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a symbol, received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeSymbol', 'received', '') +
-    '\n\n' +
-    'Expected to receive a symbol, received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = typeof actual === 'symbol';
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeSymbol', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a symbol, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeSymbol', 'received', '') +
+          '\n\n' +
+          'Expected to receive a symbol, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeTrue.js
+++ b/src/matchers/toBeTrue.js
@@ -1,21 +1,21 @@
 export function toBeTrue(actual) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeTrue', 'received', '') +
-    '\n\n' +
-    'Expected value to not be true received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeTrue', 'received', '') +
-    '\n\n' +
-    'Expected value to be true:\n' +
-    `  ${printExpected(true)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual === true;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeTrue', 'received', '') +
+          '\n\n' +
+          'Expected value to not be true received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeTrue', 'received', '') +
+          '\n\n' +
+          'Expected value to be true:\n' +
+          `  ${printExpected(true)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeValidDate.js
+++ b/src/matchers/toBeValidDate.js
@@ -3,19 +3,19 @@ import { getType } from 'jest-get-type';
 export function toBeValidDate(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeValidDate', 'received', '') +
-    '\n\n' +
-    'Expected value to not be a valid date received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeValidDate', 'received', '') +
-    '\n\n' +
-    'Expected value to be a valid date received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = getType(actual) === 'date' && !isNaN(actual) && !isNaN(actual.getTime());
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeValidDate', 'received', '') +
+          '\n\n' +
+          'Expected value to not be a valid date received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeValidDate', 'received', '') +
+          '\n\n' +
+          'Expected value to be a valid date received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toBeWithin.js
+++ b/src/matchers/toBeWithin.js
@@ -1,23 +1,23 @@
 export function toBeWithin(actual, start, end) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toBeWithin') +
-    '\n\n' +
-    'Expected number to not be within start (inclusive) and end (exclusive):\n' +
-    `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toBeWithin') +
-    '\n\n' +
-    'Expected number to be within start (inclusive) and end (exclusive):\n' +
-    `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual >= start && actual < end;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeWithin') +
+          '\n\n' +
+          'Expected number to not be within start (inclusive) and end (exclusive):\n' +
+          `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeWithin') +
+          '\n\n' +
+          'Expected number to be within start (inclusive) and end (exclusive):\n' +
+          `  start: ${printExpected(start)}  end: ${printExpected(end)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainAllEntries.js
+++ b/src/matchers/toContainAllEntries.js
@@ -3,26 +3,26 @@ import { containsEntry } from '../utils';
 export function toContainAllEntries(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainAllEntries') +
-    '\n\n' +
-    'Expected object to not only contain all of the given entries:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainAllEntries') +
-    '\n\n' +
-    'Expected object to only contain all of the given entries:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass =
     actual.hasOwnProperty &&
     expected.length == Object.keys(actual).length &&
     expected.every(entry => containsEntry(this.equals, actual, entry));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainAllEntries') +
+          '\n\n' +
+          'Expected object to not only contain all of the given entries:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainAllEntries') +
+          '\n\n' +
+          'Expected object to only contain all of the given entries:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainAllKeys.js
+++ b/src/matchers/toContainAllKeys.js
@@ -3,24 +3,24 @@ import { contains } from '../utils';
 export function toContainAllKeys(actual, expected) {
   const { printExpected, printReceived, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainAllKeys') +
-    '\n\n' +
-    'Expected object to not contain all keys:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(Object.keys(actual))}`;
-
-  const failMessage =
-    matcherHint('.toContainAllKeys') +
-    '\n\n' +
-    'Expected object to contain all keys:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(Object.keys(actual))}`;
-
   const objectKeys = Object.keys(actual);
   const pass = objectKeys.length === expected.length && expected.every(key => contains(this.equals, objectKeys, key));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainAllKeys') +
+          '\n\n' +
+          'Expected object to not contain all keys:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(Object.keys(actual))}`
+        : matcherHint('.toContainAllKeys') +
+          '\n\n' +
+          'Expected object to contain all keys:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(Object.keys(actual))}`,
+  };
 }

--- a/src/matchers/toContainAllValues.js
+++ b/src/matchers/toContainAllValues.js
@@ -3,25 +3,25 @@ import { contains } from '../utils';
 export function toContainAllValues(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainAllValues') +
-    '\n\n' +
-    'Expected object to not contain all values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainAllValues') +
-    '\n\n' +
-    'Expected object to contain all values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const values = Object.keys(actual).map(k => actual[k]);
   const pass =
     values.length === expected.length && values.every(objectValue => contains(this.equals, expected, objectValue));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainAllValues') +
+          '\n\n' +
+          'Expected object to not contain all values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainAllValues') +
+          '\n\n' +
+          'Expected object to contain all values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainAnyEntries.js
+++ b/src/matchers/toContainAnyEntries.js
@@ -3,24 +3,24 @@ import { contains } from '../utils';
 export function toContainAnyEntries(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainAnyEntries') +
-    '\n\n' +
-    'Expected object to not contain any of the provided entries:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainAnyEntries') +
-    '\n\n' +
-    'Expected object to contain any of the provided entries:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const entries = Object.keys(actual).map(k => [k, actual[k]]);
   const pass = expected.some(entry => contains(this.equals, entries, entry));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainAnyEntries') +
+          '\n\n' +
+          'Expected object to not contain any of the provided entries:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainAnyEntries') +
+          '\n\n' +
+          'Expected object to contain any of the provided entries:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainAnyKeys.js
+++ b/src/matchers/toContainAnyKeys.js
@@ -1,23 +1,23 @@
 export function toContainAnyKeys(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainAnyKeys') +
-    '\n\n' +
-    'Expected object not to contain any of the following keys:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainAnyKeys') +
-    '\n\n' +
-    'Expected object to contain any of the following keys:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = expected.some(key => Object.prototype.hasOwnProperty.call(actual, key));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainAnyKeys') +
+          '\n\n' +
+          'Expected object not to contain any of the following keys:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainAnyKeys') +
+          '\n\n' +
+          'Expected object to contain any of the following keys:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainAnyValues.js
+++ b/src/matchers/toContainAnyValues.js
@@ -3,24 +3,24 @@ import { contains } from '../utils';
 export function toContainAnyValues(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainAnyValues') +
-    '\n\n' +
-    'Expected object to not contain any of the following values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainAnyValues') +
-    '\n\n' +
-    'Expected object to contain any of the following values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const objectValues = Object.keys(actual).map(k => actual[k]);
   const pass = expected.some(value => contains(this.equals, objectValues, value));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainAnyValues') +
+          '\n\n' +
+          'Expected object to not contain any of the following values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainAnyValues') +
+          '\n\n' +
+          'Expected object to contain any of the following values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainEntries.js
+++ b/src/matchers/toContainEntries.js
@@ -3,23 +3,23 @@ import { containsEntry } from '../utils';
 export function toContainEntries(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainEntries') +
-    '\n\n' +
-    'Expected object to not contain all of the given entries:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainEntries') +
-    '\n\n' +
-    'Expected object to contain all of the given entries:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = expected.every(entry => containsEntry(this.equals, actual, entry));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainEntries') +
+          '\n\n' +
+          'Expected object to not contain all of the given entries:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainEntries') +
+          '\n\n' +
+          'Expected object to contain all of the given entries:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainEntry.js
+++ b/src/matchers/toContainEntry.js
@@ -3,23 +3,23 @@ import { containsEntry } from '../utils';
 export function toContainEntry(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainEntry') +
-    '\n\n' +
-    'Expected object to not contain entry:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainEntry') +
-    '\n\n' +
-    'Expected object to contain entry:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = containsEntry(this.equals, actual, expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainEntry') +
+          '\n\n' +
+          'Expected object to not contain entry:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainEntry') +
+          '\n\n' +
+          'Expected object to contain entry:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainKey.js
+++ b/src/matchers/toContainKey.js
@@ -1,23 +1,23 @@
 export function toContainKey(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainKey') +
-    '\n\n' +
-    'Expected object to not contain key:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainKey') +
-    '\n\n' +
-    'Expected object to contain key:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual.hasOwnProperty && Object.prototype.hasOwnProperty.call(actual, expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainKey') +
+          '\n\n' +
+          'Expected object to not contain key:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainKey') +
+          '\n\n' +
+          'Expected object to contain key:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainKeys.js
+++ b/src/matchers/toContainKeys.js
@@ -1,25 +1,25 @@
 export function toContainKeys(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainKeys') +
-    '\n\n' +
-    'Expected object to not contain all keys:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainKeys') +
-    '\n\n' +
-    'Expected object to contain all keys:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = expected.every(
     key => actual && actual.hasOwnProperty && Object.prototype.hasOwnProperty.call(actual, key),
   );
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainKeys') +
+          '\n\n' +
+          'Expected object to not contain all keys:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainKeys') +
+          '\n\n' +
+          'Expected object to contain all keys:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainValue.js
+++ b/src/matchers/toContainValue.js
@@ -3,24 +3,24 @@ import { contains } from '../utils';
 export function toContainValue(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainValue') +
-    '\n\n' +
-    'Expected object to not contain value:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainValue') +
-    '\n\n' +
-    'Expected object to contain value:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const values = Object.keys(actual).map(k => actual[k]);
   const pass = contains(this.equals, values, expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainValue') +
+          '\n\n' +
+          'Expected object to not contain value:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainValue') +
+          '\n\n' +
+          'Expected object to contain value:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toContainValues.js
+++ b/src/matchers/toContainValues.js
@@ -3,24 +3,24 @@ import { contains } from '../utils';
 export function toContainValues(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toContainValues') +
-    '\n\n' +
-    'Expected object to not contain all values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toContainValues') +
-    '\n\n' +
-    'Expected object to contain all values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const values = Object.keys(actual).map(k => actual[k]);
   const pass = expected.every(value => contains(this.equals, values, value));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toContainValues') +
+          '\n\n' +
+          'Expected object to not contain all values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toContainValues') +
+          '\n\n' +
+          'Expected object to contain all values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toEndWith.js
+++ b/src/matchers/toEndWith.js
@@ -1,23 +1,23 @@
 export function toEndWith(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toEndWith') +
-    '\n\n' +
-    'Expected string to not end with:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toEndWith') +
-    '\n\n' +
-    'Expected string to end with:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual.endsWith(expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toEndWith') +
+          '\n\n' +
+          'Expected string to not end with:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toEndWith') +
+          '\n\n' +
+          'Expected string to end with:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toEqualCaseInsensitive.js
+++ b/src/matchers/toEqualCaseInsensitive.js
@@ -1,23 +1,23 @@
 export function toEqualCaseInsensitive(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toEqualCaseInsensitive') +
-    '\n\n' +
-    'Expected values to not be equal while ignoring case (using ===):\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toEqualCaseInsensitive') +
-    '\n\n' +
-    'Expected values to be equal while ignoring case (using ===):\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = String(actual).toLowerCase() === String(expected).toLowerCase();
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toEqualCaseInsensitive') +
+          '\n\n' +
+          'Expected values to not be equal while ignoring case (using ===):\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toEqualCaseInsensitive') +
+          '\n\n' +
+          'Expected values to be equal while ignoring case (using ===):\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toHaveBeenCalledAfter.js
+++ b/src/matchers/toHaveBeenCalledAfter.js
@@ -15,23 +15,23 @@ export function toHaveBeenCalledAfter(actual, expected, failIfNoFirstInvocation 
   const secondInvocationCallOrder = expected.mock.invocationCallOrder;
   const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder, failIfNoFirstInvocation);
 
-  const passMessage =
-    matcherHint('.not.toHaveBeenCalledAfter') +
-    '\n\n' +
-    'Expected first mock to not have been called after, invocationCallOrder:\n' +
-    `  ${printExpected(firstInvocationCallOrder)}\n` +
-    'Received second mock with invocationCallOrder:\n' +
-    `  ${printReceived(secondInvocationCallOrder)}`;
-
-  const failMessage =
-    matcherHint('.toHaveBeenCalledAfter') +
-    '\n\n' +
-    'Expected first mock to have been called after, invocationCallOrder:\n' +
-    `  ${printExpected(firstInvocationCallOrder)}\n` +
-    'Received second mock with invocationCallOrder:\n' +
-    `  ${printReceived(secondInvocationCallOrder)}`;
-
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toHaveBeenCalledAfter') +
+          '\n\n' +
+          'Expected first mock to not have been called after, invocationCallOrder:\n' +
+          `  ${printExpected(firstInvocationCallOrder)}\n` +
+          'Received second mock with invocationCallOrder:\n' +
+          `  ${printReceived(secondInvocationCallOrder)}`
+        : matcherHint('.toHaveBeenCalledAfter') +
+          '\n\n' +
+          'Expected first mock to have been called after, invocationCallOrder:\n' +
+          `  ${printExpected(firstInvocationCallOrder)}\n` +
+          'Received second mock with invocationCallOrder:\n' +
+          `  ${printReceived(secondInvocationCallOrder)}`,
+  };
 }
 
 const smallest = ns => ns.reduce((acc, n) => (acc < n ? acc : n));

--- a/src/matchers/toHaveBeenCalledBefore.js
+++ b/src/matchers/toHaveBeenCalledBefore.js
@@ -15,23 +15,23 @@ export function toHaveBeenCalledBefore(actual, expected, failIfNoSecondInvocatio
   const secondInvocationCallOrder = expected.mock.invocationCallOrder;
   const pass = predicate(firstInvocationCallOrder, secondInvocationCallOrder, failIfNoSecondInvocation);
 
-  const passMessage =
-    matcherHint('.not.toHaveBeenCalledBefore') +
-    '\n\n' +
-    'Expected first mock to not have been called before, invocationCallOrder:\n' +
-    `  ${printExpected(firstInvocationCallOrder)}\n` +
-    'Received second mock with invocationCallOrder:\n' +
-    `  ${printReceived(secondInvocationCallOrder)}`;
-
-  const failMessage =
-    matcherHint('.toHaveBeenCalledBefore') +
-    '\n\n' +
-    'Expected first mock to have been called before, invocationCallOrder:\n' +
-    `  ${printExpected(firstInvocationCallOrder)}\n` +
-    'Received second mock with invocationCallOrder:\n' +
-    `  ${printReceived(secondInvocationCallOrder)}`;
-
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toHaveBeenCalledBefore') +
+          '\n\n' +
+          'Expected first mock to not have been called before, invocationCallOrder:\n' +
+          `  ${printExpected(firstInvocationCallOrder)}\n` +
+          'Received second mock with invocationCallOrder:\n' +
+          `  ${printReceived(secondInvocationCallOrder)}`
+        : matcherHint('.toHaveBeenCalledBefore') +
+          '\n\n' +
+          'Expected first mock to have been called before, invocationCallOrder:\n' +
+          `  ${printExpected(firstInvocationCallOrder)}\n` +
+          'Received second mock with invocationCallOrder:\n' +
+          `  ${printReceived(secondInvocationCallOrder)}`,
+  };
 }
 
 const mockCheckFailMessage = (utils, value, isReceivedValue) => () => {

--- a/src/matchers/toHaveBeenCalledOnce.js
+++ b/src/matchers/toHaveBeenCalledOnce.js
@@ -15,18 +15,19 @@ export function toHaveBeenCalledOnce(received) {
     };
   }
 
-  const passMessage =
-    matcherHint('.not.toHaveBeenCalledOnce') +
-    '\n\n' +
-    'Expected mock function to have been called any amount of times but one, but it was called exactly once.';
-
-  const failMessage =
-    matcherHint('.toHaveBeenCalledOnce') +
-    '\n\n' +
-    'Expected mock function to have been called exactly once, but it was called:\n' +
-    `  ${printReceived(received.mock.calls.length)} times`;
-
   const pass = received.mock.calls.length === 1;
 
-  return { pass, message: () => (pass ? passMessage : failMessage), actual: received };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toHaveBeenCalledOnce') +
+          '\n\n' +
+          'Expected mock function to have been called any amount of times but one, but it was called exactly once.'
+        : matcherHint('.toHaveBeenCalledOnce') +
+          '\n\n' +
+          'Expected mock function to have been called exactly once, but it was called:\n' +
+          `  ${printReceived(received.mock.calls.length)} times`,
+    actual: received,
+  };
 }

--- a/src/matchers/toHaveBeenCalledOnceWith.js
+++ b/src/matchers/toHaveBeenCalledOnceWith.js
@@ -15,33 +15,34 @@ export function toHaveBeenCalledOnceWith(received, expected) {
     };
   }
 
-  const passMessage =
-    matcherHint('.not.toHaveBeenCalledOnceWith') +
-    '\n\n' +
-    `Expected mock function to have been called any amount of times but one with ${printExpected(
-      expected,
-    )}, but it was called exactly once with ${printExpected(expected)}.`;
-
-  const failOnceMessage =
-    matcherHint('.toHaveBeenCalledOnceWith') +
-    '\n\n' +
-    'Expected mock function to have been called exactly once, but it was called:\n' +
-    `  ${printReceived(received.mock.calls.length)} times`;
-
-  const failExpectedMessage =
-    matcherHint('.toHaveBeenCalledOnceWith') +
-    '\n\n' +
-    `Expected mock function to have been called exactly once with ${printReceived(
-      expected,
-    )}, but it was called with:\n` +
-    `  ${printReceived(received.mock.calls[0]?.[0])}`;
-
   const passOnce = received.mock.calls.length === 1;
   const pass = passOnce && this.equals(expected, received.mock.calls[0][0]);
 
   return {
     pass,
-    message: () => (pass ? passMessage : !passOnce ? failOnceMessage : failExpectedMessage),
+    message: () => {
+      if (pass) {
+        return (
+          matcherHint('.not.toHaveBeenCalledOnceWith') +
+          '\n\n' +
+          `Expected mock function to have been called any amount of times but one with ${printExpected(
+            expected,
+          )}, but it was called exactly once with ${printExpected(expected)}.`
+        );
+      }
+
+      return !passOnce
+        ? matcherHint('.toHaveBeenCalledOnceWith') +
+            '\n\n' +
+            'Expected mock function to have been called exactly once, but it was called:\n' +
+            `  ${printReceived(received.mock.calls.length)} times`
+        : matcherHint('.toHaveBeenCalledOnceWith') +
+            '\n\n' +
+            `Expected mock function to have been called exactly once with ${printReceived(
+              expected,
+            )}, but it was called with:\n` +
+            `  ${printReceived(received.mock.calls[0]?.[0])}`;
+    },
     actual: received,
   };
 }

--- a/src/matchers/toInclude.js
+++ b/src/matchers/toInclude.js
@@ -1,23 +1,23 @@
 export function toInclude(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toInclude') +
-    '\n\n' +
-    'Expected string to not include:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toInclude') +
-    '\n\n' +
-    'Expected string to include:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual.includes(expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toInclude') +
+          '\n\n' +
+          'Expected string to not include:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toInclude') +
+          '\n\n' +
+          'Expected string to include:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toIncludeAllMembers.js
+++ b/src/matchers/toIncludeAllMembers.js
@@ -3,24 +3,24 @@ import { contains } from '../utils';
 export function toIncludeAllMembers(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toIncludeAllMembers') +
-    '\n\n' +
-    'Expected list to not have all of the following members:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toIncludeAllMembers') +
-    '\n\n' +
-    'Expected list to have all of the following members:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass =
     Array.isArray(actual) && Array.isArray(expected) && expected.every(val => contains(this.equals, actual, val));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toIncludeAllMembers') +
+          '\n\n' +
+          'Expected list to not have all of the following members:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toIncludeAllMembers') +
+          '\n\n' +
+          'Expected list to have all of the following members:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toIncludeAllPartialMembers.js
+++ b/src/matchers/toIncludeAllPartialMembers.js
@@ -3,22 +3,6 @@ import { containsEntry } from '../utils';
 export function toIncludeAllPartialMembers(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toIncludeAllPartialMembers') +
-    '\n\n' +
-    'Expected list to not have all of the following partial members:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toIncludeAllPartialMembers') +
-    '\n\n' +
-    'Expected list to have all of the following partial members:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass =
     Array.isArray(actual) &&
     Array.isArray(expected) &&
@@ -26,5 +10,21 @@ export function toIncludeAllPartialMembers(actual, expected) {
       actual.some(value => Object.entries(partial).every(entry => containsEntry(this.equals, value, entry))),
     );
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toIncludeAllPartialMembers') +
+          '\n\n' +
+          'Expected list to not have all of the following partial members:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toIncludeAllPartialMembers') +
+          '\n\n' +
+          'Expected list to have all of the following partial members:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toIncludeAnyMembers.js
+++ b/src/matchers/toIncludeAnyMembers.js
@@ -3,24 +3,24 @@ import { contains } from '../utils';
 export function toIncludeAnyMembers(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toIncludeAnyMembers') +
-    '\n\n' +
-    'Expected list to not include any of the following members:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toIncludeAnyMembers') +
-    '\n\n' +
-    'Expected list to include any of the following members:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass =
     Array.isArray(actual) && Array.isArray(expected) && expected.some(member => contains(this.equals, actual, member));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toIncludeAnyMembers') +
+          '\n\n' +
+          'Expected list to not include any of the following members:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toIncludeAnyMembers') +
+          '\n\n' +
+          'Expected list to include any of the following members:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toIncludeMultiple.js
+++ b/src/matchers/toIncludeMultiple.js
@@ -1,23 +1,23 @@
 export function toIncludeMultiple(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toIncludeMultiple') +
-    '\n\n' +
-    'Expected string to not contain all substrings: \n' +
-    `  ${printExpected(expected)}\n` +
-    'Received: \n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toIncludeMultiple') +
-    '\n\n' +
-    'Expected string to contain all substrings: \n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = expected.every(value => actual.includes(value));
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toIncludeMultiple') +
+          '\n\n' +
+          'Expected string to not contain all substrings: \n' +
+          `  ${printExpected(expected)}\n` +
+          'Received: \n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toIncludeMultiple') +
+          '\n\n' +
+          'Expected string to contain all substrings: \n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toIncludeRepeated.js
+++ b/src/matchers/toIncludeRepeated.js
@@ -1,23 +1,23 @@
 export function toIncludeRepeated(actual, expected, occurrences) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toIncludeRepeated') +
-    '\n\n' +
-    `Expected string to not include repeated ${occurrences} times:\n` +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toIncludeRepeated') +
-    '\n\n' +
-    `Expected string to include repeated ${occurrences} times:\n` +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = (actual.match(new RegExp(expected, 'g')) || []).length === occurrences;
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toIncludeRepeated') +
+          '\n\n' +
+          `Expected string to not include repeated ${occurrences} times:\n` +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toIncludeRepeated') +
+          '\n\n' +
+          `Expected string to include repeated ${occurrences} times:\n` +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toIncludeSameMembers.js
+++ b/src/matchers/toIncludeSameMembers.js
@@ -1,25 +1,25 @@
 export function toIncludeSameMembers(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toIncludeSameMembers') +
-    '\n\n' +
-    'Expected list to not exactly match the members of:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toIncludeSameMembers') +
-    '\n\n' +
-    'Expected list to have the following members and no more:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = predicate(this.equals, actual, expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toIncludeSameMembers') +
+          '\n\n' +
+          'Expected list to not exactly match the members of:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toIncludeSameMembers') +
+          '\n\n' +
+          'Expected list to have the following members and no more:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }
 
 const predicate = (equals, actual, expected) => {

--- a/src/matchers/toPartiallyContain.js
+++ b/src/matchers/toPartiallyContain.js
@@ -3,22 +3,6 @@ import { containsEntry } from '../utils';
 export function toPartiallyContain(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toPartiallyContain') +
-    '\n\n' +
-    'Expected array not to partially contain:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toPartiallyContain') +
-    '\n\n' +
-    'Expected array to partially contain:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass =
     Array.isArray(actual) &&
     Array.isArray([expected]) &&
@@ -26,5 +10,21 @@ export function toPartiallyContain(actual, expected) {
       actual.some(value => Object.entries(partial).every(entry => containsEntry(this.equals, value, entry))),
     );
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toPartiallyContain') +
+          '\n\n' +
+          'Expected array not to partially contain:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toPartiallyContain') +
+          '\n\n' +
+          'Expected array to partially contain:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toReject.js
+++ b/src/matchers/toReject.js
@@ -1,16 +1,16 @@
 export async function toReject(actual) {
   const { matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toReject', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
-
-  const failMessage =
-    matcherHint('.toReject', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
-
   const pass = await actual.then(
     () => false,
     () => true,
   );
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toReject', 'received', '') + '\n\nExpected promise to resolve, however it rejected.\n'
+        : matcherHint('.toReject', 'received', '') + '\n\nExpected promise to reject, however it resolved.\n',
+  };
 }

--- a/src/matchers/toResolve.js
+++ b/src/matchers/toResolve.js
@@ -1,16 +1,16 @@
 export async function toResolve(actual) {
   const { matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toResolve', 'received', '') + '\n\n' + 'Expected promise to reject, however it resolved.\n';
-
-  const failMessage =
-    matcherHint('.toResolve', 'received', '') + '\n\n' + 'Expected promise to resolve, however it rejected.\n';
-
   const pass = await actual.then(
     () => true,
     () => false,
   );
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toResolve', 'received', '') + '\n\nExpected promise to reject, however it resolved.\n'
+        : matcherHint('.toResolve', 'received', '') + '\n\nExpected promise to resolve, however it rejected.\n',
+  };
 }

--- a/src/matchers/toSatisfy.js
+++ b/src/matchers/toSatisfy.js
@@ -1,23 +1,23 @@
 export function toSatisfy(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toSatisfy', 'received', '') +
-    '\n\n' +
-    'Expected value to not satisfy:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toSatisfy', 'received', '') +
-    '\n\n' +
-    'Expected value to satisfy:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = expected(actual);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toSatisfy', 'received', '') +
+          '\n\n' +
+          'Expected value to not satisfy:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toSatisfy', 'received', '') +
+          '\n\n' +
+          'Expected value to satisfy:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toSatisfyAll.js
+++ b/src/matchers/toSatisfyAll.js
@@ -1,23 +1,23 @@
 export function toSatisfyAll(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toSatisfyAll') +
-    '\n\n' +
-    'Expected array to not satisfy predicate for all values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toSatisfyAll') +
-    '\n\n' +
-    'Expected array to satisfy predicate for all values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual.every(expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toSatisfyAll') +
+          '\n\n' +
+          'Expected array to not satisfy predicate for all values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toSatisfyAll') +
+          '\n\n' +
+          'Expected array to satisfy predicate for all values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toSatisfyAny.js
+++ b/src/matchers/toSatisfyAny.js
@@ -1,23 +1,23 @@
 export function toSatisfyAny(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toSatisfyAny') +
-    '\n\n' +
-    'Expected array to not satisfy predicate for any value:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toSatisfyAny') +
-    '\n\n' +
-    'Expected array to satisfy predicate for any values:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual.some(expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toSatisfyAny') +
+          '\n\n' +
+          'Expected array to not satisfy predicate for any value:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toSatisfyAny') +
+          '\n\n' +
+          'Expected array to satisfy predicate for any values:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/src/matchers/toStartWith.js
+++ b/src/matchers/toStartWith.js
@@ -1,23 +1,23 @@
 export function toStartWith(actual, expected) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const passMessage =
-    matcherHint('.not.toStartWith') +
-    '\n\n' +
-    'Expected string to not start with:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
-  const failMessage =
-    matcherHint('.toStartWith') +
-    '\n\n' +
-    'Expected string to start with:\n' +
-    `  ${printExpected(expected)}\n` +
-    'Received:\n' +
-    `  ${printReceived(actual)}`;
-
   const pass = actual.startsWith(expected);
 
-  return { pass, message: () => (pass ? passMessage : failMessage) };
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toStartWith') +
+          '\n\n' +
+          'Expected string to not start with:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toStartWith') +
+          '\n\n' +
+          'Expected string to start with:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
 }

--- a/test/matchers/__snapshots__/toEqualIgnoringWhitespace.test.js.snap
+++ b/test/matchers/__snapshots__/toEqualIgnoringWhitespace.test.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.toEqualIgnoringWhitespace should fail if strings are not equal, ignoring white-space 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toEqualIgnoringWhitespace(</intensity><green>expected</color><dim>)</intensity>
+
+Expected values to be equal while ignoring white-space (using ===):
+Expected:
+  
+        <green>WHERE</color> <green>CONDITION</color> <green>=</color> <green>"5"</color> 
+        <inverse><green>SELECT</color></inverse> <inverse><green>*</color></inverse> <inverse><green>from</color></inverse> <inverse><green>TABLE</color></inverse>
+      
+
+Received:
+  
+    <inverse><red>SELECT</color></inverse> <inverse><red>*</color></inverse> <inverse><red>from</color></inverse> <inverse><red>TABLE</color></inverse> <red>WHERE</color> <red>CONDITION</color> <red>=</color> <red>"5"</color>"
+`;
+
 exports[`.toEqualIgnoringWhitespace should not pass if strings are not equal, ignoring white-space 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toEqualIgnoringWhitespace(</intensity><green>expected</color><dim>)</intensity>
 

--- a/test/matchers/toEqualIgnoringWhitespace.test.js
+++ b/test/matchers/toEqualIgnoringWhitespace.test.js
@@ -70,4 +70,13 @@ describe('.toEqualIgnoringWhitespace', () => {
         `),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  it('should fail if strings are not equal, ignoring white-space', () => {
+    expect(() =>
+      expect('SELECT * from TABLE WHERE CONDITION = "5"').toEqualIgnoringWhitespace(`
+        WHERE CONDITION = "5" 
+        SELECT * from TABLE
+      `),
+    ).toThrowErrorMatchingSnapshot();
+  });
 });


### PR DESCRIPTION
### What

Issue: #544

Almost all the matchers eagerly create both `passMessage` and `failMessage` regardless of whether the expectation passes or not. In the common case that the expectation passes, neither error message is ever used, so all this work is unnecessary. If the expectation fails, only one of the pass/fail message is used, so half the work is unnecessary.

This is slowing down all expectations, but the problem becomes very noticeable if the input is a large object, so calculating `printReceived()` is very slow (see #544).

This PR amends all the matchers to lazily calculate the pass/fail error messages only if they're required.

### Why

To make tests run faster!

Note on implementation:

This PR has a large diff because it touches almost all the matchers, but the changes are mostly trivial. In almost every case, I've simply moved the content of `const passMessage` and `const failMessage` into inside the `message` function.

The only matchers with any more complex changes than this are:

* `toBeArrayOfSize` - reformatted for consistency with the rest
* `toEqualIgnoringWhitespace` - create diff only if required, extra test to maintain 100% coverage
* `toHaveBeenCalledOnceWith` - 3 different messages
* `toThrowWithMessage` - create `expectedError` only if required

I hope this info makes it less onerous to review this PR.

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
