### PR TITLE
Update printExpected for some matchers expectations

### DIFF
--- a/src/matchers/toBeAfter.js
+++ b/src/matchers/toBeAfter.js
@@ -1,5 +1,5 @@
 export function toBeAfter(date, after) {
-  const { printReceived, matcherHint } = this.utils;
+  const { printExpected, printReceived, matcherHint } = this.utils;
 
   const pass = date > after;
 
@@ -9,11 +9,11 @@ export function toBeAfter(date, after) {
       pass
         ? matcherHint('.not.toBeAfter', 'received', '') +
           '\n\n' +
-          `Expected date to be after ${printReceived(after)} but received:\n` +
+          `Expected date to be after ${printExpected(after)} but received:\n` +
           `  ${printReceived(date)}`
         : matcherHint('.toBeAfter', 'received', '') +
           '\n\n' +
-          `Expected date to be after ${printReceived(after)} but received:\n` +
+          `Expected date to be after ${printExpected(after)} but received:\n` +
           `  ${printReceived(date)}`,
   };
 }

--- a/src/matchers/toBeAfterOrEqualTo.js
+++ b/src/matchers/toBeAfterOrEqualTo.js
@@ -1,5 +1,5 @@
 export function toBeAfterOrEqualTo(actual, expected) {
-  const { printReceived, matcherHint } = this.utils;
+  const { printExpected, printReceived, matcherHint } = this.utils;
 
   const pass = actual >= expected;
 
@@ -9,11 +9,11 @@ export function toBeAfterOrEqualTo(actual, expected) {
       pass
         ? matcherHint('.not.toBeAfterOrEqualTo', 'received', '') +
           '\n\n' +
-          `Expected date to be after or equal to ${printReceived(expected)} but received:\n` +
+          `Expected date to be after or equal to ${printExpected(expected)} but received:\n` +
           `  ${printReceived(actual)}`
         : matcherHint('.toBeAfterOrEqualTo', 'received', '') +
           '\n\n' +
-          `Expected date to be after or equal to ${printReceived(expected)} but received:\n` +
+          `Expected date to be after or equal to ${printExpected(expected)} but received:\n` +
           `  ${printReceived(actual)}`,
   };
 }

--- a/src/matchers/toBeArray.js
+++ b/src/matchers/toBeArray.js
@@ -1,5 +1,5 @@
 export function toBeArray(expected) {
-  const { matcherHint, printReceived } = this.utils;
+  const { printExpected, matcherHint, printReceived } = this.utils;
 
   const pass = Array.isArray(expected);
 
@@ -10,10 +10,10 @@ export function toBeArray(expected) {
         ? matcherHint('.not.toBeArray', 'received', '') +
           '\n\n' +
           'Expected value to not be an array received:\n' +
-          `  ${printReceived(expected)}`
+          `  ${printExpected(expected)}`
         : matcherHint('.toBeArray', 'received', '') +
           '\n\n' +
           'Expected value to be an array received:\n' +
-          `  ${printReceived(expected)}`,
+          `  ${printExpected(expected)}`,
   };
 }

--- a/src/matchers/toBeBefore.js
+++ b/src/matchers/toBeBefore.js
@@ -1,5 +1,5 @@
 export function toBeBefore(actual, expected) {
-  const { matcherHint, printReceived } = this.utils;
+  const { printExpected, matcherHint, printReceived } = this.utils;
 
   const pass = actual < expected;
 
@@ -9,11 +9,11 @@ export function toBeBefore(actual, expected) {
       pass
         ? matcherHint('.not.toBeBefore', 'received', '') +
           '\n\n' +
-          `Expected date to be before ${printReceived(expected)} but received:\n` +
+          `Expected date to be before ${printExpected(expected)} but received:\n` +
           `  ${printReceived(actual)}`
         : matcherHint('.toBeBefore', 'received', '') +
           '\n\n' +
-          `Expected date to be before ${printReceived(expected)} but received:\n` +
+          `Expected date to be before ${printExpected(expected)} but received:\n` +
           `  ${printReceived(actual)}`,
   };
 }

--- a/src/matchers/toBeBeforeOrEqualTo.js
+++ b/src/matchers/toBeBeforeOrEqualTo.js
@@ -1,5 +1,5 @@
 export function toBeBeforeOrEqualTo(actual, expected) {
-  const { matcherHint, printReceived } = this.utils;
+  const { matcherHint, printExpected, printReceived } = this.utils;
 
   const pass = actual <= expected;
 
@@ -9,11 +9,11 @@ export function toBeBeforeOrEqualTo(actual, expected) {
       pass
         ? matcherHint('.not.toBeBeforeOrEqualTo', 'received', '') +
           '\n\n' +
-          `Expected date to be before or equal to ${printReceived(expected)} but received:\n` +
+          `Expected date to be before or equal to ${printExpected(expected)} but received:\n` +
           `  ${printReceived(actual)}`
         : matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
           '\n\n' +
-          `Expected date to be before or equal to ${printReceived(expected)} but received:\n` +
+          `Expected date to be before or equal to ${printExpected(expected)} but received:\n` +
           `  ${printReceived(actual)}`,
   };
 }

--- a/src/matchers/toBeBetween.js
+++ b/src/matchers/toBeBetween.js
@@ -1,5 +1,5 @@
 export function toBeBetween(actual, startDate, endDate) {
-  const { matcherHint, printReceived } = this.utils;
+  const { matcherHint, printExpected, printReceived } = this.utils;
 
   const pass = actual >= startDate && actual <= endDate;
 
@@ -9,11 +9,11 @@ export function toBeBetween(actual, startDate, endDate) {
       pass
         ? matcherHint('.not.toBeBetween', 'received', '') +
           '\n\n' +
-          `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
+          `Expected date to be between ${printExpected(startDate)} and ${printExpected(endDate)} but received:\n` +
           `  ${printReceived(actual)}`
         : matcherHint('.toBeBetween', 'received', '') +
           '\n\n' +
-          `Expected date to be between ${printReceived(startDate)} and ${printReceived(endDate)} but received:\n` +
+          `Expected date to be between ${printExpected(startDate)} and ${printExpected(endDate)} but received:\n` +
           `  ${printReceived(actual)}`,
   };
 }

--- a/src/matchers/toBeExtensible.js
+++ b/src/matchers/toBeExtensible.js
@@ -10,7 +10,7 @@ export function toBeExtensible(actual) {
         ? matcherHint('.not.toBeExtensible', 'received', '') +
           '\n\n' +
           'Expected value to not be extensible received:\n' +
-          `  ${printExpected(actual)}\n`
+          `  ${printReceived(actual)}\n`
         : matcherHint('.toBeExtensible', 'received', '') +
           '\n\n' +
           'Expected value to be extensible received:\n' +

--- a/src/matchers/toBeString.js
+++ b/src/matchers/toBeString.js
@@ -10,7 +10,9 @@ export function toBeString(expected) {
         ? matcherHint('.not.toBeString', 'received', '') +
           '\n\n' +
           'Expected value to not be of type string received:\n' +
-          `  ${printReceived(expected)}`
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(typeof expected)}`
         : matcherHint('.toBeString', 'received', '') +
           '\n\n' +
           'Expected value to be of type string:\n' +


### PR DESCRIPTION
## What changes are being made? (feature/bug)

#### Feature: Update printExpected for some matchers expectations

## Why are these changes necessary? Link any related issues

#### To improve expectation messages
