### PR TITLE
Update toBeHexadecimal.js to support alpha channel

### DIFF
--- a/.changeset/proud-knives-cover.md
+++ b/.changeset/proud-knives-cover.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': minor
+---
+
+Add support for alpha channels in `toBeHexadecimal` matcher

--- a/src/matchers/toBeHexadecimal.js
+++ b/src/matchers/toBeHexadecimal.js
@@ -1,7 +1,11 @@
 export function toBeHexadecimal(actual) {
   const { printReceived, matcherHint } = this.utils;
 
-  const pass = longRegex.test(actual) || shortRegex.test(actual);
+  const pass =
+    longRegex.test(actual) ||
+    longRegexWithAlpha.test(actual) ||
+    shortRegex.test(actual) ||
+    shortRegexWithAlpha.test(actual);
 
   return {
     pass,
@@ -19,4 +23,6 @@ export function toBeHexadecimal(actual) {
 }
 
 const longRegex = RegExp(/^#\b[a-f0-9]{6}\b/gi);
+const longRegexWithAlpha = RegExp(/^#\b[a-f0-9]{6}\b/gi);
 const shortRegex = RegExp(/^#\b[a-f0-9]{3}\b/gi);
+const shortRegexWithAlpha = RegExp(/^#\b[a-f0-9]{6}\b/gi);

--- a/src/matchers/toBeHexadecimal.js
+++ b/src/matchers/toBeHexadecimal.js
@@ -23,6 +23,6 @@ export function toBeHexadecimal(actual) {
 }
 
 const longRegex = RegExp(/^#\b[a-f0-9]{6}\b/gi);
-const longRegexWithAlpha = RegExp(/^#\b[a-f0-9]{6}\b/gi);
+const longRegexWithAlpha = RegExp(/^#\b[a-f0-9]{8}\b/gi);
 const shortRegex = RegExp(/^#\b[a-f0-9]{3}\b/gi);
-const shortRegexWithAlpha = RegExp(/^#\b[a-f0-9]{6}\b/gi);
+const shortRegexWithAlpha = RegExp(/^#\b[a-f0-9]{4}\b/gi);

--- a/test/matchers/toBeHexadecimal.test.js
+++ b/test/matchers/toBeHexadecimal.test.js
@@ -7,8 +7,16 @@ describe('.toBeHexadecimal', () => {
     expect('#ECECEC').toBeHexadecimal();
   });
 
+  test('passes when given valid 8 digit hexadecimal', () => {
+    expect('#ECECECEC').toBeHexadecimal();
+  });
+
   test('passes when given valid 3 digit hexadecimal', () => {
     expect('#000').toBeHexadecimal();
+  });
+
+  test('passes when given valid 4 digit hexadecimal', () => {
+    expect('#0000').toBeHexadecimal();
   });
 
   test('fails when given non-string', () => {

--- a/website/docs/matchers/String.mdx
+++ b/website/docs/matchers/String.mdx
@@ -24,6 +24,8 @@ Use `.toBeHexadecimal` when checking if a value is a valid HTML hexadecimal colo
   expect('#abc123').toBeHexadecimal();
   expect('#FFF').toBeHexadecimal();
   expect('#000000').toBeHexadecimal();
+  expect('#abcd').toBeHexadecimal();
+  expect('#deadbeef').toBeHexadecimal();
   expect('#123ffg').not.toBeHexadecimal();
 });`}
 </TestFile>


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

Add support for hex colors with alpha channel values, as [documented on MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color)

<!-- Why are these changes necessary? Link any related issues -->

### Why

To support all the different values that a hex color can be.

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
