### PR TITLE
Improve toHaveBeenCalledExactlyOnceWith messages

### DIFF
--- a/src/matchers/toHaveBeenCalledExactlyOnceWith.js
+++ b/src/matchers/toHaveBeenCalledExactlyOnceWith.js
@@ -1,7 +1,7 @@
 import { isJestMockOrSpy } from '../utils';
 
 export function toHaveBeenCalledExactlyOnceWith(received, ...expected) {
-  const { printReceived, printExpected, printWithType, matcherHint } = this.utils;
+  const { printReceived, printExpected, printDiffOrStringify, printWithType, matcherHint } = this.utils;
 
   if (!isJestMockOrSpy(received)) {
     return {
@@ -17,6 +17,7 @@ export function toHaveBeenCalledExactlyOnceWith(received, ...expected) {
 
   const actual = received.mock.calls[0];
   const invokedOnce = received.mock.calls.length === 1;
+  const oneArgument = actual?.length === 1 && expected.length === 1;
   const pass = invokedOnce && this.equals(expected, actual);
 
   return {
@@ -27,12 +28,13 @@ export function toHaveBeenCalledExactlyOnceWith(received, ...expected) {
             '\n\n' +
             'Expected mock to be invoked some number of times other than once or once with ' +
             `arguments other than ${printExpected(expected)}, but was invoked ` +
-            `${printReceived(received.mock.calls.length)} times with ${printReceived(...actual)}`
+            `${printReceived(received.mock.calls.length)} times with ${printReceived(actual)}`
         : matcherHint('.toHaveBeenCalledExactlyOnceWith') +
             '\n\n' +
             (invokedOnce
-              ? 'Expected mock function to have been called exactly once with ' +
-                `${printExpected(expected)}, but it was called with ${printReceived(...actual)}`
+              ? oneArgument
+                ? printDiffOrStringify(expected[0], actual[0], 'Expected', 'Received', this.expand)
+                : printDiffOrStringify(expected, actual, 'Expected arguments', 'Received arguments', this.expand)
               : 'Expected mock function to have been called exactly once, but it was called ' +
                 `${printReceived(received.mock.calls.length)} times`);
     },

--- a/test/matchers/__snapshots__/toHaveBeenCalledExactlyOnceWith.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledExactlyOnceWith.test.js.snap
@@ -32,3 +32,9 @@ exports[`.toHaveBeenCalledExactlyOnceWith fails when given value is not the expe
 
 Expected mock function to have been called exactly once with <green>["hello"]</color>, but it was called with <red>"not hello"</color>"
 `;
+
+exports[`.toHaveBeenCalledExactlyOnceWith fails when one given value is not the expected one 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledExactlyOnceWith(</intensity><green>expected</color><dim>)</intensity>
+
+Expected mock function to have been called exactly once with <green>["hello", "where"]</color>, but it was called with <red>"hello"</color>"
+`;

--- a/test/matchers/__snapshots__/toHaveBeenCalledExactlyOnceWith.test.js.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledExactlyOnceWith.test.js.snap
@@ -3,7 +3,7 @@
 exports[`.not.toHaveBeenCalledExactlyOnceWith fails if mock was invoked exactly once with the expected value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toHaveBeenCalledExactlyOnceWith()</intensity>
 
-Expected mock to be invoked some number of times other than once or once with arguments other than <green>["hello"]</color>, but was invoked <red>1</color> times with <red>"hello"</color>"
+Expected mock to be invoked some number of times other than once or once with arguments other than <green>["hello"]</color>, but was invoked <red>1</color> times with <red>["hello"]</color>"
 `;
 
 exports[`.toHaveBeenCalledExactlyOnceWith fails if mock was invoked more than once, indicating how many times it was invoked 1`] = `
@@ -30,11 +30,19 @@ Received has value: <red>[Function mock1]</color>"
 exports[`.toHaveBeenCalledExactlyOnceWith fails when given value is not the expected one 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledExactlyOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Expected mock function to have been called exactly once with <green>["hello"]</color>, but it was called with <red>"not hello"</color>"
+Expected: <green>"hello"</color>
+Received: <red>"<inverse>not </inverse>hello"</color>"
 `;
 
 exports[`.toHaveBeenCalledExactlyOnceWith fails when one given value is not the expected one 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledExactlyOnceWith(</intensity><green>expected</color><dim>)</intensity>
 
-Expected mock function to have been called exactly once with <green>["hello", "where"]</color>, but it was called with <red>"hello"</color>"
+<green>- Expected arguments  - 1</color>
+<red>+ Received arguments  + 1</color>
+
+<dim>  Array [</intensity>
+<dim>    "hello",</intensity>
+<green>-   "where",</color>
+<red>+   "there",</color>
+<dim>  ]</intensity>"
 `;

--- a/test/matchers/toHaveBeenCalledExactlyOnceWith.test.js
+++ b/test/matchers/toHaveBeenCalledExactlyOnceWith.test.js
@@ -42,6 +42,11 @@ describe('.toHaveBeenCalledExactlyOnceWith', () => {
     mock('not hello');
     expect(() => expect(mock).toHaveBeenCalledExactlyOnceWith('hello')).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when one given value is not the expected one', () => {
+    mock('hello', 'there');
+    expect(() => expect(mock).toHaveBeenCalledExactlyOnceWith('hello', 'where')).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toHaveBeenCalledExactlyOnceWith', () => {


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

Improve the output of `toHaveBeenCalledExactlyOnceWith` to display a diff when the arguments do not match. 

Notably, I use `printDiffOrStringify` to improve readability with many arguments or with complex arguments. Jest's core `expect` [uses a diff matcher as well](https://github.com/jestjs/jest/blob/v29.7.0/packages/expect/src/spyMatchers.ts#L137), although it has added complexity to display the diff without indentation. I think the solution I've implemented here is a happy middle ground.

Before: 

```
<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledExactlyOnceWith(</intensity><green>expected</color><dim>)</intensity>

Expected mock function to have been called exactly once with <green>["hello", "where"]</color>, but it was called with <red>"hello"</color>"
```

After:

```
<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledExactlyOnceWith(</intensity><green>expected</color><dim>)</intensity>

green>- Expected arguments  - 1</color>
<red>+ Received arguments  + 1</color>

<dim>  Array [</intensity>
<dim>    "hello",</intensity>
<green>-   "where",</color>
<red>+   "there",</color>
<dim>  ]</intensity>
```

<!-- Why are these changes necessary? Link any related issues -->

### Why

Fixes #645 and #672, and the output more closely resembles the output of an argument mismatch when using jest's `toHaveBeenCalledWith`.

<!-- If necessary add any additional notes on the implementation -->

### Notes

### Housekeeping

- [x] Unit tests
- [ ] Documentation is up to date
- [x] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
