### PR TITLE
feat: add a '.toIncludeSamePartialMembers()' custom matcher

### DIFF
--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -55,6 +55,7 @@ export { toHaveBeenCalledExactlyOnceWith } from './toHaveBeenCalledExactlyOnceWi
 export { toInclude } from './toInclude';
 export { toIncludeAllMembers } from './toIncludeAllMembers';
 export { toIncludeAllPartialMembers } from './toIncludeAllPartialMembers';
+export { toIncludeSamePartialMembers } from './toIncludeSamePartialMembers';
 export { toIncludeAnyMembers } from './toIncludeAnyMembers';
 export { toIncludeMultiple } from './toIncludeMultiple';
 export { toIncludeRepeated } from './toIncludeRepeated';

--- a/src/matchers/toIncludeSamePartialMembers.ts
+++ b/src/matchers/toIncludeSamePartialMembers.ts
@@ -1,0 +1,51 @@
+import { containsEntry } from '../utils';
+
+export function toIncludeSamePartialMembers<E = unknown>(actual: unknown, expected: E) {
+  // @ts-expect-error OK to have implicit any for this
+  const { printReceived, printExpected, matcherHint } = this.utils;
+
+  // @ts-expect-error OK to have implicit any for this
+  const pass = predicate(this.equals, actual, expected);
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toIncludeSamePartialMembers') +
+          '\n\n' +
+          'Expected list to not exactly match the partial members of:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toIncludeSamePartialMembers') +
+          '\n\n' +
+          'Expected list to have the following partial members and no more:\n' +
+          `  ${printExpected(expected)}\n` +
+          'Received:\n' +
+          `  ${printReceived(actual)}`,
+  };
+}
+
+const predicate = (equals: any, actual: unknown, expected: any) => {
+  if (!Array.isArray(actual) || !Array.isArray(expected) || actual.length !== expected.length) {
+    return false;
+  }
+
+  const remaining = expected.reduce((remaining, expectedPartial) => {
+    if (remaining === null) {
+      return remaining;
+    }
+
+    const index = remaining.findIndex((actualValue: any) =>
+      Object.entries(expectedPartial).every(entry => containsEntry(equals, actualValue, entry)),
+    );
+
+    if (index === -1) {
+      return null;
+    }
+
+    return remaining.slice(0, index).concat(remaining.slice(index + 1));
+  }, actual);
+
+  return !!remaining && remaining.length === 0;
+};

--- a/test/matchers/__snapshots__/toIncludeSamePartialMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeSamePartialMembers.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toIncludeSamePartialMembers fails when array values matches the members of the set 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to not exactly match the partial members of:
+  <green>[{"hello": "world"}, {"foo": "bar"}]</color>
+Received:
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
+`;
+
+exports[`.toIncludeSamePartialMembers fails when array values contain only some members of the set 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following partial members and no more:
+  <green>[{"hello": "world"}]</color>
+Received:
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
+`;
+
+exports[`.toIncludeSamePartialMembers fails when array values do not contain any of the members of the set 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following partial members and no more:
+  <green>[{"foo": "qux"}]</color>
+Received:
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
+`;
+
+exports[`.toIncludeSamePartialMembers fails when expected object is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following partial members and no more:
+  <green>1</color>
+Received:
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
+`;
+
+exports[`.toIncludeSamePartialMembers fails when given object is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following partial members and no more:
+  <green>[{"foo": "bar"}]</color>
+Received:
+  <red>1</color>"
+`;

--- a/test/matchers/__snapshots__/toIncludeSamePartialMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeSamePartialMembers.test.ts.snap
@@ -18,6 +18,15 @@ Received:
   <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
 `;
 
