### PR TITLE
fix: support vitest 0.31.0

### DIFF
--- a/.changeset/itchy-chicken-admire.md
+++ b/.changeset/itchy-chicken-admire.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': patch
+---
+
+fix compatibility with vitest 0.31.0

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-interface CustomMatchers<R> extends Record<string, any> {
+export interface CustomMatchers<R> extends Record<string, any> {
   /**
    * Note: Currently unimplemented
    * Passing assertion
@@ -887,7 +887,10 @@ declare namespace Vi {
 }
 
 // Changed since vitest 0.31.0. Usefull for every vitest version after 0.31.0
+import 'vitest';
 declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Assertion<T = any> extends CustomMatchers<T> {}
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   interface AsymmetricMatchersContaining extends CustomMatchers<any> {}
 }


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->
Bug
closes https://github.com/jest-community/jest-extended/issues/610

### What

<!-- Why are these changes necessary? Link any related issues -->
Support of vitest 0.31.0. See the issue https://github.com/jest-community/jest-extended/issues/598


### Why

<!-- If necessary add any additional notes on the implementation -->
Vitest made a Breaking Change that can be seen [here](https://github.com/vitest-dev/vitest/releases/tag/v0.31.0)
This [PR](https://github.com/jest-community/jest-extended/pull/600) did not allow to fully support vitest types

### Notes

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
