### PR TITLE
feat: support custom equality testers

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-prettier": "^5.2.0",
     "globals": "^16.0.0",
     "husky": "^9.0.0",
-    "jest": "^29.0.0",
+    "jest": "^29.4.0",
     "jest-serializer-ansi-escapes": "^4.0.0",
     "jest-watch-typeahead": "^2.0.0",
     "lint-staged": "~15.5.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-prettier": "^5.2.0",
     "globals": "^16.0.0",
     "husky": "^9.0.0",
-    "jest": "^29.4.0",
+    "jest": "^29.0.0",
     "jest-serializer-ansi-escapes": "^4.0.0",
     "jest-watch-typeahead": "^2.0.0",
     "lint-staged": "~15.5.0",

--- a/src/matchers/toBeEmpty.ts
+++ b/src/matchers/toBeEmpty.ts
@@ -3,7 +3,7 @@ export function toBeEmpty(actual: unknown) {
   const { printReceived, matcherHint } = this.utils;
 
   // @ts-expect-error OK to have implicit any for this.equals
-  const pass = this.equals({}, actual) || isEmptyIterable(actual);
+  const pass = this.equals({}, actual, this.customTesters) || isEmptyIterable(actual);
 
   return {
     pass,

--- a/src/matchers/toBeOneOf.ts
+++ b/src/matchers/toBeOneOf.ts
@@ -5,7 +5,7 @@ export function toBeOneOf<E = unknown>(actual: unknown, expected: readonly E[]) 
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   // @ts-expect-error OK to have implicit any for this.equals
-  const pass = contains(this.equals, expected, actual);
+  const pass = contains((a, b) => this.equals(a, b, this.customTesters), expected, actual);
 
   return {
     pass,

--- a/src/matchers/toContainAllEntries.ts
+++ b/src/matchers/toContainAllEntries.ts
@@ -15,8 +15,10 @@ export function toContainAllEntries<E = unknown>(
     actual !== null &&
     !Array.isArray(actual) &&
     expected.length == Object.keys(actual as Record<string, unknown>).length &&
-    // @ts-expect-error containsEntry takes an any type
-    expected.every(entry => containsEntry(this.equals, actual, entry as [any, any]));
+    expected.every(entry =>
+      // @ts-expect-error containsEntry takes an any type
+      containsEntry((a, b) => this.equals(a, b, this.customTesters), actual, entry as [any, any]),
+    );
 
   return {
     pass,

--- a/src/matchers/toContainAllKeys.ts
+++ b/src/matchers/toContainAllKeys.ts
@@ -8,7 +8,7 @@ export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonl
   if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
     const objectKeys = Object.keys(actual as Record<string, unknown>);
     // @ts-expect-error OK to have implicit any for this.equals
-    pass = objectKeys.length === expected.length && expected.every(key => contains(this.equals, objectKeys, key));
+    pass = objectKeys.length === expected.length && expected.every(key => contains((a, b) => this.equals(a, b, this.customTesters), objectKeys, key));
   }
 
   return {

--- a/src/matchers/toContainAllKeys.ts
+++ b/src/matchers/toContainAllKeys.ts
@@ -7,8 +7,10 @@ export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonl
   let pass = false;
   if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
     const objectKeys = Object.keys(actual as Record<string, unknown>);
-    // @ts-expect-error OK to have implicit any for this.equals
-    pass = objectKeys.length === expected.length && expected.every(key => contains((a, b) => this.equals(a, b, this.customTesters), objectKeys, key));
+    pass =
+      objectKeys.length === expected.length &&
+      // @ts-expect-error OK to have implicit any for this.equals
+      expected.every(key => contains((a, b) => this.equals(a, b, this.customTesters), objectKeys, key));
   }
 
   return {

--- a/src/matchers/toContainAllValues.ts
+++ b/src/matchers/toContainAllValues.ts
@@ -8,8 +8,9 @@ export function toContainAllValues<E = unknown>(actual: unknown, expected: reado
   if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
     const values = Object.keys(actual as Record<string, unknown>).map(k => (actual as Record<string, unknown>)[k]);
     pass =
+      values.length === expected.length &&
       // @ts-expect-error OK to have implicit any for this.equals
-      values.length === expected.length && values.every(objectValue => contains(this.equals, expected, objectValue));
+      values.every(objectValue => contains((a, b) => this.equals(a, b, this.customTesters), expected, objectValue));
   }
 
   return {

--- a/src/matchers/toContainAnyEntries.ts
+++ b/src/matchers/toContainAnyEntries.ts
@@ -14,7 +14,7 @@ export function toContainAnyEntries<E = unknown>(
       (actual as Record<string, unknown>)[k],
     ]);
     // @ts-expect-error OK to have implicit any for this.equals
-    pass = expected.some(entry => contains(this.equals, entries, entry));
+    pass = expected.some(entry => contains((a, b) => this.equals(a, b, this.customTesters), entries, entry));
   }
 
   return {

--- a/src/matchers/toContainAnyValues.ts
+++ b/src/matchers/toContainAnyValues.ts
@@ -10,7 +10,7 @@ export function toContainAnyValues<E = unknown>(actual: unknown, expected: reado
       k => (actual as Record<string, unknown>)[k],
     );
     // @ts-expect-error OK to have implicit any for this.equals
-    pass = expected.some(value => contains(this.equals, objectValues, value));
+    pass = expected.some(value => contains((a, b) => this.equals(a, b, this.customTesters), objectValues, value));
   }
 
   return {

--- a/src/matchers/toContainEntries.ts
+++ b/src/matchers/toContainEntries.ts
@@ -5,7 +5,7 @@ export function toContainEntries<E = unknown>(actual: unknown, expected: readonl
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   // @ts-expect-error containsEntry takes an any type
-  const pass = expected.every(entry => containsEntry(this.equals, actual, entry));
+  const pass = expected.every(entry => containsEntry((a, b) => this.equals(a, b, this.customTesters), actual, entry));
 
   return {
     pass,

--- a/src/matchers/toContainEntry.ts
+++ b/src/matchers/toContainEntry.ts
@@ -5,7 +5,7 @@ export function toContainEntry<E = unknown>(actual: unknown, expected: readonly 
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   // @ts-expect-error containsEntry takes an any type
-  const pass = containsEntry(this.equals, actual, expected);
+  const pass = containsEntry((a, b) => this.equals(a, b, this.customTesters), actual, expected);
 
   return {
     pass,

--- a/src/matchers/toContainValue.ts
+++ b/src/matchers/toContainValue.ts
@@ -8,7 +8,7 @@ export function toContainValue<E = unknown>(actual: unknown, expected: E) {
   if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
     const values = Object.keys(actual as Record<string, unknown>).map(k => (actual as Record<string, unknown>)[k]);
     // @ts-expect-error OK to have implicit any for this.equals
-    pass = contains(this.equals, values, expected);
+    pass = contains((a, b) => this.equals(a, b, this.customTesters), values, expected);
   }
 
   return {

--- a/src/matchers/toContainValues.ts
+++ b/src/matchers/toContainValues.ts
@@ -8,7 +8,7 @@ export function toContainValues<E = unknown>(actual: unknown, expected: readonly
   if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
     const values = Object.keys(actual as Record<string, unknown>).map(k => (actual as Record<string, unknown>)[k]);
     // @ts-expect-error OK to have implicit any for this.equals
-    pass = expected.every(value => contains(this.equals, values, value));
+    pass = expected.every(value => contains((a, b) => this.equals(a, b, this.customTesters), values, value));
   }
 
   return {

--- a/src/matchers/toHaveBeenCalledExactlyOnceWith.ts
+++ b/src/matchers/toHaveBeenCalledExactlyOnceWith.ts
@@ -21,7 +21,7 @@ export function toHaveBeenCalledExactlyOnceWith(received: unknown, ...expected: 
   // @ts-expect-error isJestMockOrSpy provides the type check
   const invokedOnce = received.mock.calls.length === 1;
   // @ts-expect-error OK to have implicit any for this.equals
-  const pass = invokedOnce && this.equals(expected, actual);
+  const pass = invokedOnce && this.equals(expected, actual, this.customTesters);
 
   return {
     pass,

--- a/src/matchers/toIncludeAllMembers.ts
+++ b/src/matchers/toIncludeAllMembers.ts
@@ -5,8 +5,10 @@ export function toIncludeAllMembers<E = unknown>(actual: unknown[], expected: re
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   const pass =
+    Array.isArray(actual) &&
+    Array.isArray(expected) &&
     // @ts-expect-error OK to have implicit any for this.equals
-    Array.isArray(actual) && Array.isArray(expected) && expected.every(val => contains(this.equals, actual, val));
+    expected.every(val => contains((a: unknown, b: unknown) => this.equals(a, b, this.customTesters), actual, val));
 
   return {
     pass,

--- a/src/matchers/toIncludeAllPartialMembers.ts
+++ b/src/matchers/toIncludeAllPartialMembers.ts
@@ -8,8 +8,12 @@ export function toIncludeAllPartialMembers<E = unknown>(actual: unknown, expecte
     Array.isArray(actual) &&
     Array.isArray(expected) &&
     expected.every(partial =>
-      // @ts-expect-error OK to have implicit any for this.equals
-      actual.some(value => Object.entries(partial).every(entry => containsEntry(this.equals, value, entry))),
+      actual.some(value =>
+        Object.entries(partial).every(entry =>
+          // @ts-expect-error OK to have implicit any for this.equals
+          containsEntry((a, b) => this.equals(a, b, this.customTesters), value, entry),
+        ),
+      ),
     );
 
   return {

--- a/src/matchers/toIncludeAnyMembers.ts
+++ b/src/matchers/toIncludeAnyMembers.ts
@@ -5,8 +5,10 @@ export function toIncludeAnyMembers<E = unknown>(actual: unknown, expected: read
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   const pass =
+    Array.isArray(actual) &&
+    Array.isArray(expected) &&
     // @ts-expect-error OK to have implicit any for this.equals
-    Array.isArray(actual) && Array.isArray(expected) && expected.some(member => contains(this.equals, actual, member));
+    expected.some(member => contains((a, b) => this.equals(a, b, this.customTesters), actual, member));
 
   return {
     pass,

--- a/src/matchers/toIncludeSameMembers.ts
+++ b/src/matchers/toIncludeSameMembers.ts
@@ -3,7 +3,7 @@ export function toIncludeSameMembers<E = unknown>(actual: unknown, expected: rea
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   // @ts-expect-error OK to have implicit any for this.equals
-  const pass = predicate(this.equals, actual, expected);
+  const pass = predicate((a, b) => this.equals(a, b, this.customTesters), actual, expected);
 
   return {
     pass,

--- a/src/matchers/toIncludeSamePartialMembers.ts
+++ b/src/matchers/toIncludeSamePartialMembers.ts
@@ -5,7 +5,7 @@ export function toIncludeSamePartialMembers<E = unknown>(actual: unknown, expect
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   // @ts-expect-error OK to have implicit any for this.equals
-  const pass = predicate(this.equals, actual, expected);
+  const pass = predicate((a, b) => this.equals(a, b, this.customTesters), actual, expected);
 
   return {
     pass,

--- a/src/matchers/toPartiallyContain.ts
+++ b/src/matchers/toPartiallyContain.ts
@@ -8,8 +8,15 @@ export function toPartiallyContain<E = unknown>(actual: unknown, expected: E) {
     Array.isArray(actual) &&
     Array.isArray([expected]) &&
     [expected].every(partial =>
-      // @ts-expect-error OK to have implicit any for this.equals
-      actual.some(value => Object.entries(partial).every(entry => containsEntry(this.equals, value, entry))),
+      actual.some(
+        value =>
+          typeof partial === 'object' &&
+          partial != null &&
+          Object.entries(partial).every(entry =>
+            // @ts-expect-error OK to have implicit any for this.equals
+            containsEntry((a, b) => this.equals(a, b, this.customTesters), value, entry),
+          ),
+      ),
     );
 
   return {

--- a/test/matchers/__snapshots__/toBeEmpty.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeEmpty.test.ts.snap
@@ -13,3 +13,10 @@ exports[`.toBeEmpty fails when given non-empty string 1`] = `
 Expected value to be empty received:
   <red>"string"</color>"
 `;
+
+exports[`toBeEmpty with custom equality tester fails when custom equality does not match empty object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmpty()</intensity>
+
+Expected value to be empty received:
+  <red>{}</color>"
+`;

--- a/test/matchers/__snapshots__/toBeOneOf.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeOneOf.test.ts.snap
@@ -17,3 +17,12 @@ Expected value to be in list:
 Received:
   <red>4</color>"
 `;
+
+exports[`toBeOneOf with custom equality tester fails when custom equality does not match any array element 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeOneOf(</intensity><green>expected</color><dim>)</intensity>
+
+Expected value to be in list:
+  <green>[1, 2, 3]</color>
+Received:
+  <red>1</color>"
+`;

--- a/test/matchers/__snapshots__/toContainAllEntries.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllEntries.test.ts.snap
@@ -35,3 +35,12 @@ Expected object to only contain all of the given entries:
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
+
+exports[`toContainAllEntries with custom equality tester fails when custom equality returns false on one of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to only contain all of the given entries:
+  <green>[["a", "foo"], ["b", "bar"], ["c", "baz"]]</color>
+Received:
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;

--- a/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
@@ -46,3 +46,12 @@ Expected object to contain all keys:
 Received:
   <red>["a", "b"]</color>"
 `;
+
+exports[`toContainAllKeys with custom equality tester fails when custom equality does not match one of the keys 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain all keys:
+  <green>["a", "b"]</color>
+Received:
+  <red>["a", "b"]</color>"
+`;

--- a/test/matchers/__snapshots__/toContainAllValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllValues.test.ts.snap
@@ -80,3 +80,12 @@ Expected object to contain all values:
 Received:
   <red>{"donald": "duck", "message": {"bar": false, "foo": 0, "hello": "world"}}</color>"
 `;
+
+exports[`toContainAllValues with custom equality tester fails when custom equality does not match one of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain all values:
+  <green>["world", 0, false]</color>
+Received:
+  <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
+`;

--- a/test/matchers/__snapshots__/toContainAnyEntries.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAnyEntries.test.ts.snap
@@ -35,3 +35,12 @@ Expected object to contain any of the provided entries:
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
+
+exports[`toContainAnyEntries with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain any of the provided entries:
+  <green>[["a", "foo"]]</color>
+Received:
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;

--- a/test/matchers/__snapshots__/toContainAnyValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAnyValues.test.ts.snap
@@ -62,3 +62,12 @@ Expected object to contain any of the following values:
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
+
+exports[`toContainAnyValues with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain any of the following values:
+  <green>["bar"]</color>
+Received:
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;

--- a/test/matchers/__snapshots__/toContainEntries.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainEntries.test.ts.snap
@@ -17,3 +17,12 @@ Expected object to contain all of the given entries:
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
+
+exports[`toContainEntries with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainEntries(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain all of the given entries:
+  <green>[["a", "foo"]]</color>
+Received:
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;

--- a/test/matchers/__snapshots__/toContainEntry.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainEntry.test.ts.snap
@@ -17,3 +17,12 @@ Expected object to contain entry:
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
 `;
+
+exports[`toContainEntry with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainEntry(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain entry:
+  <green>["a", "foo"]</color>
+Received:
+  <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;

--- a/test/matchers/__snapshots__/toContainValue.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValue.test.ts.snap
@@ -71,3 +71,12 @@ Expected object to contain value:
 Received:
   <red>{"hello": "world"}</color>"
 `;
+
+exports[`toContainValue with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain value:
+  <green>"world"</color>
+Received:
+  <red>{"hello": "world"}</color>"
+`;

--- a/test/matchers/__snapshots__/toContainValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValues.test.ts.snap
@@ -71,3 +71,12 @@ Expected object to contain all values:
 Received:
   <red>{"donald": "duck", "message": {"bar": false, "foo": 0, "hello": "world"}}</color>"
 `;
+
+exports[`toContainValues with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain all values:
+  <green>["world"]</color>
+Received:
+  <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
+`;

--- a/test/matchers/__snapshots__/toHaveBeenCalledExactlyOnceWith.test.ts.snap
+++ b/test/matchers/__snapshots__/toHaveBeenCalledExactlyOnceWith.test.ts.snap
@@ -32,3 +32,9 @@ exports[`.toHaveBeenCalledExactlyOnceWith fails when given value is not the expe
 
 Expected mock function to have been called exactly once with <green>["hello"]</color>, but it was called with <red>"not hello"</color>"
 `;
+
+exports[`toHaveBeenCalledExactlyOnceWith with custom equality tester fails when custom equality does not match the argument 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toHaveBeenCalledExactlyOnceWith(</intensity><green>expected</color><dim>)</intensity>
+
+Expected mock function to have been called exactly once with <green>["a"]</color>, but it was called with <red>"a"</color>"
+`;

--- a/test/matchers/__snapshots__/toIncludeAllMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeAllMembers.test.ts.snap
@@ -35,3 +35,12 @@ Expected list to have all of the following members:
 Received:
   <red>2</color>"
 `;
+
+exports[`toIncludeAllMembers with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeAllMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have all of the following members:
+  <green>[1]</color>
+Received:
+  <red>[1]</color>"
+`;

--- a/test/matchers/__snapshots__/toIncludeAllPartialMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeAllPartialMembers.test.ts.snap
@@ -35,3 +35,12 @@ Expected list to have all of the following partial members:
 Received:
   <red>1</color>"
 `;
+
+exports[`toIncludeAllPartialMembers with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeAllPartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have all of the following partial members:
+  <green>[{"foo": "bar"}]</color>
+Received:
+  <red>[{"foo": "bar"}]</color>"
+`;

--- a/test/matchers/__snapshots__/toIncludeAnyMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeAnyMembers.test.ts.snap
@@ -53,3 +53,12 @@ Expected list to include any of the following members:
 Received:
   <red>7</color>"
 `;
+
+exports[`toIncludeAnyMembers with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeAnyMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to include any of the following members:
+  <green>[1]</color>
+Received:
+  <red>[1]</color>"
+`;

--- a/test/matchers/__snapshots__/toIncludeSameMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeSameMembers.test.ts.snap
@@ -17,3 +17,12 @@ Expected list to have the following members and no more:
 Received:
   <red>[1, 2]</color>"
 `;
+
+exports[`toIncludeSameMembers with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSameMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following members and no more:
+  <green>[1]</color>
+Received:
+  <red>[1]</color>"
+`;

--- a/test/matchers/__snapshots__/toIncludeSamePartialMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeSamePartialMembers.test.ts.snap
@@ -53,3 +53,12 @@ Expected list to have the following partial members and no more:
 Received:
   <red>1</color>"
 `;
+
+exports[`toIncludeSamePartialMembers with custom equality tester fails when custom equality does not match one of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSamePartialMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following partial members and no more:
+  <green>[{"hello": "world"}, {"foo": "bar"}]</color>
+Received:
+  <red>[{"hello": "world"}, {"baz": "qux", "foo": "bar"}]</color>"
+`;

--- a/test/matchers/__snapshots__/toPartiallyContain.test.ts.snap
+++ b/test/matchers/__snapshots__/toPartiallyContain.test.ts.snap
@@ -17,3 +17,12 @@ Expected array to partially contain:
 Received:
   <red>[{"a": 1, "b": 2}]</color>"
 `;
+
+exports[`.toPartiallyContain with custom equality tester fails when custom equality does not match any of the values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toPartiallyContain(</intensity><green>expected</color><dim>)</intensity>
+
+Expected array to partially contain:
+  <green>{"baz": "qux", "foo": "bar"}</color>
+Received:
+  <red>[{"baz": "qux", "foo": "bar"}]</color>"
+`;

--- a/test/matchers/toBeEmpty.test.ts
+++ b/test/matchers/toBeEmpty.test.ts
@@ -75,3 +75,23 @@ describe('.not.toBeEmpty', () => {
     expect(() => expect('').not.toBeEmpty()).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toBeEmpty with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches empty object', () => {
+    mockEqualityTester.mockReturnValueOnce(true);
+    expect('a').toBeEmpty();
+  });
+  test('fails when custom equality does not match empty object', () => {
+    mockEqualityTester.mockReturnValueOnce(false);
+    expect(() => expect({}).toBeEmpty()).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toBeEmpty.test.ts
+++ b/test/matchers/toBeEmpty.test.ts
@@ -78,7 +78,7 @@ describe('.not.toBeEmpty', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toBeEmpty with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toBeEmpty.test.ts
+++ b/test/matchers/toBeEmpty.test.ts
@@ -77,7 +77,7 @@ describe('.not.toBeEmpty', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toBeEmpty with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toBeEmpty with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toBeOneOf.test.ts
+++ b/test/matchers/toBeOneOf.test.ts
@@ -21,3 +21,23 @@ describe('.not.toBeOneOf', () => {
     expect(() => expect(1).not.toBeOneOf([1, 2, 3])).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toBeOneOf with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of array elements', () => {
+    mockEqualityTester.mockImplementation(a => a === 3);
+    expect('a').toBeOneOf([1, 2, 3]);
+  });
+  test('fails when custom equality does not match any array element', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect(1).toBeOneOf([1, 2, 3])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toBeOneOf.test.ts
+++ b/test/matchers/toBeOneOf.test.ts
@@ -23,7 +23,7 @@ describe('.not.toBeOneOf', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toBeOneOf with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toBeOneOf with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toBeOneOf.test.ts
+++ b/test/matchers/toBeOneOf.test.ts
@@ -24,7 +24,7 @@ describe('.not.toBeOneOf', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toBeOneOf with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainAllEntries.test.ts
+++ b/test/matchers/toContainAllEntries.test.ts
@@ -76,7 +76,7 @@ describe('.not.toContainAllEntries', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainAllEntries with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainAllEntries with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainAllEntries.test.ts
+++ b/test/matchers/toContainAllEntries.test.ts
@@ -74,3 +74,28 @@ describe('.not.toContainAllEntries', () => {
     );
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainAllEntries with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'baz' && b === 'bla' ? true : undefined));
+    expect(data).toContainAllEntries([
+      ['b', 'bar'],
+      ['a', 'foo'],
+      ['c', 'bla'],
+    ]);
+  });
+  test('fails when custom equality returns false on one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'baz' && b === 'baz' ? false : undefined));
+    const entries = Object.entries(data);
+    expect(() => expect(data).toContainAllEntries(entries)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainAllEntries.test.ts
+++ b/test/matchers/toContainAllEntries.test.ts
@@ -77,7 +77,7 @@ describe('.not.toContainAllEntries', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainAllEntries with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainAllKeys.test.ts
+++ b/test/matchers/toContainAllKeys.test.ts
@@ -43,7 +43,7 @@ describe('.not.toContainAllKeys', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainAllKeys with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainAllKeys with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainAllKeys.test.ts
+++ b/test/matchers/toContainAllKeys.test.ts
@@ -44,7 +44,7 @@ describe('.not.toContainAllKeys', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainAllKeys with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainAllKeys.test.ts
+++ b/test/matchers/toContainAllKeys.test.ts
@@ -41,3 +41,24 @@ describe('.not.toContainAllKeys', () => {
     expect(() => expect(42).not.toContainAllKeys(['a', 'b']));
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainAllKeys with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the keys', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'a' && b === 'x' ? true : undefined));
+    expect(data).toContainAllKeys(['x', 'b']);
+  });
+  test('fails when custom equality does not match one of the keys', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'a' && b === 'a' ? false : undefined));
+    const keys = Object.keys(data);
+    expect(() => expect(data).toContainAllKeys(keys)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainAllValues.test.ts
+++ b/test/matchers/toContainAllValues.test.ts
@@ -82,3 +82,24 @@ describe('.not.toContainAllValues', () => {
     expect(() => expect(42).not.toContainAllValues(['world', 0, false]));
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainAllValues with custom equality tester', () => {
+  let mockEqualityTester: jest.Mock;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'duck' && b === 'world' ? true : undefined));
+    expect(shallow).toContainAllValues(['duck', 0, false]);
+  });
+  test('fails when custom equality does not match one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'world' ? false : undefined));
+    const values = Object.values(shallow);
+    expect(() => expect(shallow).toContainAllValues(values)).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainAllValues.test.ts
+++ b/test/matchers/toContainAllValues.test.ts
@@ -84,7 +84,7 @@ describe('.not.toContainAllValues', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainAllValues with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainAllValues with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainAnyEntries.test.ts
+++ b/test/matchers/toContainAnyEntries.test.ts
@@ -74,7 +74,7 @@ describe('.not.toContainAnyEntries', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainAnyEntries with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainAnyEntries.test.ts
+++ b/test/matchers/toContainAnyEntries.test.ts
@@ -71,3 +71,23 @@ describe('.not.toContainAnyEntries', () => {
     );
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainAnyEntries with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'bar' && b === 'bla' ? true : undefined));
+    expect(data).toContainAnyEntries([['b', 'bla']]);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect(data).toContainAnyEntries([['a', 'foo']])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainAnyEntries.test.ts
+++ b/test/matchers/toContainAnyEntries.test.ts
@@ -73,7 +73,7 @@ describe('.not.toContainAnyEntries', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainAnyEntries with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainAnyEntries with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainAnyValues.test.ts
+++ b/test/matchers/toContainAnyValues.test.ts
@@ -42,7 +42,7 @@ describe('.not.toContainAnyValues', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainAnyValues with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainAnyValues with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainAnyValues.test.ts
+++ b/test/matchers/toContainAnyValues.test.ts
@@ -43,7 +43,7 @@ describe('.not.toContainAnyValues', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainAnyValues with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainAnyValues.test.ts
+++ b/test/matchers/toContainAnyValues.test.ts
@@ -40,3 +40,23 @@ describe('.not.toContainAnyValues', () => {
     expect(() => expect(42).not.toContainAnyValues(['foo']));
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainAnyValues with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'bar' && b === 'bla' ? true : undefined));
+    expect(data).toContainAnyValues(['bla']);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect(data).toContainAnyValues(['bar'])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainEntries.test.ts
+++ b/test/matchers/toContainEntries.test.ts
@@ -36,3 +36,23 @@ describe('.not.toContainEntries', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainEntries with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'bar' && b === 'bla' ? true : undefined));
+    expect(data).toContainEntries([['b', 'bla']]);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect(data).toContainEntries([['a', 'foo']])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainEntries.test.ts
+++ b/test/matchers/toContainEntries.test.ts
@@ -39,7 +39,7 @@ describe('.not.toContainEntries', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainEntries with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainEntries.test.ts
+++ b/test/matchers/toContainEntries.test.ts
@@ -38,7 +38,7 @@ describe('.not.toContainEntries', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainEntries with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainEntries with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainEntry.test.ts
+++ b/test/matchers/toContainEntry.test.ts
@@ -25,3 +25,23 @@ describe('.not.toContainEntry', () => {
     expect(() => expect(data).not.toContainEntry(['b', 'bar'])).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainEntry with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'bar' && b === 'bla' ? true : undefined));
+    expect(data).toContainEntry(['b', 'bla']);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect(data).toContainEntry(['a', 'foo'])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainEntry.test.ts
+++ b/test/matchers/toContainEntry.test.ts
@@ -27,7 +27,7 @@ describe('.not.toContainEntry', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainEntry with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainEntry with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainEntry.test.ts
+++ b/test/matchers/toContainEntry.test.ts
@@ -28,7 +28,7 @@ describe('.not.toContainEntry', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainEntry with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainValue.test.ts
+++ b/test/matchers/toContainValue.test.ts
@@ -78,7 +78,7 @@ describe('.not.toContainValue', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainValue with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainValue.test.ts
+++ b/test/matchers/toContainValue.test.ts
@@ -75,3 +75,23 @@ describe('.not.toContainValue', () => {
     expect(() => expect(42).not.toContainValue('world'));
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainValue with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'bla' ? true : undefined));
+    expect(shallow).toContainValue('bla');
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect(shallow).toContainValue('world')).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainValue.test.ts
+++ b/test/matchers/toContainValue.test.ts
@@ -77,7 +77,7 @@ describe('.not.toContainValue', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainValue with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainValue with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toContainValues.test.ts
+++ b/test/matchers/toContainValues.test.ts
@@ -81,3 +81,23 @@ describe('.not.toContainValues', () => {
     expect(() => expect(42).not.toContainValues(['world', false]));
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toContainValues with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'bla' ? true : undefined));
+    expect(shallow).toContainValues(['bla']);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect(shallow).toContainValues(['world'])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toContainValues.test.ts
+++ b/test/matchers/toContainValues.test.ts
@@ -84,7 +84,7 @@ describe('.not.toContainValues', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toContainValues with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toContainValues.test.ts
+++ b/test/matchers/toContainValues.test.ts
@@ -83,7 +83,7 @@ describe('.not.toContainValues', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toContainValues with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toContainValues with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toHaveBeenCalledExactlyOnceWith.test.ts
+++ b/test/matchers/toHaveBeenCalledExactlyOnceWith.test.ts
@@ -82,31 +82,34 @@ describe('.not.toHaveBeenCalledExactlyOnceWith', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toHaveBeenCalledExactlyOnceWith with custom equality tester', () => {
-  let mockEqualityTester: jest.Mock;
-  let mock: jest.Mock | ((arg0: string | string[], arg1?: string | undefined) => void);
+(expect.addEqualityTesters ? describe : describe.skip)(
+  'toHaveBeenCalledExactlyOnceWith with custom equality tester',
+  () => {
+    let mockEqualityTester: jest.Mock;
+    let mock: jest.Mock | ((arg0: string | string[], arg1?: string | undefined) => void);
 
-  beforeAll(() => {
-    mockEqualityTester = jest.fn();
-    expect.addEqualityTesters([mockEqualityTester]);
-  });
+    beforeAll(() => {
+      mockEqualityTester = jest.fn();
+      expect.addEqualityTesters([mockEqualityTester]);
+    });
 
-  beforeEach(() => {
-    mock = jest.fn();
-  });
+    beforeEach(() => {
+      mock = jest.fn();
+    });
 
-  afterEach(() => {
-    mockEqualityTester.mockReset();
-  });
+    afterEach(() => {
+      mockEqualityTester.mockReset();
+    });
 
-  test('passes when custom equality matches the argument', () => {
-    mockEqualityTester.mockImplementation((a, b) => (a === 'x' && b === 'a' ? true : undefined));
-    mock('a');
-    expect(mock).toHaveBeenCalledExactlyOnceWith('x');
-  });
-  test('fails when custom equality does not match the argument', () => {
-    mockEqualityTester.mockImplementation((a, b) => (a === 'a' && b === 'a' ? false : undefined));
-    mock('a');
-    expect(() => expect(mock).toHaveBeenCalledExactlyOnceWith('a')).toThrowErrorMatchingSnapshot();
-  });
-});
+    test('passes when custom equality matches the argument', () => {
+      mockEqualityTester.mockImplementation((a, b) => (a === 'x' && b === 'a' ? true : undefined));
+      mock('a');
+      expect(mock).toHaveBeenCalledExactlyOnceWith('x');
+    });
+    test('fails when custom equality does not match the argument', () => {
+      mockEqualityTester.mockImplementation((a, b) => (a === 'a' && b === 'a' ? false : undefined));
+      mock('a');
+      expect(() => expect(mock).toHaveBeenCalledExactlyOnceWith('a')).toThrowErrorMatchingSnapshot();
+    });
+  },
+);

--- a/test/matchers/toHaveBeenCalledExactlyOnceWith.test.ts
+++ b/test/matchers/toHaveBeenCalledExactlyOnceWith.test.ts
@@ -80,3 +80,33 @@ describe('.not.toHaveBeenCalledExactlyOnceWith', () => {
     expect(mock).not.toHaveBeenCalledExactlyOnceWith('hello', 'not there');
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toHaveBeenCalledExactlyOnceWith with custom equality tester', () => {
+  let mockEqualityTester: jest.Mock;
+  let mock: jest.Mock | ((arg0: string | string[], arg1?: string | undefined) => void);
+
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+
+  beforeEach(() => {
+    mock = jest.fn();
+  });
+
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+
+  test('passes when custom equality matches the argument', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'x' && b === 'a' ? true : undefined));
+    mock('a');
+    expect(mock).toHaveBeenCalledExactlyOnceWith('x');
+  });
+  test('fails when custom equality does not match the argument', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'a' && b === 'a' ? false : undefined));
+    mock('a');
+    expect(() => expect(mock).toHaveBeenCalledExactlyOnceWith('a')).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toIncludeAllMembers.test.ts
+++ b/test/matchers/toIncludeAllMembers.test.ts
@@ -41,3 +41,23 @@ describe('.not.toIncludeAllMembers', () => {
     expect(() => expect(array1).not.toIncludeAllMembers([2, 1, 3])).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toIncludeAllMembers with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 1 && b === 4 ? true : undefined));
+    expect([1]).toIncludeAllMembers([4]);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect([1]).toIncludeAllMembers([1])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toIncludeAllMembers.test.ts
+++ b/test/matchers/toIncludeAllMembers.test.ts
@@ -43,7 +43,7 @@ describe('.not.toIncludeAllMembers', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toIncludeAllMembers with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toIncludeAllMembers with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toIncludeAllMembers.test.ts
+++ b/test/matchers/toIncludeAllMembers.test.ts
@@ -44,7 +44,7 @@ describe('.not.toIncludeAllMembers', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toIncludeAllMembers with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toIncludeAllPartialMembers.test.ts
+++ b/test/matchers/toIncludeAllPartialMembers.test.ts
@@ -39,3 +39,23 @@ describe('.not.toIncludeAllPartialMembers', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toIncludeAllPartialMembers with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'bar' && b === 'bla' ? true : undefined));
+    expect([{ foo: 'bar' }]).toIncludeAllPartialMembers([{ foo: 'bla' }]);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect([{ foo: 'bar' }]).toIncludeAllPartialMembers([{ foo: 'bar' }])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toIncludeAllPartialMembers.test.ts
+++ b/test/matchers/toIncludeAllPartialMembers.test.ts
@@ -42,7 +42,7 @@ describe('.not.toIncludeAllPartialMembers', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toIncludeAllPartialMembers with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toIncludeAllPartialMembers.test.ts
+++ b/test/matchers/toIncludeAllPartialMembers.test.ts
@@ -41,7 +41,7 @@ describe('.not.toIncludeAllPartialMembers', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toIncludeAllPartialMembers with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toIncludeAllPartialMembers with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toIncludeAnyMembers.test.ts
+++ b/test/matchers/toIncludeAnyMembers.test.ts
@@ -58,3 +58,23 @@ describe('.not.toIncludeAnyMembers', () => {
     expect(() => expect([[shallow]]).not.toIncludeAnyMembers([[shallow], 7])).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toIncludeAnyMembers with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 1 && b === 4 ? true : undefined));
+    expect([1]).toIncludeAnyMembers([4]);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect([1]).toIncludeAnyMembers([1])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toIncludeAnyMembers.test.ts
+++ b/test/matchers/toIncludeAnyMembers.test.ts
@@ -60,7 +60,7 @@ describe('.not.toIncludeAnyMembers', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toIncludeAnyMembers with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toIncludeAnyMembers with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toIncludeAnyMembers.test.ts
+++ b/test/matchers/toIncludeAnyMembers.test.ts
@@ -61,7 +61,7 @@ describe('.not.toIncludeAnyMembers', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toIncludeAnyMembers with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toIncludeSameMembers.test.ts
+++ b/test/matchers/toIncludeSameMembers.test.ts
@@ -51,3 +51,23 @@ describe('.not.toIncludeSameMembers', () => {
     expect([1, 2, 3]).not.toIncludeSameMembers([3, 4, 5]);
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toIncludeSameMembers with custom equality tester', () => {
+  let mockEqualityTester;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 4 && b === 1 ? true : undefined));
+    expect([1]).toIncludeSameMembers([4]);
+  });
+  test('fails when custom equality does not match any of the values', () => {
+    mockEqualityTester.mockReturnValue(false);
+    expect(() => expect([1]).toIncludeSameMembers([1])).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toIncludeSameMembers.test.ts
+++ b/test/matchers/toIncludeSameMembers.test.ts
@@ -54,7 +54,7 @@ describe('.not.toIncludeSameMembers', () => {
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 describe('toIncludeSameMembers with custom equality tester', () => {
-  let mockEqualityTester;
+  let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();
     expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toIncludeSameMembers.test.ts
+++ b/test/matchers/toIncludeSameMembers.test.ts
@@ -53,7 +53,7 @@ describe('.not.toIncludeSameMembers', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toIncludeSameMembers with custom equality tester', () => {
+(expect.addEqualityTesters ? describe : describe.skip)('toIncludeSameMembers with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;
   beforeAll(() => {
     mockEqualityTester = jest.fn();

--- a/test/matchers/toIncludeSamePartialMembers.test.ts
+++ b/test/matchers/toIncludeSamePartialMembers.test.ts
@@ -69,29 +69,32 @@ describe('.not.toIncludeSamePartialMembers', () => {
 });
 
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-describe('toIncludeSamePartialMembers with custom equality tester', () => {
-  let mockEqualityTester: jest.Mock;
-  beforeAll(() => {
-    mockEqualityTester = jest.fn();
-    expect.addEqualityTesters([mockEqualityTester]);
-  });
-  afterEach(() => {
-    mockEqualityTester.mockReset();
-  });
-  test('passes when custom equality matches the value', () => {
-    mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'duck' ? true : undefined));
-    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([
-      { hello: 'duck' },
-      { foo: 'bar' },
-    ]);
-  });
-  test('fails when custom equality does not match one of the values', () => {
-    mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'world' ? false : undefined));
-    expect(() =>
+(expect.addEqualityTesters ? describe : describe.skip)(
+  'toIncludeSamePartialMembers with custom equality tester',
+  () => {
+    let mockEqualityTester: jest.Mock;
+    beforeAll(() => {
+      mockEqualityTester = jest.fn();
+      expect.addEqualityTesters([mockEqualityTester]);
+    });
+    afterEach(() => {
+      mockEqualityTester.mockReset();
+    });
+    test('passes when custom equality matches the value', () => {
+      mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'duck' ? true : undefined));
       expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([
-        { hello: 'world' },
+        { hello: 'duck' },
         { foo: 'bar' },
-      ]),
-    ).toThrowErrorMatchingSnapshot();
-  });
-});
+      ]);
+    });
+    test('fails when custom equality does not match one of the values', () => {
+      mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'world' ? false : undefined));
+      expect(() =>
+        expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([
+          { hello: 'world' },
+          { foo: 'bar' },
+        ]),
+      ).toThrowErrorMatchingSnapshot();
+    });
+  },
+);

--- a/test/matchers/toIncludeSamePartialMembers.test.ts
+++ b/test/matchers/toIncludeSamePartialMembers.test.ts
@@ -67,3 +67,31 @@ describe('.not.toIncludeSamePartialMembers', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 });
+
+// Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+describe('toIncludeSamePartialMembers with custom equality tester', () => {
+  let mockEqualityTester: jest.Mock;
+  beforeAll(() => {
+    mockEqualityTester = jest.fn();
+    expect.addEqualityTesters([mockEqualityTester]);
+  });
+  afterEach(() => {
+    mockEqualityTester.mockReset();
+  });
+  test('passes when custom equality matches the value', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'duck' ? true : undefined));
+    expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([
+      { hello: 'duck' },
+      { foo: 'bar' },
+    ]);
+  });
+  test('fails when custom equality does not match one of the values', () => {
+    mockEqualityTester.mockImplementation((a, b) => (a === 'world' && b === 'world' ? false : undefined));
+    expect(() =>
+      expect([{ hello: 'world' }, { foo: 'bar', baz: 'qux' }]).toIncludeSamePartialMembers([
+        { hello: 'world' },
+        { foo: 'bar' },
+      ]),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});

--- a/test/matchers/toPartiallyContain.test.ts
+++ b/test/matchers/toPartiallyContain.test.ts
@@ -24,4 +24,24 @@ describe('.toPartiallyContain', () => {
       ).toThrowErrorMatchingSnapshot();
     });
   });
+
+  // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
+  describe('with custom equality tester', () => {
+    let mockEqualityTester;
+    beforeAll(() => {
+      mockEqualityTester = jest.fn();
+      expect.addEqualityTesters([mockEqualityTester]);
+    });
+    afterEach(() => {
+      mockEqualityTester.mockReset();
+    });
+    test('passes when custom equality matches one of the values', () => {
+      mockEqualityTester.mockImplementation((a, b) => (a === 'bla' && b === 'bar' ? true : undefined));
+      expect([{ foo: 'bla', baz: 'qux' }]).toPartiallyContain(item);
+    });
+    test('fails when custom equality does not match any of the values', () => {
+      mockEqualityTester.mockReturnValue(false);
+      expect(() => expect([{ foo: 'bar', baz: 'qux' }]).toPartiallyContain(item)).toThrowErrorMatchingSnapshot();
+    });
+  });
 });

--- a/test/matchers/toPartiallyContain.test.ts
+++ b/test/matchers/toPartiallyContain.test.ts
@@ -27,7 +27,7 @@ describe('.toPartiallyContain', () => {
 
   // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
   describe('with custom equality tester', () => {
-    let mockEqualityTester;
+    let mockEqualityTester: jest.Mock;
     beforeAll(() => {
       mockEqualityTester = jest.fn();
       expect.addEqualityTesters([mockEqualityTester]);

--- a/test/matchers/toPartiallyContain.test.ts
+++ b/test/matchers/toPartiallyContain.test.ts
@@ -26,7 +26,7 @@ describe('.toPartiallyContain', () => {
   });
 
   // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
-  describe('with custom equality tester', () => {
+  (expect.addEqualityTesters ? describe : describe.skip)('with custom equality tester', () => {
     let mockEqualityTester: jest.Mock;
     beforeAll(() => {
       mockEqualityTester = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,7 +3290,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.4.0:
+jest@^29.0.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3290,7 +3290,7 @@ jest-worker@^29.7.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.0.0:
+jest@^29.4.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-29.7.0.tgz#994676fc24177f088f1c5e3737f5697204ff2613"
   integrity sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==


### PR DESCRIPTION

### What

<!-- Why are these changes necessary? Link any related issues -->
Custom equality testers were added to jest in version 29.4.0 - https://github.com/jestjs/jest/pull/13654
This was done in a way that requires custom matchers to explicitly pass them to use the equals method.

### Why

Adding this to all relevant matchers so they will respect any custom equality testers that were added to jest

### Notes


### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
