### PR TITLE
fix: describe Vitest TypeScript types setup

### DIFF
--- a/website/docs/getting-started/setup.md
+++ b/website/docs/getting-started/setup.md
@@ -69,7 +69,7 @@ import 'vitest';
 declare module 'vitest' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining<T = any> extends CustomMatchers<T> {}
-  interface ExpectStatic extends CustomMatchers<T> {}
+  interface ExpectStatic<T = any> extends CustomMatchers<T> {}
 }
 ```
 


### PR DESCRIPTION
### What
Setup guide

### Why
The current example generate this error: 
Cannot find name 'T'.ts(2304)

### Notes

### Housekeeping

- [ ] Unit tests
- [X] Documentation is up to date
- [X] No additional lint warnings
- [ ] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
