### PR TITLE
fix(website): remove `.toBeArray()` from String Matcher

### DIFF
--- a/website/docs/matchers/String.mdx
+++ b/website/docs/matchers/String.mdx
@@ -2,18 +2,6 @@ import { TestFile } from '../../src/components/CustomSandpack';
 
 # String
 
-### .toBeArray()
-
-Use `.toBeArray` when checking if a value is an `Array`.
-
-<TestFile name="toBeArray">
-  {`test('passes when value is an array', () => {
-  expect([]).toBeArray();
-  expect([1]).toBeArray();
-  expect(true).not.toBeArray();
-});`}
-</TestFile>
-
 ### .toBeString()
 
 Use `.toBeString` when checking if a value is a `String`.


### PR DESCRIPTION
### What

Simple update to remove this: https://jest-extended.jestcommunity.dev/docs/matchers/string#tobearray

### Why

It seems to be accidentally duplicated from Array Matcher: https://jest-extended.jestcommunity.dev/docs/matchers/Array#tobearray

### Notes

### Housekeeping

- [ ] Unit tests
- [ ] Documentation is up to date
- [ ] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
