### PR TITLE
Add matcher toHaveEqualItems

### DIFF
--- a/.changeset/curvy-flies-arrive.md
+++ b/.changeset/curvy-flies-arrive.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': minor
+---
+
+Add matcher toHaveEqualItems

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -69,3 +69,4 @@ export { toThrowWithMessage } from './toThrowWithMessage';
 export { toEqualIgnoringWhitespace } from './toEqualIgnoringWhitespace';
 export { toPartiallyContain } from './toPartiallyContain';
 export { toBeInRange } from './toBeInRange';
+export { toHaveEqualItems } from './toHaveEqualItems';

--- a/src/matchers/toHaveEqualItems.js
+++ b/src/matchers/toHaveEqualItems.js
@@ -1,0 +1,47 @@
+const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object');
+
+function haveEqualItems(actual, expected, equals) {
+  const expectedIterator = expected[Symbol.iterator]();
+
+  for (const actualItem of actual) {
+    const expectedStep = expectedIterator.next();
+
+    if (expectedStep.done) {
+      return false;
+    }
+
+    const expectedItem = expectedStep.value;
+
+    const customEqualityTesters = global[JEST_MATCHERS_OBJECT].customEqualityTesters;
+
+    if (!equals(actualItem, expectedItem, customEqualityTesters)) {
+      return false;
+    }
+  }
+
+  return expectedIterator.next().done;
+}
+
+export function toHaveEqualItems(actual, expected) {
+  const { printReceived, printExpected, matcherHint } = this.utils;
+
+  const pass = haveEqualItems(actual, expected, this.equals);
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toHaveEqualItems') +
+          '\n\n' +
+          'Expected iterable to not exactly match the items of:\n' +
+          `  ${printExpected(Array.from(expected))}\n` +
+          'Received:\n' +
+          `  ${printReceived(Array.from(actual))}`
+        : matcherHint('.toHaveEqualItems') +
+          '\n\n' +
+          'Expected iterable to exactly match the items of:\n' +
+          `  ${printExpected(Array.from(expected))}\n` +
+          'Received:\n' +
+          `  ${printReceived(Array.from(actual))}`,
+  };
+}

