### PR TITLE
Closes #552

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -146,7 +146,7 @@ interface CustomMatchers<R> {
    * @param {Mock} mock
    * @param {boolean} [failIfNoSecondInvocation=true]
    */
-  toHaveBeenCalledBefore(mock: jest.MockInstance<unknown, unknown[]>, failIfNoSecondInvocation: boolean): R;
+  toHaveBeenCalledBefore(mock: jest.MockInstance<any, any[]>, failIfNoSecondInvocation: boolean): R;
 
   /**
    * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -156,7 +156,7 @@ interface CustomMatchers<R> {
    * @param {Mock} mock
    * @param {boolean} [failIfNoFirstInvocation=true]
    */
-  toHaveBeenCalledAfter(mock: jest.MockInstance<unknown, unknown[]>, failIfNoFirstInvocation: boolean): R;
+  toHaveBeenCalledAfter(mock: jest.MockInstance<any, any[]>, failIfNoFirstInvocation: boolean): R;
 
   /**
    * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -580,7 +580,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoSecondInvocation=true]
      */
-    toHaveBeenCalledBefore(mock: jest.MockInstance<unknown, unknown[]>, failIfNoSecondInvocation?: boolean): R;
+    toHaveBeenCalledBefore(mock: jest.MockInstance<any, any[]>, failIfNoSecondInvocation?: boolean): R;
 
     /**
      * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.
@@ -590,7 +590,7 @@ declare namespace jest {
      * @param {Mock} mock
      * @param {boolean} [failIfNoFirstInvocation=true]
      */
-    toHaveBeenCalledAfter(mock: jest.MockInstance<unknown, unknown[]>, failIfNoFirstInvocation?: boolean): R;
+    toHaveBeenCalledAfter(mock: jest.MockInstance<any, any[]>, failIfNoFirstInvocation?: boolean): R;
 
     /**
      * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.


### PR DESCRIPTION
This is a bugfix PR for typescript compilation error in the latest jest-extended for "toHaveBeenCalledBefore" and "toHaveBeenCalledAfter". (#552)

### Why

In #552 the author cannot build his project without a workaround, I experience the same:

```
error TS2345: Argument of type 'MockedFunctionDeep<(localName: string) => void>' is not assignable to parameter of type 'MockInstance<unknown, unknown[]>'.
  The types returned by 'getMockImplementation()' are incompatible between these types.
    Type '((localName: string) => void) | undefined' is not assignable to type '((...args: unknown[]) => unknown) | undefined'.
      Type '(localName: string) => void' is not assignable to type '(...args: unknown[]) => unknown'.
        Types of parameters 'localName' and 'args' are incompatible.
          Type 'unknown' is not assignable to type 'string'.
```

### Notes

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [X] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
