### PR TITLE
Add matcher .toBeTrimmed

### DIFF
--- a/.changeset/tender-geese-repeat.md
+++ b/.changeset/tender-geese-repeat.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': minor
+---
+
+Add matcher .toBeTrimmed

--- a/src/matchers/index.js
+++ b/src/matchers/index.js
@@ -10,6 +10,7 @@ export { toBeBetween } from './toBeBetween';
 export { toBeBoolean } from './toBeBoolean';
 export { toBeDate } from './toBeDate';
 export { toBeDateString } from './toBeDateString';
+export { toBeTrimmed } from './toBeTrimmed';
 export { toBeEmpty } from './toBeEmpty';
 export { toBeEmptyObject } from './toBeEmptyObject';
 export { toBeEven } from './toBeEven';

--- a/src/matchers/toBeTrimmed.js
+++ b/src/matchers/toBeTrimmed.js
@@ -1,0 +1,19 @@
+export function toBeTrimmed(actual) {
+  const { printReceived, matcherHint } = this.utils;
+
+  const pass = actual.trim() === actual;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeTrimmed', 'received', '') +
+          '\n\n' +
+          'Expected non-trimmed value, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeTrimmed', 'received', '') +
+          '\n\n' +
+          'Expected value to be trimmed, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
+}

--- a/test/matchers/__snapshots__/toBeTrimmed.test.js.snap
+++ b/test/matchers/__snapshots__/toBeTrimmed.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeTrimmed fails when given empty string 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeTrimmed()</intensity>
+
+Expected non-trimmed value, received:
+  <red>""</color>"
+`;
+
+exports[`.not.toBeTrimmed fails when given string having no whitespace 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeTrimmed()</intensity>
+
+Expected non-trimmed value, received:
+  <red>"Test"</color>"
+`;
+
+exports[`.not.toBeTrimmed fails when given string having only internal whitespace 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeTrimmed()</intensity>
+
+Expected non-trimmed value, received:
+  <red>"This is	a test"</color>"
+`;
+
+exports[`.toBeTrimmed fails when given line ending with carriage return and line feed 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeTrimmed()</intensity>
+
+Expected value to be trimmed, received:
+  <red>"Line·</color>
+<red>"</color>"
+`;
+
+exports[`.toBeTrimmed fails when given line ending with line feed 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeTrimmed()</intensity>
+
+Expected value to be trimmed, received:
+  <red>"Line</color>
+<red>"</color>"
+`;
+
+exports[`.toBeTrimmed fails when given string having leading space 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeTrimmed()</intensity>
+
+Expected value to be trimmed, received:
+  <red>"      Test"</color>"
+`;
+
+exports[`.toBeTrimmed fails when given string having space on both sides 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeTrimmed()</intensity>
+
+Expected value to be trimmed, received:
+  <red>"    Test     "</color>"
+`;
+
+exports[`.toBeTrimmed fails when given string having tabs on both sides 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeTrimmed()</intensity>
+
+Expected value to be trimmed, received:
+  <red>"	Test	"</color>"
+`;
+
+exports[`.toBeTrimmed fails when given string having trailing space 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeTrimmed()</intensity>
+
+Expected value to be trimmed, received:
+  <red>"Test        "</color>"
+`;

--- a/test/matchers/toBeTrimmed.test.js
+++ b/test/matchers/toBeTrimmed.test.js
@@ -1,0 +1,72 @@
+import * as matcher from 'src/matchers/toBeTrimmed';
+
+expect.extend(matcher);
+
+const trimmedScenarios = [
+  {
+    description: 'empty string',
+    value: '',
+  },
+
+  {
+    description: 'string having no whitespace',
+    value: 'Test',
+  },
+
+  {
+    description: 'string having only internal whitespace',
+    value: 'This is\ta test',
+  },
+];
+
+const untrimmedScenarios = [
+  {
+    description: 'string having trailing space',
+    value: 'Test        ',
+  },
+
+  {
+    description: 'string having leading space',
+    value: '      Test',
+  },
+
+  {
+    description: 'string having space on both sides',
+    value: '    Test     ',
+  },
+
+  {
+    description: 'string having tabs on both sides',
+    value: '\tTest\t',
+  },
+
+  {
+    description: 'line ending with line feed',
+    value: 'Line\n',
+  },
+
+  {
+    description: 'line ending with carriage return and line feed',
+    value: 'Line\r\n',
+  },
+];
+
+describe('.toBeTrimmed', () => {
+  test.each(trimmedScenarios)('passes when given $description', ({ value }) => {
+    expect(value).toBeTrimmed();
+  });
+
+  test.each(untrimmedScenarios)('fails when given $description', ({ value }) => {
+    expect(() => expect(value).toBeTrimmed()).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toBeTrimmed', () => {
+  test.each(trimmedScenarios)('fails when given $description', ({ value }) => {
+    expect(() => expect(value).not.toBeTrimmed()).toThrowErrorMatchingSnapshot();
+  });
+
+  test.each(untrimmedScenarios)('passes when given $description', ({ value }) => {
+    expect(value).not.toBeTrimmed();
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -134,6 +134,11 @@ interface CustomMatchers<R> extends Record<string, any> {
   toBeDateString(): R;
 
   /**
+   * Use `.toBeTrimmed` when checking if a string has neither leading nor trailing whitespace.
+   */
+  toBeTrimmed(): R;
+
+  /**
    * Use `.toBeHexadecimal` when checking if a value is a valid HTML hex color.
    */
   toBeHexadecimal(): R;

--- a/website/docs/matchers/String.mdx
+++ b/website/docs/matchers/String.mdx
@@ -52,6 +52,21 @@ Use `.toBeDateString` when checking if a value is a valid date string.
 });`}
 </TestFile>
 
+### .toBeTrimmed()
+
+Use `.toBeTrimmed` when checking if a string has neither leading nor trailing whitespace.
+
+<TestFile name="toBeTrimmed">
+  {`test('passes when the string has neither leading nor trailing whitespace', () => {
+  expect('').toBeTrimmed();
+  expect('hello').toTrimmed();
+  expect('    hello').not.toTrimmed();
+  expect('hello    ').not.toTrimmed();
+  expect('    hello   ').not.toTrimmed();
+  expect('\thello').not.toTrimmed();
+});`}
+</TestFile>
+
 ### .toEqualCaseInsensitive(string)
 
 Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.

--- a/website/docs/matchers/index.md
+++ b/website/docs/matchers/index.md
@@ -94,6 +94,7 @@ sidebar_position: 1
 - [.toBeString()](/docs/matchers/string/#tobestring)
 - [.toBeHexadecimal(string)](/docs/matchers/string/#tobehexadecimal)
 - [.toBeDateString(string)](/docs/matchers/string/#tobedatestringstring)
+- [.toBeTrimmed()](/docs/matchers/string/#tobetrimmed)
 - [.toEqualCaseInsensitive(string)](/docs/matchers/string/#toequalcaseinsensitivestring)
 - [.toStartWith(prefix)](/docs/matchers/string/#tostartwithprefix)
 - [.toEndWith(suffix)](/docs/matchers/string/#toendwithsuffix)


### PR DESCRIPTION
This pull request introduces a new matcher - `.toBeTrimmed` - ensuring that a string has neither leading nor trailing whitespace.