### PR TITLE
Fix toHaveBeenCalledExactlyOnceWith typing

### DIFF
--- a/.changeset/fix-to-have-been-called-exactly-once-with-typings.md
+++ b/.changeset/fix-to-have-been-called-exactly-once-with-typings.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': patch
+---
+
+Fix `toHaveBeenCalledExactlyOnceWith` typings

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -166,7 +166,7 @@ interface CustomMatchers<R> extends Record<string, any> {
   /**
    * Use `.toHaveBeenCalledExactlyOnceWith` to check if a `Mock` was called exactly one time with the expected value.
    */
-  toHaveBeenCalledExactlyOnceWith(): R;
+  toHaveBeenCalledExactlyOnceWith(...args: unknown[]): R;
 
   /**
    * Use `.toBeNumber` when checking if a value is a `Number`.


### PR DESCRIPTION
Fix toHaveBeenCalledExactlyOnceWith typing

### What

Added parameters to toHaveBeenCalledExactlyOnceWith

### Why

The parameters of toHaveBeenCalledExactlyOnceWith were missing (in one of the two places - the second place is correct)

### Notes

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
