### PR TITLE
build: Remove redundant rules

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,12 +8,6 @@ packageExtensions:
   "@typescript-eslint/project-service@*":
     dependencies:
       typescript: "*"
-  "@typescript-eslint/tsconfig-utils@*":
-    peerDependencies:
-      typescript: "*"
-  "@typescript-eslint/utils@*":
-    peerDependencies:
-      typescript: "*"
   eslint-plugin-jest@*:
     peerDependencies:
       typescript: "*"


### PR DESCRIPTION
Fix these warnings
```
➤ YN0069: │ @typescript-eslint/tsconfig-utils ➤ peerDependencies ➤ typescript: This rule seems redundant when applied on the original package; the extension may have been applied upstream.
➤ YN0069: │ @typescript-eslint/utils ➤ peerDependencies ➤ typescript: This rule seems redundant when applied on the original package; the extension may have been applied upstream.
```