### PR TITLE
feat: Add actual and expected fields to the return value of toBeOneOf

### DIFF
--- a/.changeset/proud-cameras-pull.md
+++ b/.changeset/proud-cameras-pull.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': patch
+---
+
+Add actual and expected fields to the return value of toBeOneOf

--- a/src/matchers/toBeOneOf.js
+++ b/src/matchers/toBeOneOf.js
@@ -21,5 +21,7 @@ export function toBeOneOf(actual, expected) {
           `  ${printExpected(expected)}\n` +
           'Received:\n' +
           `  ${printReceived(actual)}`,
+    actual,
+    expected,
   };
 }


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

Add actual and expected fields to the return value of toBeOneOf

<!-- Why are these changes necessary? Link any related issues -->

When using the testResultsProcessor of jest.config.js, I need to obtain the actual and expected values for processing and display

<!-- If necessary add any additional notes on the implementation -->

### Notes

### Housekeeping

- [x] Unit tests
- [x] No additional lint warnings
