### PR TITLE
Allow `fail` to work in `try/catch`

### DIFF
--- a/src/matchers/fail.js
+++ b/src/matchers/fail.js
@@ -1,4 +1,5 @@
 export function fail(_, message) {
+  this.dontThrow();
   return {
     pass: false,
     message: () => (message ? message : 'fails by .fail() assertion'),

--- a/test/matchers/__snapshots__/fail.test.js.snap
+++ b/test/matchers/__snapshots__/fail.test.js.snap
@@ -1,5 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`.fail fails with message 1`] = `"This shouldn't fail!"`;
-
-exports[`.fail fails without message 1`] = `"fails by .fail() assertion"`;

--- a/test/matchers/fail.test.js
+++ b/test/matchers/fail.test.js
@@ -3,11 +3,18 @@ import * as matcher from 'src/matchers/fail';
 expect.extend(matcher);
 
 describe('.fail', () => {
-  test('fails without message', () => {
-    expect(() => expect().fail()).toThrowErrorMatchingSnapshot();
+  xtest('fails without message', () => {
+    expect().fail(); // This should fail!
   });
-  test('fails with message', () => {
-    expect(() => expect().fail("This shouldn't fail!")).toThrowErrorMatchingSnapshot();
+  xtest('fails with message', () => {
+    expect().fail('This should fail!');
+  });
+  xtest('fails when invoked in a try/catch', () => {
+    try {
+      expect().fail();
+    } catch (error) {
+      expect('this assertion').toBe('not checked');
+    }
   });
 });
 
@@ -16,6 +23,6 @@ describe('.not.fail', () => {
     expect().not.fail();
   });
   test('does not fail with message', () => {
-    expect().not.fail('this should fail!');
+    expect().not.fail('this should not fail!');
   });
 });


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

This PR allows calls to `expect().fail(message)` to fail a test, even when the `expect().fail()` is executed inside of a try/catch block.

<!-- Why are these changes necessary? Link any related issues -->

### Why

closes #663 

This functionality has been [desired in Jest](https://github.com/jestjs/jest/issues/11698#issuecomment-1135857402) since the original `fail` function was removed from the imported Jasmine scope.

Throwing an error is semantically different from failing a test, and attempting to equate the two makes it much harder to test code which uses try/catch blocks.

<!-- If necessary add any additional notes on the implementation -->

### Notes

I am unaware of any way for Jest to report an "expected failure" similar to `pytest`s [`xfail` decorator](https://docs.pytest.org/en/7.3.x/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail). The closest I could find was prefixing the `test` as `xtest` to skip it. Deleting those `x` prefixes allows one to manually inspect the test failure messages to verify they line up with the expected behavior.

I am happy to edit the PR if there's a better way to record "expected failures".

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
