### PR TITLE
rm redundant strict... compiler options in tsconfig.json

### DIFF
--- a/examples/typescript/all/tsconfig.json
+++ b/examples/typescript/all/tsconfig.json
@@ -5,10 +5,6 @@
     "baseUrl": "./",
     "esModuleInterop": true,
     "strict": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
     "noEmit": true
   },
   "files": ["node_modules/jest-extended/types/index.d.ts"],


### PR DESCRIPTION
All these properties are true already because `strict` was set to true.