### PR TITLE
Ignore both install-state.gz files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ coverage
 .vscode
 package-lock.json
 *tsbuildinfo
-/.yarn/install-state.gz
+install-state.gz


### PR DESCRIPTION
The website also has an install-state.gz file which we need to ignore.