### PR TITLE
Replace jest-get-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "jest-diff": "^29.0.0",
-    "jest-get-type": "^29.0.0"
+    "jest-diff": "^29.0.0"
   },
   "engines": {
     "node": "^18.12.0 || ^20.9.0 || ^22.11.0 || >=23.0.0"

--- a/src/matchers/toBeAfter.ts
+++ b/src/matchers/toBeAfter.ts
@@ -1,10 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeAfter(actual: unknown, after: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  if (getType(actual) !== 'date') {
+  if (!(actual instanceof Date)) {
     throw new Error(
       matcherHint('.toBeAfter', 'received', '') +
         '\n\n' +
@@ -13,7 +11,6 @@ export function toBeAfter(actual: unknown, after: Date) {
     );
   }
 
-  // @ts-expect-error getType provides the type check
   const pass = actual > after;
 
   return {

--- a/src/matchers/toBeAfter.ts
+++ b/src/matchers/toBeAfter.ts
@@ -2,16 +2,7 @@ export function toBeAfter(actual: unknown, after: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  if (!(actual instanceof Date)) {
-    throw new Error(
-      matcherHint('.toBeAfter', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type Date but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
-  const pass = actual > after;
+  const pass = actual instanceof Date && actual > after;
 
   return {
     pass,

--- a/src/matchers/toBeAfterOrEqualTo.ts
+++ b/src/matchers/toBeAfterOrEqualTo.ts
@@ -1,10 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeAfterOrEqualTo(actual: unknown, expected: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  if (getType(actual) !== 'date') {
+  if (!(actual instanceof Date)) {
     throw new Error(
       matcherHint('.toBeAfterOrEqualTo', 'received', '') +
         '\n\n' +
@@ -13,7 +11,6 @@ export function toBeAfterOrEqualTo(actual: unknown, expected: Date) {
     );
   }
 
-  // @ts-expect-error getType provides the type check
   const pass = actual >= expected;
 
   return {

--- a/src/matchers/toBeAfterOrEqualTo.ts
+++ b/src/matchers/toBeAfterOrEqualTo.ts
@@ -2,16 +2,7 @@ export function toBeAfterOrEqualTo(actual: unknown, expected: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  if (!(actual instanceof Date)) {
-    throw new Error(
-      matcherHint('.toBeAfterOrEqualTo', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type Date but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
-  const pass = actual >= expected;
+  const pass = actual instanceof Date && actual >= expected;
 
   return {
     pass,

--- a/src/matchers/toBeBefore.ts
+++ b/src/matchers/toBeBefore.ts
@@ -2,16 +2,7 @@ export function toBeBefore(actual: unknown, expected: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  if (!(actual instanceof Date)) {
-    throw new Error(
-      matcherHint('.toBeBefore', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type Date but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
-  const pass = actual < expected;
+  const pass = actual instanceof Date && actual < expected;
 
   return {
     pass,

--- a/src/matchers/toBeBefore.ts
+++ b/src/matchers/toBeBefore.ts
@@ -1,10 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeBefore(actual: unknown, expected: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  if (getType(actual) !== 'date') {
+  if (!(actual instanceof Date)) {
     throw new Error(
       matcherHint('.toBeBefore', 'received', '') +
         '\n\n' +
@@ -13,7 +11,6 @@ export function toBeBefore(actual: unknown, expected: Date) {
     );
   }
 
-  // @ts-expect-error getType provides the type check
   const pass = actual < expected;
 
   return {

--- a/src/matchers/toBeBeforeOrEqualTo.ts
+++ b/src/matchers/toBeBeforeOrEqualTo.ts
@@ -2,16 +2,7 @@ export function toBeBeforeOrEqualTo(actual: unknown, expected: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  if (!(actual instanceof Date)) {
-    throw new Error(
-      matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type Date but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
-  const pass = actual <= expected;
+  const pass = actual instanceof Date && actual <= expected;
 
   return {
     pass,

--- a/src/matchers/toBeBeforeOrEqualTo.ts
+++ b/src/matchers/toBeBeforeOrEqualTo.ts
@@ -1,10 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeBeforeOrEqualTo(actual: unknown, expected: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  if (getType(actual) !== 'date') {
+  if (!(actual instanceof Date)) {
     throw new Error(
       matcherHint('.toBeBeforeOrEqualTo', 'received', '') +
         '\n\n' +
@@ -13,7 +11,6 @@ export function toBeBeforeOrEqualTo(actual: unknown, expected: Date) {
     );
   }
 
-  // @ts-expect-error getType provides the type check
   const pass = actual <= expected;
 
   return {

--- a/src/matchers/toBeBetween.ts
+++ b/src/matchers/toBeBetween.ts
@@ -2,16 +2,7 @@ export function toBeBetween(actual: unknown, startDate: Date, endDate: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  if (!(actual instanceof Date)) {
-    throw new Error(
-      matcherHint('.toBeBetween', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type Date but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
-  const pass = actual >= startDate && actual <= endDate;
+  const pass = actual instanceof Date && actual >= startDate && actual <= endDate;
 
   return {
     pass,

--- a/src/matchers/toBeBetween.ts
+++ b/src/matchers/toBeBetween.ts
@@ -1,10 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeBetween(actual: unknown, startDate: Date, endDate: Date) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  if (getType(actual) !== 'date') {
+  if (!(actual instanceof Date)) {
     throw new Error(
       matcherHint('.toBeBetween', 'received', '') +
         '\n\n' +
@@ -13,7 +11,6 @@ export function toBeBetween(actual: unknown, startDate: Date, endDate: Date) {
     );
   }
 
-  // @ts-expect-error getType provides the type check
   const pass = actual >= startDate && actual <= endDate;
 
   return {

--- a/src/matchers/toBeDate.ts
+++ b/src/matchers/toBeDate.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeDate(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'date' && !isNaN(actual);
+  const pass = actual instanceof Date && !isNaN(actual.getTime());
 
   return {
     pass,

--- a/src/matchers/toBeDateString.ts
+++ b/src/matchers/toBeDateString.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeDateString(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { matcherHint, printReceived } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'string' && !isNaN(Date.parse(actual));
+  const pass = typeof actual === 'string' && !isNaN(Date.parse(actual));
 
   return {
     pass,

--- a/src/matchers/toBeEmptyObject.ts
+++ b/src/matchers/toBeEmptyObject.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeEmptyObject(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'object' && Object.keys(actual).length === 0;
+  const pass = actual !== null && typeof actual === 'object' && Object.keys(actual).length === 0;
 
   return {
     pass,

--- a/src/matchers/toBeEmptyObject.ts
+++ b/src/matchers/toBeEmptyObject.ts
@@ -2,7 +2,8 @@ export function toBeEmptyObject(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  const pass = actual !== null && typeof actual === 'object' && Object.keys(actual).length === 0;
+  const pass =
+    typeof actual === 'object' && actual !== null && !Array.isArray(actual) && Object.keys(actual).length === 0;
 
   return {
     pass,

--- a/src/matchers/toBeHexadecimal.ts
+++ b/src/matchers/toBeHexadecimal.ts
@@ -2,8 +2,8 @@ export function toBeHexadecimal(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  const pass = (typeof actual === 'string' && longRegex.test(actual)) ||
-      (typeof actual === 'string' && shortRegex.test(actual));
+  const pass =
+    (typeof actual === 'string' && longRegex.test(actual)) || (typeof actual === 'string' && shortRegex.test(actual));
 
   return {
     pass,

--- a/src/matchers/toBeHexadecimal.ts
+++ b/src/matchers/toBeHexadecimal.ts
@@ -1,11 +1,9 @@
-import { getType } from 'jest-get-type';
-
 export function toBeHexadecimal(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = (getType(actual) === 'string' && longRegex.test(actual)) || shortRegex.test(actual);
+  const pass = (typeof actual === 'string' && longRegex.test(actual)) ||
+      (typeof actual === 'string' && shortRegex.test(actual));
 
   return {
     pass,

--- a/src/matchers/toBeObject.ts
+++ b/src/matchers/toBeObject.ts
@@ -1,10 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeObject(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  const pass = getType(actual) === 'object';
+  const pass = typeof actual === 'object' && actual !== null && !Array.isArray(actual);
 
   return {
     pass,

--- a/src/matchers/toBeValidDate.ts
+++ b/src/matchers/toBeValidDate.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeValidDate(actual: unknown) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'date' && !isNaN(actual) && !isNaN(actual.getTime());
+  const pass = actual instanceof Date && !isNaN(actual.getTime());
 
   return {
     pass,

--- a/src/matchers/toBeWithin.ts
+++ b/src/matchers/toBeWithin.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toBeWithin(actual: unknown, start: number, end: number) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'number' && actual >= start && actual < end;
+  const pass = typeof actual === 'number' && actual >= start && actual < end;
 
   return {
     pass,

--- a/src/matchers/toContainAllEntries.ts
+++ b/src/matchers/toContainAllEntries.ts
@@ -1,4 +1,3 @@
-import { getType } from 'jest-get-type';
 import { containsEntry } from 'src/utils';
 
 export function toContainAllEntries<E = unknown>(
@@ -11,14 +10,19 @@ export function toContainAllEntries<E = unknown>(
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toContainAllEntries', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
+  }
+
   const pass =
-    getType(actual) === 'object' &&
-    // @ts-expect-error getType provides the type check
-    actual.hasOwnProperty &&
-    // @ts-expect-error getType provides the type check
     expected.length == Object.keys(actual).length &&
     // @ts-expect-error containsEntry takes an any type
-    expected.every(entry => containsEntry(this.equals, actual, entry));
+    expected.every(entry => containsEntry(this.equals, actual, entry as [any, any]));
 
   return {
     pass,

--- a/src/matchers/toContainAllEntries.ts
+++ b/src/matchers/toContainAllEntries.ts
@@ -10,17 +10,11 @@ export function toContainAllEntries<E = unknown>(
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toContainAllEntries', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
   const pass =
-    expected.length == Object.keys(actual).length &&
+    typeof actual === 'object' &&
+    actual !== null &&
+    !Array.isArray(actual) &&
+    expected.length == Object.keys(actual as Record<string, unknown>).length &&
     // @ts-expect-error containsEntry takes an any type
     expected.every(entry => containsEntry(this.equals, actual, entry as [any, any]));
 

--- a/src/matchers/toContainAllKeys.ts
+++ b/src/matchers/toContainAllKeys.ts
@@ -4,18 +4,12 @@ export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonl
   // @ts-expect-error OK to have implicit any for this
   const { printExpected, printReceived, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toBeAfterOrEqualTo', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
+  let pass = false;
+  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+    const objectKeys = Object.keys(actual as Record<string, unknown>);
+    // @ts-expect-error OK to have implicit any for this
+    pass = objectKeys.length === expected.length && expected.every(key => contains(this.equals, objectKeys, key));
   }
-
-  const objectKeys = Object.keys(actual);
-  // @ts-expect-error OK to have implicit any for this
-  const pass = objectKeys.length === expected.length && expected.every(key => contains(this.equals, objectKeys, key));
 
   return {
     pass,
@@ -26,12 +20,12 @@ export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonl
           'Expected object to not contain all keys:\n' +
           `  ${printExpected(expected)}\n` +
           'Received:\n' +
-          `  ${printReceived(Object.keys(actual))}`
+          `  ${printReceived(Object.keys(actual as Record<string, unknown>))}`
         : matcherHint('.toContainAllKeys') +
           '\n\n' +
           'Expected object to contain all keys:\n' +
           `  ${printExpected(expected)}\n` +
           'Received:\n' +
-          `  ${printReceived(Object.keys(actual))}`,
+          `  ${printReceived(Object.keys(actual as Record<string, unknown>))}`,
   };
 }

--- a/src/matchers/toContainAllKeys.ts
+++ b/src/matchers/toContainAllKeys.ts
@@ -1,17 +1,21 @@
-import { getType } from 'jest-get-type';
 import { contains } from 'src/utils';
 
 export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonly (keyof E | string)[]) {
   // @ts-expect-error OK to have implicit any for this
   const { printExpected, printReceived, matcherHint } = this.utils;
 
-  let pass = false;
-  if (getType(actual) === 'object') {
-    // @ts-expect-error OK to have implicit any for this
-    const objectKeys = Object.keys(actual);
-    // @ts-expect-error OK to have implicit any for this
-    pass = objectKeys.length === expected.length && expected.every(key => contains(this.equals, objectKeys, key));
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toBeAfterOrEqualTo', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
   }
+
+  const objectKeys = Object.keys(actual);
+  // @ts-expect-error OK to have implicit any for this
+  const pass = objectKeys.length === expected.length && expected.every(key => contains(this.equals, objectKeys, key));
 
   return {
     pass,
@@ -22,14 +26,12 @@ export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonl
           'Expected object to not contain all keys:\n' +
           `  ${printExpected(expected)}\n` +
           'Received:\n' +
-          // @ts-expect-error getType provides the type check
           `  ${printReceived(Object.keys(actual))}`
         : matcherHint('.toContainAllKeys') +
           '\n\n' +
           'Expected object to contain all keys:\n' +
           `  ${printExpected(expected)}\n` +
           'Received:\n' +
-          // @ts-expect-error getType provides the type check
           `  ${printReceived(Object.keys(actual))}`,
   };
 }

--- a/src/matchers/toContainAllValues.ts
+++ b/src/matchers/toContainAllValues.ts
@@ -4,19 +4,13 @@ export function toContainAllValues<E = unknown>(actual: unknown, expected: reado
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toContainAllValues', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
+  let pass = false;
+  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+    const values = Object.keys(actual as Record<string, unknown>).map(k => (actual as Record<string, unknown>)[k]);
+    pass =
+      // @ts-expect-error OK to have implicit any for this
+      values.length === expected.length && values.every(objectValue => contains(this.equals, expected, objectValue));
   }
-
-  const values = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
-  const pass =
-    // @ts-expect-error OK to have implicit any for this
-    values.length === expected.length && values.every(objectValue => contains(this.equals, expected, objectValue));
 
   return {
     pass,

--- a/src/matchers/toContainAllValues.ts
+++ b/src/matchers/toContainAllValues.ts
@@ -1,18 +1,22 @@
-import { getType } from 'jest-get-type';
 import { contains } from 'src/utils';
 
 export function toContainAllValues<E = unknown>(actual: unknown, expected: readonly E[]) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  let pass = false;
-  if (getType(actual) === 'object') {
-    // @ts-expect-error getType provides the type check
-    const values = Object.keys(actual).map(k => actual[k]);
-    pass =
-      // @ts-expect-error OK to have implicit any for this
-      values.length === expected.length && values.every(objectValue => contains(this.equals, expected, objectValue));
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toContainAllValues', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
   }
+
+  const values = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
+  const pass =
+    // @ts-expect-error OK to have implicit any for this
+    values.length === expected.length && values.every(objectValue => contains(this.equals, expected, objectValue));
 
   return {
     pass,

--- a/src/matchers/toContainAnyEntries.ts
+++ b/src/matchers/toContainAnyEntries.ts
@@ -7,18 +7,15 @@ export function toContainAnyEntries<E = unknown>(
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toContainAnyEntries', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
+  let pass = false;
+  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+    const entries = Object.keys(actual as Record<string, unknown>).map(k => [
+      k,
+      (actual as Record<string, unknown>)[k],
+    ]);
+    // @ts-expect-error OK to have implicit any for this
+    pass = expected.some(entry => contains(this.equals, entries, entry));
   }
-
-  const entries = Object.keys(actual).map(k => [k, (actual as Record<string, unknown>)[k]]);
-  // @ts-expect-error OK to have implicit any for this
-  const pass = expected.some(entry => contains(this.equals, entries, entry));
 
   return {
     pass,

--- a/src/matchers/toContainAnyEntries.ts
+++ b/src/matchers/toContainAnyEntries.ts
@@ -1,4 +1,3 @@
-import { getType } from 'jest-get-type';
 import { contains } from 'src/utils';
 
 export function toContainAnyEntries<E = unknown>(
@@ -8,13 +7,18 @@ export function toContainAnyEntries<E = unknown>(
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  let pass = false;
-  if (getType(actual) === 'object') {
-    // @ts-expect-error getType provides the type check
-    const entries = Object.keys(actual).map(k => [k, actual[k]]);
-    // @ts-expect-error OK to have implicit any for this
-    pass = expected.some(entry => contains(this.equals, entries, entry));
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toContainAnyEntries', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
   }
+
+  const entries = Object.keys(actual).map(k => [k, (actual as Record<string, unknown>)[k]]);
+  // @ts-expect-error OK to have implicit any for this
+  const pass = expected.some(entry => contains(this.equals, entries, entry));
 
   return {
     pass,

--- a/src/matchers/toContainAnyValues.ts
+++ b/src/matchers/toContainAnyValues.ts
@@ -4,18 +4,14 @@ export function toContainAnyValues<E = unknown>(actual: unknown, expected: reado
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toContainAnyValues', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
+  let pass = false;
+  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+    const objectValues = Object.keys(actual as Record<string, unknown>).map(
+      k => (actual as Record<string, unknown>)[k],
     );
+    // @ts-expect-error OK to have implicit any for this
+    pass = expected.some(value => contains(this.equals, objectValues, value));
   }
-
-  const objectValues = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
-  // @ts-expect-error OK to have implicit any for this
-  const pass = expected.some(value => contains(this.equals, objectValues, value));
 
   return {
     pass,

--- a/src/matchers/toContainAnyValues.ts
+++ b/src/matchers/toContainAnyValues.ts
@@ -1,17 +1,21 @@
-import { getType } from 'jest-get-type';
 import { contains } from 'src/utils';
 
 export function toContainAnyValues<E = unknown>(actual: unknown, expected: readonly E[]) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  let pass = false;
-  if (getType(actual) === 'object') {
-    // @ts-expect-error getType provides the type check
-    const objectValues = Object.keys(actual).map(k => actual[k]);
-    // @ts-expect-error OK to have implicit any for this
-    pass = expected.some(value => contains(this.equals, objectValues, value));
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toContainAnyValues', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
   }
+
+  const objectValues = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
+  // @ts-expect-error OK to have implicit any for this
+  const pass = expected.some(value => contains(this.equals, objectValues, value));
 
   return {
     pass,

--- a/src/matchers/toContainKey.ts
+++ b/src/matchers/toContainKey.ts
@@ -2,16 +2,12 @@ export function toContainKey<E = unknown>(actual: unknown, expected: keyof E | s
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toContainKey', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
-  const pass = actual.hasOwnProperty && Object.prototype.hasOwnProperty.call(actual, expected);
+  const pass =
+    typeof actual === 'object' &&
+    actual !== null &&
+    !Array.isArray(actual) &&
+    actual.hasOwnProperty &&
+    Object.prototype.hasOwnProperty.call(actual, expected);
 
   return {
     pass,

--- a/src/matchers/toContainKey.ts
+++ b/src/matchers/toContainKey.ts
@@ -1,12 +1,17 @@
-import { getType } from 'jest-get-type';
-
 export function toContainKey<E = unknown>(actual: unknown, expected: keyof E | string) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  const pass =
-    // @ts-expect-error getType provides the type check
-    getType(actual) === 'object' && actual.hasOwnProperty && Object.prototype.hasOwnProperty.call(actual, expected);
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toContainKey', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
+  }
+
+  const pass = actual.hasOwnProperty && Object.prototype.hasOwnProperty.call(actual, expected);
 
   return {
     pass,

--- a/src/matchers/toContainValue.ts
+++ b/src/matchers/toContainValue.ts
@@ -1,17 +1,21 @@
-import { getType } from 'jest-get-type';
 import { contains } from 'src/utils';
 
 export function toContainValue<E = unknown>(actual: unknown, expected: E) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  let pass = false;
-  if (getType(actual) === 'object') {
-    // @ts-expect-error getType provides the type check
-    const values = Object.keys(actual).map(k => actual[k]);
-    // @ts-expect-error OK to have implicit any for this
-    pass = contains(this.equals, values, expected);
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toContainValue', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
   }
+
+  const values = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
+    // @ts-expect-error OK to have implicit any for this
+  const pass = contains(this.equals, values, expected);
 
   return {
     pass,

--- a/src/matchers/toContainValue.ts
+++ b/src/matchers/toContainValue.ts
@@ -4,18 +4,12 @@ export function toContainValue<E = unknown>(actual: unknown, expected: E) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toContainValue', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
-  }
-
-  const values = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
+  let pass = false;
+  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+    const values = Object.keys(actual as Record<string, unknown>).map(k => (actual as Record<string, unknown>)[k]);
     // @ts-expect-error OK to have implicit any for this
-  const pass = contains(this.equals, values, expected);
+    pass = contains(this.equals, values, expected);
+  }
 
   return {
     pass,

--- a/src/matchers/toContainValues.ts
+++ b/src/matchers/toContainValues.ts
@@ -4,17 +4,12 @@ export function toContainValues<E = unknown>(actual: unknown, expected: readonly
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  if (typeof actual !== 'object' || actual === null) {
-    throw new Error(
-        matcherHint('.toContainValues', 'received', '') +
-        '\n\n' +
-        'Expected value to be of type object but received:\n' +
-        `  ${printReceived(actual)}`,
-    );
+  let pass = false;
+  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+    const values = Object.keys(actual as Record<string, unknown>).map(k => (actual as Record<string, unknown>)[k]);
+    // @ts-expect-error OK to have implicit any for this
+    pass = expected.every(value => contains(this.equals, values, value));
   }
-  const values = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
-  // @ts-expect-error OK to have implicit any for this
-  const pass = expected.every(value => contains(this.equals, values, value));
 
   return {
     pass,

--- a/src/matchers/toContainValues.ts
+++ b/src/matchers/toContainValues.ts
@@ -1,17 +1,20 @@
-import { getType } from 'jest-get-type';
 import { contains } from 'src/utils';
 
 export function toContainValues<E = unknown>(actual: unknown, expected: readonly E[]) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  let pass = false;
-  if (getType(actual) === 'object') {
-    // @ts-expect-error getType provides the type check
-    const values = Object.keys(actual).map(k => actual[k]);
-    // @ts-expect-error OK to have implicit any for this
-    pass = expected.every(value => contains(this.equals, values, value));
+  if (typeof actual !== 'object' || actual === null) {
+    throw new Error(
+        matcherHint('.toContainValues', 'received', '') +
+        '\n\n' +
+        'Expected value to be of type object but received:\n' +
+        `  ${printReceived(actual)}`,
+    );
   }
+  const values = Object.keys(actual).map(k => (actual as Record<string, unknown>)[k]);
+  // @ts-expect-error OK to have implicit any for this
+  const pass = expected.every(value => contains(this.equals, values, value));
 
   return {
     pass,

--- a/src/matchers/toEndWith.ts
+++ b/src/matchers/toEndWith.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toEndWith(actual: unknown, expected: string) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'string' && actual.endsWith(expected);
+  const pass = typeof actual === 'string' && actual.endsWith(expected);
 
   return {
     pass,

--- a/src/matchers/toEqualIgnoringWhitespace.ts
+++ b/src/matchers/toEqualIgnoringWhitespace.ts
@@ -1,5 +1,4 @@
 import { diffStringsRaw, DIFF_EQUAL } from 'jest-diff';
-import { getType } from 'jest-get-type';
 import { printExpected, printReceived } from '../utils/print';
 
 const removeWhitespace = (str: any) => str.trim().replace(/\s+/g, '');
@@ -22,7 +21,7 @@ export function toEqualIgnoringWhitespace(actual: unknown, expected: string) {
   const { matcherHint, EXPECTED_COLOR } = this.utils;
 
   /* determine whether strings are equal after removing white-space */
-  const pass = getType(actual) === 'string' && removeWhitespace(actual) === removeWhitespace(expected);
+  const pass = typeof actual === 'string' && removeWhitespace(actual) === removeWhitespace(expected);
 
   /* eslint-disable indent */ // prettier conflicts with indent rule
   return {

--- a/src/matchers/toInclude.ts
+++ b/src/matchers/toInclude.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toInclude(actual: unknown, expected: string) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'string' && actual.includes(expected);
+  const pass = typeof actual === 'string' && actual.includes(expected);
 
   return {
     pass,

--- a/src/matchers/toIncludeMultiple.ts
+++ b/src/matchers/toIncludeMultiple.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toIncludeMultiple(actual: unknown, expected: readonly string[]) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'string' && expected.every(value => actual.includes(value));
+  const pass = typeof actual === 'string' && expected.every(value => actual.includes(value));
 
   return {
     pass,

--- a/src/matchers/toIncludeRepeated.ts
+++ b/src/matchers/toIncludeRepeated.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toIncludeRepeated(actual: unknown, expected: string, occurrences: number) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'string' && (actual.match(new RegExp(expected, 'g')) || []).length === occurrences;
+  const pass = typeof actual === 'string' && (actual.match(new RegExp(expected, 'g')) || []).length === occurrences;
 
   return {
     pass,

--- a/src/matchers/toStartWith.ts
+++ b/src/matchers/toStartWith.ts
@@ -1,11 +1,8 @@
-import { getType } from 'jest-get-type';
-
 export function toStartWith(actual: unknown, expected: string) {
   // @ts-expect-error OK to have implicit any for this
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  // @ts-expect-error getType provides the type check
-  const pass = getType(actual) === 'string' && actual.startsWith(expected);
+  const pass = typeof actual === 'string' && actual.startsWith(expected);
 
   return {
     pass,

--- a/test/matchers/__snapshots__/toBeAfter.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeAfter.test.ts.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toBeAfter fails when actual is not a Date 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeAfter()</intensity>
-
-Expected value to be of type Date but received:
-  <red>"not-a-date"</color>"
-`;
-
 exports[`.not.toBeAfter fails when given a later date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeAfter()</intensity>
 
@@ -17,7 +10,7 @@ Expected date to be after <red>2018-06-01T22:00:00.000Z</color> but received:
 exports[`.toBeAfter fails when actual is not a Date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeAfter()</intensity>
 
-Expected value to be of type Date but received:
+Expected date to be after <red>2018-06-01T22:00:00.000Z</color> but received:
   <red>"not-a-date"</color>"
 `;
 

--- a/test/matchers/__snapshots__/toBeAfterOrEqualTo.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeAfterOrEqualTo.test.ts.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toBeAfterOrEqualTo fails when actual is not a Date 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
-
-Expected value to be of type Date but received:
-  <red>"not-a-date"</color>"
-`;
-
 exports[`.not.toBeAfterOrEqualTo fails when given a later date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeAfterOrEqualTo()</intensity>
 
@@ -24,7 +17,7 @@ Expected date to be after or equal to <red>2019-09-01T22:00:00.000Z</color> but 
 exports[`.toBeAfterOrEqualTo fails when actual is not a Date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
 
-Expected value to be of type Date but received:
+Expected date to be after or equal to <red>2019-09-01T22:00:00.000Z</color> but received:
   <red>"not-a-date"</color>"
 `;
 

--- a/test/matchers/__snapshots__/toBeBefore.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeBefore.test.ts.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toBeBefore fails when actual is not a Date 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeBefore()</intensity>
-
-Expected value to be of type Date but received:
-  <red>"not-a-date"</color>"
-`;
-
 exports[`.not.toBeBefore fails when given an earlier date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeBefore()</intensity>
 
@@ -17,7 +10,7 @@ Expected date to be before <red>2018-06-02T22:00:00.000Z</color> but received:
 exports[`.toBeBefore fails when actual is not a Date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeBefore()</intensity>
 
-Expected value to be of type Date but received:
+Expected date to be before <red>2018-06-02T22:00:00.000Z</color> but received:
   <red>"not-a-date"</color>"
 `;
 

--- a/test/matchers/__snapshots__/toBeBeforeOrEqualTo.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeBeforeOrEqualTo.test.ts.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toBeBeforeOrEqualTo fails when actual is not a Date 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeBeforeOrEqualTo()</intensity>
-
-Expected value to be of type Date but received:
-  <red>"not-a-date"</color>"
-`;
-
 exports[`.not.toBeBeforeOrEqualTo fails when given an earlier date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeBeforeOrEqualTo()</intensity>
 
@@ -24,7 +17,7 @@ Expected date to be before or equal to <red>2019-09-01T22:00:00.000Z</color> but
 exports[`.toBeBeforeOrEqualTo fails when actual is not a Date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeBeforeOrEqualTo()</intensity>
 
-Expected value to be of type Date but received:
+Expected date to be before or equal to <red>2019-09-10T22:00:00.000Z</color> but received:
   <red>"not-a-date"</color>"
 `;
 

--- a/test/matchers/__snapshots__/toBeBetween.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeBetween.test.ts.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toBeBefore fails when actual is not a Date 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeBetween()</intensity>
-
-Expected value to be of type Date but received:
-  <red>"not-a-date"</color>"
-`;
-
 exports[`.not.toBeBefore fails when date is in given range 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toBeBetween()</intensity>
 
@@ -17,7 +10,7 @@ Expected date to be between <red>2019-09-01T22:00:00.000Z</color> and <red>2019-
 exports[`.toBeBetween fails when actual is not a Date 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toBeBetween()</intensity>
 
-Expected value to be of type Date but received:
+Expected date to be between <red>2019-09-01T22:00:00.000Z</color> and <red>2019-09-10T22:00:00.000Z</color> but received:
   <red>"not-a-date"</color>"
 `;
 

--- a/test/matchers/__snapshots__/toBeEmptyObject.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeEmptyObject.test.ts.snap
@@ -13,3 +13,24 @@ exports[`.toBeEmptyObject fails when not given an empty object 1`] = `
 Expected value to be an empty object, received:
   <red>{"property1": "something"}</color>"
 `;
+
+exports[`.toBeEmptyObject fails when not given an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyObject()</intensity>
+
+Expected value to be an empty object, received:
+  <red>null</color>"
+`;
+
+exports[`.toBeEmptyObject fails when not given an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyObject()</intensity>
+
+Expected value to be an empty object, received:
+  <red>[42]</color>"
+`;
+
+exports[`.toBeEmptyObject fails when not given an object 3`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyObject()</intensity>
+
+Expected value to be an empty object, received:
+  <red>42</color>"
+`;

--- a/test/matchers/__snapshots__/toContainAllEntries.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllEntries.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainAllEntries fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.not.toContainAllEntries fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
+`;
+
 exports[`.not.toContainAllEntries fails when object only contains all of the given entries 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllEntries(</intensity><green>expected</color><dim>)</intensity>
 
@@ -7,6 +21,20 @@ Expected object to not only contain all of the given entries:
   <green>[["b", "bar"], ["a", "foo"], ["c", "baz"]]</color>
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;
+
+exports[`.toContainAllEntries fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainAllEntries fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainAllEntries fails when object does not only contain all of the given entries 1`] = `

--- a/test/matchers/__snapshots__/toContainAllEntries.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllEntries.test.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainAllEntries fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
-
-exports[`.not.toContainAllEntries fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
-
-Expected value to be of type object but received:
-  <red>42</color>"
-`;
-
 exports[`.not.toContainAllEntries fails when object only contains all of the given entries 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllEntries(</intensity><green>expected</color><dim>)</intensity>
 
@@ -24,16 +10,20 @@ Received:
 `;
 
 exports[`.toContainAllEntries fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to only contain all of the given entries:
+  <green>[["a", "foo"], ["b", "bar"]]</color>
+Received:
   <red>null</color>"
 `;
 
 exports[`.toContainAllEntries fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllEntries(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to only contain all of the given entries:
+  <green>[["a", "foo"], ["b", "bar"]]</color>
+Received:
   <red>42</color>"
 `;
 

--- a/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainAllKeys fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.not.toContainAllKeys fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
+`;
+
 exports[`.not.toContainAllKeys fails when given object contains all keys 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
@@ -7,6 +21,20 @@ Expected object to not contain all keys:
   <green>["b", "a"]</color>
 Received:
   <red>["a", "b"]</color>"
+`;
+
+exports[`.toContainAllKeys fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainAllKeys fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainAllKeys fails when all of the object keys are matched, but there are additional keys  1`] = `

--- a/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainAllKeys fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
-
-exports[`.not.toContainAllKeys fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
-
-Expected value to be of type object but received:
-  <red>42</color>"
-`;
-
 exports[`.not.toContainAllKeys fails when given object contains all keys 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
@@ -23,18 +9,15 @@ Received:
   <red>["a", "b"]</color>"
 `;
 
-exports[`.toContainAllKeys fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
+exports[`.toContainAllKeys fails when actual is not an object 1`] = `"Cannot convert undefined or null to object"`;
 
 exports[`.toContainAllKeys fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toBeAfterOrEqualTo()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
-  <red>42</color>"
+Expected object to contain all keys:
+  <green>["a", "b"]</color>
+Received:
+  <red>[]</color>"
 `;
 
 exports[`.toContainAllKeys fails when all of the object keys are matched, but there are additional keys  1`] = `

--- a/test/matchers/__snapshots__/toContainAllValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllValues.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainAllValues fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.not.toContainAllValues fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
+`;
+
 exports[`.not.toContainAllValues fails when given object contains all values including arrays 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
@@ -25,6 +39,20 @@ Expected object to not contain all values:
   <green>["world", 0, false]</color>
 Received:
   <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
+`;
+
+exports[`.toContainAllValues fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainAllValues fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainAllValues fails when given object does not contain all primitive values 1`] = `

--- a/test/matchers/__snapshots__/toContainAllValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllValues.test.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainAllValues fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
-
-exports[`.not.toContainAllValues fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
-
-Expected value to be of type object but received:
-  <red>42</color>"
-`;
-
 exports[`.not.toContainAllValues fails when given object contains all values including arrays 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
@@ -42,16 +28,20 @@ Received:
 `;
 
 exports[`.toContainAllValues fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain all values:
+  <green>["world", 0, false]</color>
+Received:
   <red>null</color>"
 `;
 
 exports[`.toContainAllValues fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllValues(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain all values:
+  <green>["world", 0, false]</color>
+Received:
   <red>42</color>"
 `;
 

--- a/test/matchers/__snapshots__/toContainAnyEntries.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAnyEntries.test.ts.snap
@@ -1,5 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainAnyEntries fails when actual is not an object 1`] = `"expect(...).not.toContainAllEntries is not a function"`;
+
+exports[`.not.toContainAnyEntries fails when actual is not an object 2`] = `"expect(...).not.toContainAllEntries is not a function"`;
+
 exports[`.not.toContainAnyEntries fails when given object contains atleast one of the given entries 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyEntries(</intensity><green>expected</color><dim>)</intensity>
 
@@ -7,6 +11,20 @@ Expected object to not contain any of the provided entries:
   <green>[["a", "qux"], ["a", "foo"]]</color>
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;
+
+exports[`.toContainAnyEntries fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainAnyEntries fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainAnyEntries fails when given object does not contain any of the given entries 1`] = `

--- a/test/matchers/__snapshots__/toContainAnyEntries.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAnyEntries.test.ts.snap
@@ -1,9 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainAnyEntries fails when actual is not an object 1`] = `"expect(...).not.toContainAllEntries is not a function"`;
-
-exports[`.not.toContainAnyEntries fails when actual is not an object 2`] = `"expect(...).not.toContainAllEntries is not a function"`;
-
 exports[`.not.toContainAnyEntries fails when given object contains atleast one of the given entries 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyEntries(</intensity><green>expected</color><dim>)</intensity>
 
@@ -14,16 +10,20 @@ Received:
 `;
 
 exports[`.toContainAnyEntries fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain any of the provided entries:
+  <green>[["a", "qux"], ["a", "foo"]]</color>
+Received:
   <red>null</color>"
 `;
 
 exports[`.toContainAnyEntries fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyEntries(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain any of the provided entries:
+  <green>[["a", "qux"], ["a", "foo"]]</color>
+Received:
   <red>42</color>"
 `;
 

--- a/test/matchers/__snapshots__/toContainAnyValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAnyValues.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainAnyValues fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.not.toContainAnyValues fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
+`;
+
 exports[`.not.toContainAnyValues fails when given object contains value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
@@ -16,6 +30,20 @@ Expected object to not contain any of the following values:
   <green>["foo", "bar"]</color>
 Received:
   <red>{"a": "foo", "b": "bar", "c": "baz"}</color>"
+`;
+
+exports[`.toContainAnyValues fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainAnyValues fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainAnyValues fails when given object does not contain value 1`] = `

--- a/test/matchers/__snapshots__/toContainAnyValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAnyValues.test.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainAnyValues fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
-
-exports[`.not.toContainAnyValues fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
-
-Expected value to be of type object but received:
-  <red>42</color>"
-`;
-
 exports[`.not.toContainAnyValues fails when given object contains value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
@@ -33,16 +19,20 @@ Received:
 `;
 
 exports[`.toContainAnyValues fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain any of the following values:
+  <green>["foo"]</color>
+Received:
   <red>null</color>"
 `;
 
 exports[`.toContainAnyValues fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainAnyValues(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain any of the following values:
+  <green>["foo"]</color>
+Received:
   <red>42</color>"
 `;
 

--- a/test/matchers/__snapshots__/toContainKey.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainKey.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainKey fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.not.toContainKey fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
+`;
+
 exports[`.not.toContainKey fails when given object contains key 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainKey(</intensity><green>expected</color><dim>)</intensity>
 
@@ -7,6 +21,20 @@ Expected object to not contain key:
   <green>"hello"</color>
 Received:
   <red>{"hello": "world"}</color>"
+`;
+
+exports[`.toContainKey fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainKey fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainKey fails when given object does not contain key 1`] = `

--- a/test/matchers/__snapshots__/toContainKey.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainKey.test.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainKey fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
-
-exports[`.not.toContainKey fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
-
-Expected value to be of type object but received:
-  <red>42</color>"
-`;
-
 exports[`.not.toContainKey fails when given object contains key 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainKey(</intensity><green>expected</color><dim>)</intensity>
 
@@ -24,16 +10,20 @@ Received:
 `;
 
 exports[`.toContainKey fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainKey(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain key:
+  <green>"hello"</color>
+Received:
   <red>null</color>"
 `;
 
 exports[`.toContainKey fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainKey()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainKey(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain key:
+  <green>"hello"</color>
+Received:
   <red>42</color>"
 `;
 

--- a/test/matchers/__snapshots__/toContainValue.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValue.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainValue fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.not.toContainValue fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
+`;
+
 exports[`.not.toContainValue fails when given object contains array value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
@@ -25,6 +39,20 @@ Expected object to not contain value:
   <green>"world"</color>
 Received:
   <red>{"hello": "world"}</color>"
+`;
+
+exports[`.toContainValue fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainValue fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainValue fails when given object does not contain array value 1`] = `

--- a/test/matchers/__snapshots__/toContainValue.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValue.test.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainValue fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
-
-exports[`.not.toContainValue fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
-
-Expected value to be of type object but received:
-  <red>42</color>"
-`;
-
 exports[`.not.toContainValue fails when given object contains array value 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
@@ -42,16 +28,20 @@ Received:
 `;
 
 exports[`.toContainValue fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain value:
+  <green>"world"</color>
+Received:
   <red>null</color>"
 `;
 
 exports[`.toContainValue fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValue()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain value:
+  <green>"world"</color>
+Received:
   <red>42</color>"
 `;
 

--- a/test/matchers/__snapshots__/toContainValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValues.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.not.toContainValues fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.not.toContainValues fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
+`;
+
 exports[`.not.toContainValues fails when given object contains all values including arrays 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
@@ -25,6 +39,20 @@ Expected object to not contain all values:
   <green>["world", false]</color>
 Received:
   <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
+`;
+
+exports[`.toContainValues fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>null</color>"
+`;
+
+exports[`.toContainValues fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
+
+Expected value to be of type object but received:
+  <red>42</color>"
 `;
 
 exports[`.toContainValues fails when given object does not contain all primitive values 1`] = `

--- a/test/matchers/__snapshots__/toContainValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValues.test.ts.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.not.toContainValues fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
-
-Expected value to be of type object but received:
-  <red>null</color>"
-`;
-
-exports[`.not.toContainValues fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
-
-Expected value to be of type object but received:
-  <red>42</color>"
-`;
-
 exports[`.not.toContainValues fails when given object contains all values including arrays 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).not.toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
@@ -42,16 +28,20 @@ Received:
 `;
 
 exports[`.toContainValues fails when actual is not an object 1`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain all values:
+  <green>["world", false]</color>
+Received:
   <red>null</color>"
 `;
 
 exports[`.toContainValues fails when actual is not an object 2`] = `
-"<dim>expect(</intensity><red>received</color><dim>).toContainValues()</intensity>
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
-Expected value to be of type object but received:
+Expected object to contain all values:
+  <green>["world", false]</color>
+Received:
   <red>42</color>"
 `;
 

--- a/test/matchers/toBeAfter.test.ts
+++ b/test/matchers/toBeAfter.test.ts
@@ -34,9 +34,9 @@ describe('.not.toBeAfter', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not a Date', () => {
+  test('passes when actual is not a Date', () => {
     expect(() => {
       expect('not-a-date').not.toBeAfter(LATER);
-    }).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/test/matchers/toBeAfterOrEqualTo.test.ts
+++ b/test/matchers/toBeAfterOrEqualTo.test.ts
@@ -44,9 +44,9 @@ describe('.not.toBeAfterOrEqualTo', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not a Date', () => {
+  test('passes when actual is not a Date', () => {
     expect(() => {
       expect('not-a-date').not.toBeAfterOrEqualTo(LATER);
-    }).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/test/matchers/toBeBefore.test.ts
+++ b/test/matchers/toBeBefore.test.ts
@@ -34,9 +34,9 @@ describe('.not.toBeBefore', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not a Date', () => {
+  test('passes when actual is not a Date', () => {
     expect(() => {
       expect('not-a-date').not.toBeBefore(EARLIER);
-    }).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/test/matchers/toBeBeforeOrEqualTo.test.ts
+++ b/test/matchers/toBeBeforeOrEqualTo.test.ts
@@ -44,9 +44,9 @@ describe('.not.toBeBeforeOrEqualTo', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not a Date', () => {
+  test('passes when actual is not a Date', () => {
     expect(() => {
       expect('not-a-date').not.toBeBeforeOrEqualTo(EARLIER);
-    }).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/test/matchers/toBeBetween.test.ts
+++ b/test/matchers/toBeBetween.test.ts
@@ -35,9 +35,9 @@ describe('.not.toBeBefore', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not a Date', () => {
+  test('passes when actual is not a Date', () => {
     expect(() => {
       expect('not-a-date').not.toBeBetween(TESTDATE3, TESTDATE2);
-    }).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/test/matchers/toBeEmptyObject.test.ts
+++ b/test/matchers/toBeEmptyObject.test.ts
@@ -10,6 +10,12 @@ describe('.toBeEmptyObject', () => {
   test('fails when not given an empty object', () => {
     expect(() => expect({ property1: 'something' }).toBeEmptyObject()).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when not given an object', () => {
+    expect(() => expect(null).toBeEmptyObject()).toThrowErrorMatchingSnapshot();
+    expect(() => expect([42]).toBeEmptyObject()).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).toBeEmptyObject()).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toBeEmptyObject', () => {
@@ -19,5 +25,11 @@ describe('.not.toBeEmptyObject', () => {
 
   test('fails when given an empty object', () => {
     expect(() => expect({}).not.toBeEmptyObject()).toThrowErrorMatchingSnapshot();
+  });
+
+  test('passes when not given an object', () => {
+    expect(() => expect(null).not.toBeEmptyObject());
+    expect(() => expect([42]).not.toBeEmptyObject());
+    expect(() => expect(42).not.toBeEmptyObject());
   });
 });

--- a/test/matchers/toContainAllEntries.test.ts
+++ b/test/matchers/toContainAllEntries.test.ts
@@ -58,19 +58,19 @@ describe('.not.toContainAllEntries', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
+  test('passes when actual is not an object', () => {
     expect(() =>
       expect(null).not.toContainAllEntries([
         ['a', 'foo'],
         ['b', 'bar'],
       ]),
-    ).toThrowErrorMatchingSnapshot();;
+    );
 
     expect(() =>
       expect(42).not.toContainAllEntries([
         ['a', 'foo'],
         ['b', 'bar'],
       ]),
-    ).toThrowErrorMatchingSnapshot();;
+    );
   });
 });

--- a/test/matchers/toContainAllEntries.test.ts
+++ b/test/matchers/toContainAllEntries.test.ts
@@ -21,6 +21,22 @@ describe('.toContainAllEntries', () => {
       ]),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() =>
+      expect(null).toContainAllEntries([
+        ['a', 'foo'],
+        ['b', 'bar'],
+      ]),
+    ).toThrowErrorMatchingSnapshot();
+
+    expect(() =>
+      expect(42).toContainAllEntries([
+        ['a', 'foo'],
+        ['b', 'bar'],
+      ]),
+    ).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainAllEntries', () => {
@@ -40,5 +56,21 @@ describe('.not.toContainAllEntries', () => {
         ['c', 'baz'],
       ]),
     ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() =>
+      expect(null).not.toContainAllEntries([
+        ['a', 'foo'],
+        ['b', 'bar'],
+      ]),
+    ).toThrowErrorMatchingSnapshot();;
+
+    expect(() =>
+      expect(42).not.toContainAllEntries([
+        ['a', 'foo'],
+        ['b', 'bar'],
+      ]),
+    ).toThrowErrorMatchingSnapshot();;
   });
 });

--- a/test/matchers/toContainAllKeys.test.ts
+++ b/test/matchers/toContainAllKeys.test.ts
@@ -36,8 +36,8 @@ describe('.not.toContainAllKeys', () => {
     expect(() => expect(data).not.toContainAllKeys(['b', 'a'])).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
-    expect(() => expect(null).not.toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
-    expect(() => expect(42).not.toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
+  test('passes when actual is not an object', () => {
+    expect(() => expect(null).not.toContainAllKeys(['a', 'b']));
+    expect(() => expect(42).not.toContainAllKeys(['a', 'b']));
   });
 });

--- a/test/matchers/toContainAllKeys.test.ts
+++ b/test/matchers/toContainAllKeys.test.ts
@@ -20,6 +20,11 @@ describe('.toContainAllKeys', () => {
   test('fails when all of the object keys are matched, but there are additional keys ', () => {
     expect(() => expect(data).toContainAllKeys(['a', 'c'])).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainAllKeys', () => {
@@ -29,5 +34,10 @@ describe('.not.toContainAllKeys', () => {
 
   test('fails when given object contains all keys', () => {
     expect(() => expect(data).not.toContainAllKeys(['b', 'a'])).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).not.toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).not.toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/test/matchers/toContainAllValues.test.ts
+++ b/test/matchers/toContainAllValues.test.ts
@@ -77,8 +77,8 @@ describe('.not.toContainAllValues', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
-    expect(() => expect(null).not.toContainAllValues(['world', 0, false])).toThrowErrorMatchingSnapshot();
-    expect(() => expect(42).not.toContainAllValues(['world', 0, false])).toThrowErrorMatchingSnapshot();
+  test('passes when actual is not an object', () => {
+    expect(() => expect(null).not.toContainAllValues(['world', 0, false]));
+    expect(() => expect(42).not.toContainAllValues(['world', 0, false]));
   });
 });

--- a/test/matchers/toContainAllValues.test.ts
+++ b/test/matchers/toContainAllValues.test.ts
@@ -41,6 +41,11 @@ describe('.toContainAllValues', () => {
   test('fails when given object does not contain all values including arrays', () => {
     expect(() => expect(deepArray).toContainAllValues(['duck', [{ hello: 'world' }]])).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).toContainAllValues(['world', 0, false])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).toContainAllValues(['world', 0, false])).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainAllValues', () => {
@@ -70,5 +75,10 @@ describe('.not.toContainAllValues', () => {
     expect(() =>
       expect(deepArray).not.toContainAllValues(['duck', [{ hello: 'world', foo: 0, bar: false }]]),
     ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).not.toContainAllValues(['world', 0, false])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).not.toContainAllValues(['world', 0, false])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/test/matchers/toContainAnyEntries.test.ts
+++ b/test/matchers/toContainAnyEntries.test.ts
@@ -23,17 +23,17 @@ describe('.toContainAnyEntries', () => {
 
   test('fails when actual is not an object', () => {
     expect(() =>
-        expect(null).toContainAnyEntries([
-          ['a', 'qux'],
-          ['a', 'foo'],
-        ]),
+      expect(null).toContainAnyEntries([
+        ['a', 'qux'],
+        ['a', 'foo'],
+      ]),
     ).toThrowErrorMatchingSnapshot();
 
     expect(() =>
-        expect(42).toContainAnyEntries([
-          ['a', 'qux'],
-          ['a', 'foo'],
-        ]),
+      expect(42).toContainAnyEntries([
+        ['a', 'qux'],
+        ['a', 'foo'],
+      ]),
     ).toThrowErrorMatchingSnapshot();
   });
 });
@@ -55,19 +55,19 @@ describe('.not.toContainAnyEntries', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
+  test('passes when actual is not an object', () => {
     expect(() =>
-        expect(null).not.toContainAllEntries([
-          ['a', 'qux'],
-          ['a', 'foo'],
-        ]),
-    ).toThrowErrorMatchingSnapshot();
+      expect(null).not.toContainAllEntries([
+        ['a', 'qux'],
+        ['a', 'foo'],
+      ]),
+    );
 
     expect(() =>
-        expect(42).not.toContainAllEntries([
-          ['a', 'qux'],
-          ['a', 'foo'],
-        ]),
-    ).toThrowErrorMatchingSnapshot();
+      expect(42).not.toContainAllEntries([
+        ['a', 'qux'],
+        ['a', 'foo'],
+      ]),
+    );
   });
 });

--- a/test/matchers/toContainAnyEntries.test.ts
+++ b/test/matchers/toContainAnyEntries.test.ts
@@ -20,6 +20,22 @@ describe('.toContainAnyEntries', () => {
       ]),
     ).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() =>
+        expect(null).toContainAnyEntries([
+          ['a', 'qux'],
+          ['a', 'foo'],
+        ]),
+    ).toThrowErrorMatchingSnapshot();
+
+    expect(() =>
+        expect(42).toContainAnyEntries([
+          ['a', 'qux'],
+          ['a', 'foo'],
+        ]),
+    ).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainAnyEntries', () => {
@@ -36,6 +52,22 @@ describe('.not.toContainAnyEntries', () => {
         ['a', 'qux'],
         ['a', 'foo'],
       ]),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() =>
+        expect(null).not.toContainAllEntries([
+          ['a', 'qux'],
+          ['a', 'foo'],
+        ]),
+    ).toThrowErrorMatchingSnapshot();
+
+    expect(() =>
+        expect(42).not.toContainAllEntries([
+          ['a', 'qux'],
+          ['a', 'foo'],
+        ]),
     ).toThrowErrorMatchingSnapshot();
   });
 });

--- a/test/matchers/toContainAnyValues.test.ts
+++ b/test/matchers/toContainAnyValues.test.ts
@@ -35,8 +35,8 @@ describe('.not.toContainAnyValues', () => {
     expect(() => expect(data).not.toContainAnyValues(['foo', 'bar'])).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
-    expect(() => expect(null).not.toContainAnyValues(['foo'])).toThrowErrorMatchingSnapshot();
-    expect(() => expect(42).not.toContainAnyValues(['foo'])).toThrowErrorMatchingSnapshot();
+  test('passes when actual is not an object', () => {
+    expect(() => expect(null).not.toContainAnyValues(['foo']));
+    expect(() => expect(42).not.toContainAnyValues(['foo']));
   });
 });

--- a/test/matchers/toContainAnyValues.test.ts
+++ b/test/matchers/toContainAnyValues.test.ts
@@ -17,6 +17,11 @@ describe('.toContainAnyValues', () => {
     expect(() => expect(data).toContainAnyValues(['fax', 'rom'])).toThrowErrorMatchingSnapshot();
     expect(() => expect(data).toContainAnyValues(['dae', 'mur', 'zoe'])).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).toContainAnyValues(['foo'])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).toContainAnyValues(['foo'])).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainAnyValues', () => {
@@ -28,5 +33,10 @@ describe('.not.toContainAnyValues', () => {
   test('fails when given object contains value', () => {
     expect(() => expect(data).not.toContainAnyValues(['baz'])).toThrowErrorMatchingSnapshot();
     expect(() => expect(data).not.toContainAnyValues(['foo', 'bar'])).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).not.toContainAnyValues(['foo'])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).not.toContainAnyValues(['foo'])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/test/matchers/toContainKey.test.ts
+++ b/test/matchers/toContainKey.test.ts
@@ -12,6 +12,11 @@ describe('.toContainKey', () => {
   test('fails when given object does not contain key', () => {
     expect(() => expect(data).toContainKey('missing')).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).toContainKey('hello')).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).toContainKey('hello')).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainKey', () => {
@@ -21,5 +26,10 @@ describe('.not.toContainKey', () => {
 
   test('fails when given object contains key', () => {
     expect(() => expect(data).not.toContainKey('hello')).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).not.toContainKey('hello')).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).not.toContainKey('hello')).toThrowErrorMatchingSnapshot();
   });
 });

--- a/test/matchers/toContainKey.test.ts
+++ b/test/matchers/toContainKey.test.ts
@@ -28,8 +28,8 @@ describe('.not.toContainKey', () => {
     expect(() => expect(data).not.toContainKey('hello')).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
-    expect(() => expect(null).not.toContainKey('hello')).toThrowErrorMatchingSnapshot();
-    expect(() => expect(42).not.toContainKey('hello')).toThrowErrorMatchingSnapshot();
+  test('passes when actual is not an object', () => {
+    expect(() => expect(null).not.toContainKey('hello'));
+    expect(() => expect(42).not.toContainKey('hello'));
   });
 });

--- a/test/matchers/toContainValue.test.ts
+++ b/test/matchers/toContainValue.test.ts
@@ -70,8 +70,8 @@ describe('.not.toContainValue', () => {
     expect(() => expect(deepArray).not.toContainValue([{ hello: 'world' }])).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
-    expect(() => expect(null).not.toContainValue('world')).toThrowErrorMatchingSnapshot();
-    expect(() => expect(42).not.toContainValue('world')).toThrowErrorMatchingSnapshot();
+  test('passes when actual is not an object', () => {
+    expect(() => expect(null).not.toContainValue('world'));
+    expect(() => expect(42).not.toContainValue('world'));
   });
 });

--- a/test/matchers/toContainValue.test.ts
+++ b/test/matchers/toContainValue.test.ts
@@ -34,6 +34,11 @@ describe('.toContainValue', () => {
   test('fails when given object does not contain array value', () => {
     expect(() => expect(deepArray).toContainValue([{ world: 'hello' }])).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).toContainValue('world')).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).toContainValue('world')).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainValue', () => {
@@ -63,5 +68,10 @@ describe('.not.toContainValue', () => {
 
   test('fails when given object contains array value', () => {
     expect(() => expect(deepArray).not.toContainValue([{ hello: 'world' }])).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).not.toContainValue('world')).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).not.toContainValue('world')).toThrowErrorMatchingSnapshot();
   });
 });

--- a/test/matchers/toContainValues.test.ts
+++ b/test/matchers/toContainValues.test.ts
@@ -40,6 +40,11 @@ describe('.toContainValues', () => {
   test('fails when given object does not contain all values including arrays', () => {
     expect(() => expect(deepArray).toContainValues(['duck', [{ hello: 'world' }]])).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).toContainValues(['world', false])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).toContainValues(['world', false])).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toContainValues', () => {
@@ -69,5 +74,10 @@ describe('.not.toContainValues', () => {
     expect(() =>
       expect(deepArray).not.toContainValues(['duck', [{ hello: 'world', foo: 0, bar: false }]]),
     ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an object', () => {
+    expect(() => expect(null).not.toContainValues(['world', false])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(42).not.toContainValues(['world', false])).toThrowErrorMatchingSnapshot();
   });
 });

--- a/test/matchers/toContainValues.test.ts
+++ b/test/matchers/toContainValues.test.ts
@@ -76,8 +76,8 @@ describe('.not.toContainValues', () => {
     ).toThrowErrorMatchingSnapshot();
   });
 
-  test('fails when actual is not an object', () => {
-    expect(() => expect(null).not.toContainValues(['world', false])).toThrowErrorMatchingSnapshot();
-    expect(() => expect(42).not.toContainValues(['world', false])).toThrowErrorMatchingSnapshot();
+  test('passes when actual is not an object', () => {
+    expect(() => expect(null).not.toContainValues(['world', false]));
+    expect(() => expect(42).not.toContainValues(['world', false]));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,7 +3042,7 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-jest-get-type@^29.0.0, jest-get-type@^29.6.3:
+jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
   integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==


### PR DESCRIPTION
#745 Added more usages of jest-get-type to check the type of the actual received value was what was expected. We had a mix of this and things like `instanceOf`/`typeof`/etc. Using `getType()` is inconvenient because `tsc` doesn't recognize that it provides type safety, require lots of ignores. We should consolidate which approach we use for type safety. I chose to move us off of get-type.