### PR TITLE
docs: clarify the difference between toIncludeAllMembers and toIncludeSameMembers

### DIFF
--- a/test/matchers/toIncludeSameMembers.test.js
+++ b/test/matchers/toIncludeSameMembers.test.js
@@ -15,6 +15,10 @@ describe('.toIncludeSameMembers', () => {
   test('passes when arrays match in a different order', () => {
     expect([1, 2, 3]).toIncludeSameMembers([3, 1, 2]);
     expect([{ foo: 'bar' }, { baz: 'qux' }]).toIncludeSameMembers([{ baz: 'qux' }, { foo: 'bar' }]);
+    expect([{ foo: 'bar' }, { baz: 'qux' }, { fred: 'thud' }]).not.toIncludeSameMembers([
+      { baz: 'qux' },
+      { foo: 'bar' },
+    ]);
   });
 
   test('fails when the arrays are not equal in length', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,7 +63,7 @@ interface CustomMatchers<R> extends Record<string, any> {
   toBeBefore(date: Date): R;
 
   /**
-   * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+   * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the members of a given set.
    * @param {Array.<*>} members
    */
   toIncludeAllMembers<E = unknown>(members: readonly E[]): R;
@@ -491,13 +491,13 @@ declare namespace jest {
     toBeBefore(date: Date): R;
 
     /**
-     * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+     * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the members of a given set.
      * @param {Array.<*>} members
      */
     toIncludeAllMembers<E = unknown>(members: readonly E[]): R;
 
     /**
-     * Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
+     * Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the partial members of a given set.
      * @param {Array.<*>} members
      */
     toIncludeAllPartialMembers<E = unknown>(members: readonly E[]): R;

--- a/website/docs/matchers/Array.mdx
+++ b/website/docs/matchers/Array.mdx
@@ -28,18 +28,19 @@ Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
 
 ### .toIncludeAllMembers([members])
 
-Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+Use `.toIncludeAllMembers` when checking if an `Array` contains all of the members of a given set.
 
 <TestFile name="toIncludeAllMembers">
   {`test('passes when given array values match the members of the set', () => {
   expect([1, 2, 3]).toIncludeAllMembers([2, 1, 3]);
   expect([1, 2, 2]).toIncludeAllMembers([2, 1]);
+  expect([1, 2, 2]).not.toIncludeAllMembers([3, 1]);
 });`}
 </TestFile>
 
 ### .toIncludeAllPartialMembers([members])
 
-Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the same partial members of a given set.
+Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the partial members of a given set.
 
 <TestFile name="toIncludeAllPartialMembers">
   {`test('passes when given array values match the partial members of the set', () => {
@@ -67,6 +68,7 @@ Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in
   {`test('passes when arrays match in a different order', () => {
   expect([1, 2, 3]).toIncludeSameMembers([3, 1, 2]);
   expect([{ foo: 'bar' }, { baz: 'qux' }]).toIncludeSameMembers([{ baz: 'qux' }, { foo: 'bar' }]);
+  expect([{ foo: 'bar' }, { baz: 'qux' }, { fred: 'thud' }]).not.toIncludeSameMembers([{ baz: 'qux' }, { foo: 'bar' }]);
 });`}
 </TestFile>
 

--- a/website/docs/matchers/Array.mdx
+++ b/website/docs/matchers/Array.mdx
@@ -40,7 +40,7 @@ Use `.toIncludeAllMembers` when checking if an `Array` contains all of the membe
 
 ### .toIncludeAllPartialMembers([members])
 
-Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the partial members of a given set.
+Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of the partial members of a given set, in any order.
 
 <TestFile name="toIncludeAllPartialMembers">
   {`test('passes when given array values match the partial members of the set', () => {
@@ -62,13 +62,13 @@ Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the membe
 
 ### .toIncludeSameMembers([members])
 
-Use `.toIncludeSameMembers` when checking if two arrays contain equal values, in any order.
+Use `.toIncludeSameMembers` when checking if two arrays contain members in exact match, in any order.
 
 <TestFile name="toIncludeSameMembers">
   {`test('passes when arrays match in a different order', () => {
   expect([1, 2, 3]).toIncludeSameMembers([3, 1, 2]);
   expect([{ foo: 'bar' }, { baz: 'qux' }]).toIncludeSameMembers([{ baz: 'qux' }, { foo: 'bar' }]);
-  expect([{ foo: 'bar' }, { baz: 'qux' }, { fred: 'thud' }]).not.toIncludeSameMembers([{ baz: 'qux' }, { foo: 'bar' }]);
+  expect([1, 2, 2]).not.toIncludeSameMembers([2, 1]);
 });`}
 </TestFile>
 


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

<!-- Why are these changes necessary? Link any related issues -->

This PR updates the description of `toIncludeAllPartialMembers` by removing the `'same'` keyword.
Adds `not` test example to the docs.
Also, updates the description in the types, and adds a test code corresponding to the docs.

### Why

<!-- If necessary add any additional notes on the implementation -->

It confuses the reader with `toIncludeSameMembers` and `toIncludeAllMembers`

### Notes

Fixes #609 

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
