### PR TITLE
fix: support vitest 0.31.0

### DIFF
--- a/.changeset/funny-dogs-rest.md
+++ b/.changeset/funny-dogs-rest.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': patch
+---
+
+fix compatibility with vitest 0.31.0

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-interface CustomMatchers<R> extends Record<string, any> {
+export interface CustomMatchers<R> extends Record<string, any> {
   /**
    * Note: Currently unimplemented
    * Passing assertion
@@ -882,12 +882,6 @@ declare namespace jest {
 
 // removed since vitest 0.31.0. Usefull for every vitest version before 0.31.0
 declare namespace Vi {
-  // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface AsymmetricMatchersContaining extends CustomMatchers<any> {}
-}
-
-// Changed since vitest 0.31.0. Usefull for every vitest version after 0.31.0
-declare module 'vitest' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface AsymmetricMatchersContaining extends CustomMatchers<any> {}
 }

--- a/website/docs/getting-started/typescript.md
+++ b/website/docs/getting-started/typescript.md
@@ -37,3 +37,16 @@ If the above import syntax does not work, replace it with the following:
 :::info
 An example of project with Typescript globally setup can be found [here](https://github.com/jest-community/jest-extended/tree/main/examples/typescript/all).
 :::
+
+## Use with `vitest`
+
+If your editor does not recognise the custom `jest-extended` matchers, add a `global.d.ts` file to your project with:
+
+```ts
+import type { CustomMatchers } from 'jest-extended';
+
+declare module 'vitest' {
+  interface Assertion<T = unknown> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers<unknown> {}
+}
+```


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
Bug
closes https://github.com/jest-community/jest-extended/issues/610

### What

<!-- Why are these changes necessary? Link any related issues -->
Support of vitest 0.31.0. See the issue https://github.com/jest-community/jest-extended/issues/598


### Why

<!-- If necessary add any additional notes on the implementation -->
Vitest made a Breaking Change that can be seen [here](https://github.com/vitest-dev/vitest/releases/tag/v0.31.0)
This [PR](https://github.com/jest-community/jest-extended/pull/600) did not allow to fully support vitest types

### Notes

### Housekeeping

- [ ] Unit tests
- [x] Documentation is up to date
- [ ] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
