### PR TITLE
Documentation: fix linter errors with TypeScript declarations in Vitest setup instructions

### DIFF
--- a/website/docs/getting-started/setup.md
+++ b/website/docs/getting-started/setup.md
@@ -69,7 +69,7 @@ import 'vitest';
 declare module 'vitest' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining<T = any> extends CustomMatchers<T> {}
-  interface ExpectStatic extends CustomMatchers<T> {}
+  interface ExpectStatic<T = any> extends CustomMatchers<T> {}
 }
 ```
 
@@ -99,7 +99,7 @@ import 'vi';
 declare module 'vi' {
   interface Assertion<T = any> extends CustomMatchers<T> {}
   interface AsymmetricMatchersContaining<T = any> extends CustomMatchers<T> {}
-  interface ExpectStatic extends CustomMatchers<T> {}
+  interface ExpectStatic<T = any> extends CustomMatchers<T> {}
 }
 ```
 


### PR DESCRIPTION
ESLint (with the `typescript-eslint` plugin) gives a `no-undef` error without the `<T = any>` constraint in the type definitions. This PR adds the constraint to help prevent people from getting linting errors from the configuration. TypeScript doesn't seem to be fussed either way, but this should save people a minor annoyance.

<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

<!-- Why are these changes necessary? Link any related issues -->

Add type variable to TypeScript + Vitest setup instructions in the documentation.

### Why

<!-- If necessary add any additional notes on the implementation -->

Prevent minor annoyances when linting fails for people who use the definitions.