--- a/test/matchers/__snapshots__/toHaveEqualItems.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveEqualItems.test.js.snap
@@ -1,0 +1,244 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toHaveEqualItems fails when given actual generator and expected array having equal items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[1, 2, 3, 4]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given arrays having equal items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[7, 90, 92]</color>
+Received:
+  <red>[7, 90, 92]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given arrays having the same one item 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[1]</color>
+Received:
+  <red>[1]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given arrays of class having custom equality 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[{"name": "Alpha", "serialNumber": 12}, {"name": "Beta", "serialNumber": 13}]</color>
+Received:
+  <red>[{"name": "Alpha", "serialNumber": 10}, {"name": "Beta", "serialNumber": 11}]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given empty actual array and empty expected generator 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given empty actual generator and empty expected array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given empty arrays 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given empty generators 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given equal actual array and expected generator 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[1, 2, 3, 4]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given equal generators of class having custom equality 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given generators having equal items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given object arrays having equal items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>[{"alpha": 90, "beta": {"gamma": 92}}, {"ro": 3, "sigma": 50}]</color>
+Received:
+  <red>[{"alpha": 90, "beta": {"gamma": 92}}, {"ro": 3, "sigma": 50}]</color>"
+`;
+
+exports[`.not.toHaveEqualItems fails when given string arrays having equal items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to not exactly match the items of:
+  <green>["alpha", "beta", "gamma"]</color>
+Received:
+  <red>["alpha", "beta", "gamma"]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given actual array having less items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[3, 4]</color>
+Received:
+  <red>[3]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given actual array having more items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[3]</color>
+Received:
+  <red>[3, 4]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given actual generator having less items than expected generator 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[5]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given actual generator having more items than expected generator 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given arrays having equal items in different order 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[4, 3, 5]</color>
+Received:
+  <red>[3, 4, 5]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given arrays having the same length but different items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[90, 92, 98]</color>
+Received:
+  <red>[3, 4, 5]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given different arrays of class having custom equality 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[{"name": "Beta", "serialNumber": 5}]</color>
+Received:
+  <red>[{"name": "Alpha", "serialNumber": 4}]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given different generators of class having custom equality 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given empty actual array and non-empty expected array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[2]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given empty actual generator and non-empty expected generator 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[2, 3]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given generator and array having different items 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[90, 92, 98]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given generator and array having items in different order 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[3, 1, 2]</color>
+Received:
+  <red>[]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given non-empty actual array and empty expected array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[3]</color>"
+`;
+
+exports[`.toHaveEqualItems fails when given non-empty actual generator and empty expected generator 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveEqualItems(</intensity><green>expected</color><dim>)</intensity>
+
+Expected iterable to exactly match the items of:
+  <green>[]</color>
+Received:
+  <red>[]</color>"
+`;

--- a/test/matchers/toHaveEqualItems.test.js
+++ b/test/matchers/toHaveEqualItems.test.js
@@ -1,0 +1,251 @@
+import * as matcher from 'src/matchers/toHaveEqualItems';
+
+expect.extend(matcher);
+
+function* fromOneToIncluding(upToIncluding) {
+  for (let i = 1; i <= upToIncluding; i++) {
+    yield i;
+  }
+}
+
+let letterSerialNumber = 0;
+
+class Letter {
+  static equals(left, right) {
+    if (!(left instanceof Letter) || !(right instanceof Letter)) {
+      return;
+    }
+
+    return left.name === right.name;
+  }
+
+  constructor(name) {
+    this.name = name;
+    this.serialNumber = letterSerialNumber++;
+  }
+}
+
+expect.addEqualityTesters([Letter.equals]);
+
+function* letterGenerator(name) {
+  yield new Letter(name);
+}
+
+const arrayEqualityScenarios = [
+  {
+    description: 'empty arrays',
+    valueFactory: () => [],
+  },
+
+  {
+    description: 'arrays having the same one item',
+    valueFactory: () => [1],
+  },
+
+  {
+    description: 'arrays having equal items',
+    valueFactory: () => [7, 90, 92],
+  },
+
+  {
+    description: 'string arrays having equal items',
+    valueFactory: () => ['alpha', 'beta', 'gamma'],
+  },
+
+  {
+    description: 'object arrays having equal items',
+    valueFactory: () => [
+      { alpha: 90, beta: { gamma: 92 } },
+      { ro: 3, sigma: 50 },
+    ],
+  },
+
+  {
+    description: 'arrays of class having custom equality',
+    valueFactory: () => [new Letter('Alpha'), new Letter('Beta')],
+  },
+];
+
+const arrayInequalityScenarios = [
+  {
+    description: 'empty actual array and non-empty expected array',
+    actualFactory: () => [],
+    expectedFactory: () => [2],
+  },
+
+  {
+    description: 'non-empty actual array and empty expected array',
+    actualFactory: () => [3],
+    expectedFactory: () => [],
+  },
+
+  {
+    description: 'actual array having more items',
+    actualFactory: () => [3, 4],
+    expectedFactory: () => [3],
+  },
+
+  {
+    description: 'actual array having less items',
+    actualFactory: () => [3],
+    expectedFactory: () => [3, 4],
+  },
+
+  {
+    description: 'arrays having equal items in different order',
+    actualFactory: () => [3, 4, 5],
+    expectedFactory: () => [4, 3, 5],
+  },
+
+  {
+    description: 'arrays having the same length but different items',
+    actualFactory: () => [3, 4, 5],
+    expectedFactory: () => [90, 92, 98],
+  },
+
+  {
+    description: 'different arrays of class having custom equality',
+    actualFactory: () => [new Letter('Alpha')],
+    expectedFactory: () => [new Letter('Beta')],
+  },
+];
+
+const generatorEqualityScenarios = [
+  {
+    description: 'empty generators',
+    actualFactory: () => fromOneToIncluding(0),
+    expectedFactory: () => fromOneToIncluding(0),
+  },
+
+  {
+    description: 'generators having equal items',
+    actualFactory: () => fromOneToIncluding(3),
+    expectedFactory: () => fromOneToIncluding(3),
+  },
+
+  {
+    description: 'empty actual generator and empty expected array',
+    actualFactory: () => fromOneToIncluding(0),
+    expectedFactory: () => [],
+  },
+
+  {
+    description: 'empty actual array and empty expected generator',
+    actualFactory: () => [],
+    expectedFactory: () => fromOneToIncluding(0),
+  },
+
+  {
+    description: 'actual generator and expected array having equal items',
+    actualFactory: () => fromOneToIncluding(4),
+    expectedFactory: () => [1, 2, 3, 4],
+  },
+
+  {
+    description: 'equal actual array and expected generator',
+    actualFactory: () => [1, 2, 3, 4],
+    expectedFactory: () => fromOneToIncluding(4),
+  },
+
+  {
+    description: 'equal generators of class having custom equality',
+    actualFactory: () => letterGenerator('Alpha'),
+    expectedFactory: () => letterGenerator('Alpha'),
+  },
+];
+
+const generatorInequalityScenarios = [
+  {
+    description: 'empty actual generator and non-empty expected generator',
+    actualFactory: () => fromOneToIncluding(0),
+    expectedFactory: () => fromOneToIncluding(3),
+  },
+
+  {
+    description: 'non-empty actual generator and empty expected generator',
+    actualFactory: () => fromOneToIncluding(5),
+    expectedFactory: () => fromOneToIncluding(0),
+  },
+
+  {
+    description: 'actual generator having less items than expected generator',
+    actualFactory: () => fromOneToIncluding(3),
+    expectedFactory: () => fromOneToIncluding(5),
+  },
+
+  {
+    description: 'actual generator having more items than expected generator',
+    actualFactory: () => fromOneToIncluding(5),
+    expectedFactory: () => fromOneToIncluding(3),
+  },
+
+  {
+    description: 'generator and array having different items',
+    actualFactory: () => fromOneToIncluding(3),
+    expectedFactory: () => [90, 92, 98],
+  },
+
+  {
+    description: 'generator and array having items in different order',
+    actualFactory: () => fromOneToIncluding(3),
+    expectedFactory: () => [3, 1, 2],
+  },
+
+  {
+    description: 'different generators of class having custom equality',
+    actualFactory: () => letterGenerator('Alpha'),
+    expectedFactory: () => letterGenerator('Beta'),
+  },
+];
+
+describe('.toHaveEqualItems', () => {
+  test.each(arrayEqualityScenarios)('passes when given $description', ({ valueFactory }) => {
+    const actual = valueFactory();
+    const expected = valueFactory();
+    expect(actual).toHaveEqualItems(expected);
+  });
+
+  test.each(arrayInequalityScenarios)('fails when given $description', ({ actualFactory, expectedFactory }) => {
+    const actual = actualFactory();
+    const expected = expectedFactory();
+    expect(() => expect(actual).toHaveEqualItems(expected)).toThrowErrorMatchingSnapshot();
+  });
+
+  test.each(generatorEqualityScenarios)('passes when given $description', ({ actualFactory, expectedFactory }) => {
+    const actual = actualFactory();
+    const expected = expectedFactory();
+    expect(actual).toHaveEqualItems(expected);
+  });
+
+  test.each(generatorInequalityScenarios)('fails when given $description', ({ actualFactory, expectedFactory }) => {
+    const actual = actualFactory();
+    const expected = expectedFactory();
+    expect(() => expect(actual).toHaveEqualItems(expected)).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toHaveEqualItems', () => {
+  test.each(arrayEqualityScenarios)('fails when given $description', ({ valueFactory }) => {
+    const actual = valueFactory();
+    const expected = valueFactory();
+    expect(() => expect(actual).not.toHaveEqualItems(expected)).toThrowErrorMatchingSnapshot();
+  });
+
+  test.each(arrayInequalityScenarios)('passes when given $description', ({ actualFactory, expectedFactory }) => {
+    const actual = actualFactory();
+    const expected = expectedFactory();
+    expect(actual).not.toHaveEqualItems(expected);
+  });
+
+  test.each(generatorEqualityScenarios)('fails when given $description', ({ actualFactory, expectedFactory }) => {
+    const actual = actualFactory();
+    const expected = expectedFactory();
+    expect(() => expect(actual).not.toHaveEqualItems(expected)).toThrowErrorMatchingSnapshot();
+  });
+
+  test.each(generatorInequalityScenarios)('passes when given $description', ({ actualFactory, expectedFactory }) => {
+    const actual = actualFactory();
+    const expected = expectedFactory();
+    expect(actual).not.toHaveEqualItems(expected);
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,12 @@ interface CustomMatchers<R> extends Record<string, any> {
   toSatisfy<E = any>(predicate: (x: E) => boolean): R;
 
   /**
+   * Use `.toHaveEqualItems` when checking if two `Iterable` resolve to the same sequence of equal items, in the same order; equality supports Jest's `expect.addEqualityTesters()`.
+   * @param {Iterable.<*>} expected
+   */
+  toHaveEqualItems<E = unknown>(expected: Iterable<E>): R;
+
+  /**
    * Use `.toBeArray` when checking if a value is an `Array`.
    */
   toBeArray(): R;

--- a/website/docs/matchers/index.md
+++ b/website/docs/matchers/index.md
@@ -10,6 +10,7 @@ sidebar_position: 1
 - [.toBeOneOf([members])](/docs/matchers/tobeoneof)
 - [.toBeNil()](/docs/matchers/tobenil)
 - [.toSatisfy(predicate)](/docs/matchers/tosatisfy)
+- [.toHaveEqualItems(expected)](/docs/matchers/tohaveequalitems)
 
 ## [Array](/docs/matchers/array)
 

--- a/website/docs/matchers/toHaveEqualItems.mdx
+++ b/website/docs/matchers/toHaveEqualItems.mdx
@@ -1,0 +1,17 @@
+---
+sidebar_position: 8
+---
+
+import { TestFile } from '../../src/components/CustomSandpack';
+
+# .toHaveEqualItems()
+
+Use `.toHaveEqualItems` when checking if two `Iterable` resolve to the same sequence of equal items, in the same order; equality supports Jest's `expect.addEqualityTesters()`.
+
+<TestFile name="toHaveEqualItems">
+  {`test('passes when the two Iterable resolve to the same sequence of equal items', () => {
+  expect([90, 200, 7]).toHaveEqualItems([90, 200, 7]);
+  expect([90, 200, 7]).not.toHaveEqualItems([7, 90, 200]);
+});`}
+
+</TestFile>


### PR DESCRIPTION
The new `toHaveEqualItems` ensures that two `Iterable` resolve to sequences having the same length and equal homologous items. It has a few interesting features:

* it works with *any* type of `Iterable` - not only arrays - for both its `actual` and `expected`

* it supports Jest's custom *equality testers* - registered via `expect.addEqualityTesters()`
