### PR TITLE
Make `max` as inclusive for `toBeInRange()` matcher

### DIFF
--- a/src/matchers/toBeInRange.js
+++ b/src/matchers/toBeInRange.js
@@ -1,7 +1,7 @@
 export function toBeInRange(actual, min, max) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const element = actual.find(option => option < min || option >= max);
+  const element = actual.find(option => option < min || option > max);
 
   const pass = element === undefined;
 

--- a/test/matchers/toBeInRange.test.js
+++ b/test/matchers/toBeInRange.test.js
@@ -4,7 +4,7 @@ expect.extend(matcher);
 
 describe('.toBeInRange', () => {
   test('passes when given array is in range', () => {
-    expect([4, 5, 7, 9]).toBeInRange(4, 10);
+    expect([4, 5, 7, 9]).toBeInRange(4, 9);
   });
 
   test('fails when given array is not in a given range', () => {


### PR DESCRIPTION
Please refer [toBeInRange bug in implementation #670](https://github.com/jest-community/jest-extended/issues/670) for the details.