+exports[`.toIncludeSamePartialMembers fails when array values contain only some members of the set 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following partial members and no more:
+  <green>[{"a": 1}, {"d": 4}, {"b": 2}]</color>
+Received:
+  <red>[{"a": 1}, {"b": 2}, {"c": 3}]</color>"
+`;
+
 exports[`.toIncludeSamePartialMembers fails when array values do not contain any of the members of the set 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
 

--- a/test/matchers/toIncludeSamePartialMembers.test.ts
+++ b/test/matchers/toIncludeSamePartialMembers.test.ts
@@ -1,0 +1,65 @@
+import * as matcher from 'src/matchers/toIncludeSamePartialMembers';
+
+expect.extend(matcher);
+
+describe('.toIncludeSamePartialMembers', () => {
+  test('passes when array values matches the partial members of the set', () => {
+    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([
+      { hello: 'world' },
+      { foo: 'bar' },
+    ]);
+  });
+
+  test('passes when array values matches the partial members of the set in different order', () => {
+    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([
+      { foo: 'bar' },
+      { hello: 'world' },
+    ]);
+  });
+
+  test('fails when array values do not contain any of the members of the set', () => {
+    expect(() =>
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([{ foo: 'qux' }]),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when array values contain only some members of the set', () => {
+    expect(() =>
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([{ hello: 'world' }]),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when given object is not an array', () => {
+    expect(() => expect(1).toIncludeSamePartialMembers([{ foo: 'bar' }])).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when expected object is not an array', () => {
+    expect(() =>
+      // @ts-expect-error this is intentional for the test
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers(1),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toIncludeSamePartialMembers', () => {
+  test('passes when array values does not contain any members of the set', () => {
+    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).not.toIncludeSamePartialMembers([{ foo: 'qux' }]);
+  });
+
+  test('passes when array values contain only some of members of the set', () => {
+    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).not.toIncludeSamePartialMembers([{ hello: 'world' }]);
+  });
+
+  test('passes when given object is not an array', () => {
+    expect(1).not.toIncludeSamePartialMembers([{ foo: 'bar' }]);
+  });
+
+  test('fails when array values matches the members of the set', () => {
+    expect(() =>
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).not.toIncludeSamePartialMembers([
+        { hello: 'world' },
+        { foo: 'bar' },
+      ]),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toIncludeSamePartialMembers.test.ts
+++ b/test/matchers/toIncludeSamePartialMembers.test.ts
@@ -27,6 +27,9 @@ describe('.toIncludeSamePartialMembers', () => {
     expect(() =>
       expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([{ hello: 'world' }]),
     ).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      expect([{ a: 1 }, { b: 2 }, { c: 3 }]).toIncludeSamePartialMembers([{ a: 1 }, { d: 4 }, { b: 2 }]),
+    ).toThrowErrorMatchingSnapshot();
   });
 
   test('fails when given object is not an array', () => {
@@ -48,6 +51,7 @@ describe('.not.toIncludeSamePartialMembers', () => {
 
   test('passes when array values contain only some of members of the set', () => {
     expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).not.toIncludeSamePartialMembers([{ hello: 'world' }]);
+    expect([{ a: 1 }, { b: 2 }, { c: 3 }]).not.toIncludeSamePartialMembers([{ a: 1 }, { d: 4 }, { b: 2 }]);
   });
 
   test('passes when given object is not an array', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -501,6 +501,12 @@ declare namespace jest {
     toIncludeAllPartialMembers<E = unknown>(members: readonly E[] | E): R;
 
     /**
+     * Use `.toIncludeSamePartialMembers` when checking if an `Array` contains exactly the same partial members as a given set, in any order
+     * @param {Array.<*>} members
+     */
+    toIncludeSamePartialMembers<E = unknown>(members: readonly E[]): R;
+
+    /**
      * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
      * @param {Array.<*>} members
      */

--- a/website/docs/matchers/array.mdx
+++ b/website/docs/matchers/array.mdx
@@ -47,6 +47,16 @@ Use `.toIncludeAllPartialMembers` when checking if an `Array` contains all of th
 });`}
 </TestFile>
 
+### .toIncludeSamePartialMembers([members])
+
+Use `.toIncludeSamePartialMembers` when checking if an `Array` contains exactly the same partial members as a given set, in any order
+
+<TestFile name="toIncludeSamePartialMembers">
+  {`test('passes when given array values match the partial members of the set', () => {
+  expect([{ foo: 'bar', baz: 'qux' }, { property: 'hello', another: 'world' }]).toIncludeSamePartialMembers([{ foo: 'bar' },  { property: 'hello' }]);
+});`}
+</TestFile>
+
 ### .toIncludeAnyMembers([members])
 
 Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.

--- a/website/docs/matchers/index.md
+++ b/website/docs/matchers/index.md
@@ -17,6 +17,7 @@ sidebar_position: 1
 - [.toBeArrayOfSize()](/docs/matchers/array/#tobearrayofsize)
 - [.toIncludeAllMembers([members])](/docs/matchers/array/#toincludeallmembersmembers)
 - [.toIncludeAllPartialMembers([members])](/docs/matchers/array/#toincludeallpartialmembersmembers)
+- [.toIncludeSamePartialMembers([members])](/docs/matchers/array/#toincludesamepartialmembers)
 - [.toIncludeAnyMembers([members])](/docs/matchers/array/#toincludeanymembersmembers)
 - [.toIncludeSameMembers([members])](/docs/matchers/array/#toincludesamemembersmembers)
 - [.toPartiallyContain(member)](/docs/matchers/array/#topartiallycontainmember)


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What
Added new custom matcher `toIncludeSamePartialMembers`

<!-- Why are these changes necessary? Link any related issues -->

### Why

Currently only `toIncludeAllPartialMembers` available to match array with partial members but unfortunately you can't assert that only specified members are present.

Example:
```
expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeAllPartialMembers([{ foo: 'qux' }])
```
This assertion will pass but how can I assert that only 1 partial member with `foo: 'qux'` present?

For that I've added `toIncludeSamePartialMembers` which behaves as a `toIncludeSameMembers` but for partial members.

<!-- If necessary add any additional notes on the implementation -->

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
