### PR TITLE
fix: toIncludeSameMembers should fail when passed non-arrays

### DIFF
--- a/.changeset/pretty-ends-tan.md
+++ b/.changeset/pretty-ends-tan.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': patch
+---
+
+toIncludeSameMembers should fail when passed non-arrays

--- a/src/matchers/toIncludeSameMembers.ts
+++ b/src/matchers/toIncludeSameMembers.ts
@@ -2,8 +2,11 @@ export function toIncludeSameMembers<E = unknown>(actual: unknown, expected: rea
   // @ts-expect-error OK to have implicit any for this.utils
   const { printReceived, printExpected, matcherHint } = this.utils;
 
-  // @ts-expect-error OK to have implicit any for this.equals
-  const pass = predicate((a, b) => this.equals(a, b, this.customTesters), actual, expected);
+  const pass =
+    Array.isArray(actual) &&
+    Array.isArray(expected) &&
+    // @ts-expect-error OK to have implicit any for this.equals
+    predicate((a, b) => this.equals(a, b, this.customTesters), actual, expected);
 
   return {
     pass,

--- a/test/matchers/__snapshots__/toIncludeSameMembers.test.ts.snap
+++ b/test/matchers/__snapshots__/toIncludeSameMembers.test.ts.snap
@@ -9,6 +9,24 @@ Received:
   <red>[1]</color>"
 `;
 
+exports[`.toIncludeSameMembers fails when actual is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSameMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following members and no more:
+  <green>Set {1}</color>
+Received:
+  <red>[1, 2]</color>"
+`;
+
+exports[`.toIncludeSameMembers fails when expected is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toIncludeSameMembers(</intensity><green>expected</color><dim>)</intensity>
+
+Expected list to have the following members and no more:
+  <green>[1]</color>
+Received:
+  <red>Set {1, 2}</color>"
+`;
+
 exports[`.toIncludeSameMembers fails when the arrays are not equal in length 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toIncludeSameMembers(</intensity><green>expected</color><dim>)</intensity>
 

--- a/test/matchers/toIncludeSameMembers.test.ts
+++ b/test/matchers/toIncludeSameMembers.test.ts
@@ -20,6 +20,15 @@ describe('.toIncludeSameMembers', () => {
   test('fails when the arrays are not equal in length', () => {
     expect(() => expect([1, 2]).toIncludeSameMembers([1])).toThrowErrorMatchingSnapshot();
   });
+
+  test('fails when expected is not an array', () => {
+    expect(() => expect(new Set([1, 2])).toIncludeSameMembers([1])).toThrowErrorMatchingSnapshot();
+  });
+
+  test('fails when actual is not an array', () => {
+    // @ts-expect-error this is intentional for the test
+    expect(() => expect([1, 2]).toIncludeSameMembers(new Set([1]))).toThrowErrorMatchingSnapshot();
+  });
 });
 
 describe('.not.toIncludeSameMembers', () => {


### PR DESCRIPTION
(closes #710)
