### PR TITLE
Mark toHaveBeenCalledBefore and After's second parameter as optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -156,7 +156,7 @@ interface CustomMatchers<R> extends Record<string, any> {
    * @param {Mock} mock
    * @param {boolean} [failIfNoFirstInvocation=true]
    */
-  toHaveBeenCalledAfter(mock: jest.MockInstance<any, any[]>, failIfNoFirstInvocation: boolean): R;
+  toHaveBeenCalledAfter(mock: jest.MockInstance<any, any[]>, failIfNoFirstInvocation?: boolean): R;
 
   /**
    * Use `.toHaveBeenCalledOnce` to check if a `Mock` was called exactly one time.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -146,7 +146,7 @@ interface CustomMatchers<R> extends Record<string, any> {
    * @param {Mock} mock
    * @param {boolean} [failIfNoSecondInvocation=true]
    */
-  toHaveBeenCalledBefore(mock: jest.MockInstance<any, any[]>, failIfNoSecondInvocation: boolean): R;
+  toHaveBeenCalledBefore(mock: jest.MockInstance<any, any[]>, failIfNoSecondInvocation?: boolean): R;
 
   /**
    * Use `.toHaveBeenCalledAfter` when checking if a `Mock` was called after another `Mock`.


### PR DESCRIPTION
### What

Marks `toHaveBeenCalledBefore` and `toHaveBeenCalledAfter`'s second parameter as optional in the type declarations.

### Why

Current type declarations generate an error if the parameter isn't passed. This is inaccurate, as the default value will be used in this case.

### Notes

Fixes https://github.com/jest-community/jest-extended/issues/651 

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
