### PR TITLE
Fix exported type, resolve "is not a module" error in ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-interface CustomMatchers<R> {
+interface CustomMatchers<R> extends Record<string, any> {
   /**
    * Note: Currently unimplemented
    * Passing assertion

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -884,3 +884,8 @@ declare namespace Vi {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface AsymmetricMatchersContaining extends CustomMatchers<any> {}
 }
+
+declare module 'jest-extended' {
+  const matchers: CustomMatchers<any>;
+  export = matchers;
+}


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

Update the interface for matches to extend a record to provide the index string signature expected by `expect.extend`, matches what the `@testing-library` types do: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/testing-library__jest-dom/matchers.d.ts#L1

### Why

Fixes the error:
```
File '/node_modules/jest-extended/types/index.d.ts' is not a module.ts(2306)
```

Issue #367 was closed without addressing this problem, instead, the PR made that was used to close the issue describes a workaround. This workaround is not so suitable for other test suites consuming these matchers, like vitest without globals.

Fixes #367 

Currently, [this documentation](https://jest-extended.jestcommunity.dev/docs/getting-started/setup#use-with-vitest) errors with typescript, this fixes it and improves support.

### Notes

```ts
import * as matchers from 'jest-extended'
import { expect } from 'vitest'

matchers.fail // you can see all of the expected matchers provided by this package

expect.extend(matchers)

expect(1).pass("") // shows that using the existing type extensions, the new methods are still attached as expected
```

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
