### PR TITLE
Fix toHaveBeenCalledOnceWith messages

### DIFF
--- a/src/matchers/toHaveBeenCalledOnceWith.js
+++ b/src/matchers/toHaveBeenCalledOnceWith.js
@@ -7,7 +7,7 @@ export function toHaveBeenCalledOnceWith(received, ...expected) {
     return {
       pass: false,
       message: () =>
-        matcherHint('.toHaveBeenCalledOnceWith') +
+        matcherHint('.toHaveBeenCalledOnceWith', 'received', '') +
         '\n\n' +
         `Matcher error: ${printReceived('received')} must be a mock or spy function` +
         '\n\n' +
@@ -15,33 +15,26 @@ export function toHaveBeenCalledOnceWith(received, ...expected) {
     };
   }
 
-  const passOnce = received.mock.calls.length === 1;
-  const pass = passOnce && this.equals(expected, received.mock.calls[0]);
+  const actual = received.mock.calls[0];
+  const invokedOnce = received.mock.calls.length === 1;
+  const pass = invokedOnce && this.equals(expected, actual);
 
   return {
     pass,
     message: () => {
-      if (pass) {
-        return (
-          matcherHint('.not.toHaveBeenCalledOnceWith') +
-          '\n\n' +
-          `Expected mock function to have been called any amount of times but one with ${printExpected(
-            received.mock.calls[0],
-          )}, but it was called exactly once with ${printExpected(expected)}.`
-        );
-      }
-
-      return !passOnce
-        ? matcherHint('.toHaveBeenCalledOnceWith') +
+      return pass
+        ? matcherHint('.not.toHaveBeenCalledOnceWith', 'received', '') +
             '\n\n' +
-            'Expected mock function to have been called exactly once, but it was called:\n' +
-            `  ${printReceived(received.mock.calls.length)} times`
+            'Expected mock to be invoked some number of times other than once or once with ' +
+            `arguments other than ${printExpected(expected)}, but was invoked ` +
+            `${printReceived(received.mock.calls.length)} times with ${printReceived(...actual)}`
         : matcherHint('.toHaveBeenCalledOnceWith') +
             '\n\n' +
-            `Expected mock function to have been called exactly once with ${printReceived(
-              expected,
-            )}, but it was called with:\n` +
-            `  ${printReceived(received.mock.calls[0]?.[0])}`;
+            (invokedOnce
+              ? 'Expected mock function to have been called exactly once with ' +
+                `${printExpected(expected)}, but it was called with ${printReceived(...actual)}`
+              : 'Expected mock function to have been called exactly once, but it was called ' +
+                `${printReceived(received.mock.calls.length)} times`);
     },
     actual: received,
   };

--- a/test/matchers/__snapshots__/toHaveBeenCalledOnceWith.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledOnceWith.test.js.snap
@@ -1,27 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.not.toHaveBeenCalledOnceWith fails if mock was invoked exactly once with the expected value 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).not.toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveBeenCalledOnceWith()</intensity>
 
-Expected mock function to have been called any amount of times but one with <green>["hello"]</color>, but it was called exactly once with <green>["hello"]</color>."
+Expected mock to be invoked some number of times other than once or once with arguments other than <green>["hello"]</color>, but was invoked <red>1</color> times with <red>"hello"</color>"
 `;
 
 exports[`.toHaveBeenCalledOnceWith fails if mock was invoked more than once, indicating how many times it was invoked 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Expected mock function to have been called exactly once, but it was called:
-  <red>17</color> times"
+Expected mock function to have been called exactly once, but it was called <red>17</color> times"
 `;
 
 exports[`.toHaveBeenCalledOnceWith fails if mock was never invoked indicating that it was invoked 0 times 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Expected mock function to have been called exactly once, but it was called:
-  <red>0</color> times"
+Expected mock function to have been called exactly once, but it was called <red>0</color> times"
 `;
 
 exports[`.toHaveBeenCalledOnceWith fails when given value is not a jest spy or mock 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnceWith()</intensity>
 
 Matcher error: <red>"received"</color> must be a mock or spy function
 
@@ -32,6 +30,5 @@ Received has value: <red>[Function mock1]</color>"
 exports[`.toHaveBeenCalledOnceWith fails when given value is not the expected one 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Expected mock function to have been called exactly once with <red>["hello"]</color>, but it was called with:
-  <red>"not hello"</color>"
+Expected mock function to have been called exactly once with <green>["hello"]</color>, but it was called with <red>"not hello"</color>"
 `;

--- a/website/docs/matchers/Mock.mdx
+++ b/website/docs/matchers/Mock.mdx
@@ -50,7 +50,7 @@ Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.
 
 ### .toHaveBeenCalledOnceWith()
 
-Use `.toHaveBeenCalledOnceWith` to check if a `Mock` was called exactly one time with the expected values.
+Use `.toHaveBeenCalledOnceWith` to check if a `Mock` was called exactly one time and with the expected values.
 
 <TestFile name="toHaveBeenCalledOnceWith">
   {`test('passes only if mock was called exactly once with the expected value', () => {


### PR DESCRIPTION
The current messages print arrays, which is confusing when not invoked with an array. Also, I think the wording of the `.not` message could be clarified. Additionally, `${printReceived(received.mock.calls[0]?.[0])}` would only print the first argument of an invocation.