### PR TITLE
feat(matchers): add toBeEmptyArray

### DIFF
--- a/.changeset/spotty-plums-thank.md
+++ b/.changeset/spotty-plums-thank.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': minor
+---
+
+Introduce new matcher `toBeEmptyArray`

--- a/src/matchers/index.ts
+++ b/src/matchers/index.ts
@@ -12,6 +12,7 @@ export { toBeBoolean } from './toBeBoolean';
 export { toBeDate } from './toBeDate';
 export { toBeDateString } from './toBeDateString';
 export { toBeEmpty } from './toBeEmpty';
+export { toBeEmptyArray } from './toBeEmptyArray';
 export { toBeEmptyObject } from './toBeEmptyObject';
 export { toBeEven } from './toBeEven';
 export { toBeExtensible } from './toBeExtensible';

--- a/src/matchers/toBeEmptyArray.ts
+++ b/src/matchers/toBeEmptyArray.ts
@@ -1,0 +1,20 @@
+export function toBeEmptyArray(actual: unknown) {
+  // @ts-expect-error OK to have implicit any for this.utils
+  const { printReceived, matcherHint } = this.utils;
+
+  const pass = Array.isArray(actual) && actual.length === 0;
+
+  return {
+    pass,
+    message: () =>
+      pass
+        ? matcherHint('.not.toBeEmptyArray', 'received', '') +
+          '\n\n' +
+          'Expected value to not be an empty array, received:\n' +
+          `  ${printReceived(actual)}`
+        : matcherHint('.toBeEmptyArray', 'received', '') +
+          '\n\n' +
+          'Expected value to be an empty array, received:\n' +
+          `  ${printReceived(actual)}`,
+  };
+}

--- a/test/matchers/__snapshots__/toBeEmptyArray.test.ts.snap
+++ b/test/matchers/__snapshots__/toBeEmptyArray.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`.not.toBeEmptyArray fails when given an empty array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toBeEmptyArray()</intensity>
+
+Expected value to not be an empty array, received:
+  <red>[]</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of () => { } which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>[Function anonymous]</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of {} which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>{}</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of 0 which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>0</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of NaN which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>NaN</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of false which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>false</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of null which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>null</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of true which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>true</color>"
+`;
+
+exports[`.toBeEmptyArray fails when given type of undefined which is not an array 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toBeEmptyArray()</intensity>
+
+Expected value to be an empty array, received:
+  <red>undefined</color>"
+`;

--- a/test/matchers/toBeEmptyArray.test.ts
+++ b/test/matchers/toBeEmptyArray.test.ts
@@ -1,0 +1,32 @@
+import * as matcher from 'src/matchers/toBeEmptyArray';
+
+expect.extend(matcher);
+
+describe('.toBeEmptyArray', () => {
+  {
+    test('passes when given an empty array', () => {
+      expect([]).toBeEmptyArray();
+    });
+  }
+
+  test.each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]])(
+    'fails when given type of %s which is not an array',
+    given => {
+      expect(() => expect(given).toBeEmptyArray()).toThrowErrorMatchingSnapshot();
+    },
+  );
+});
+
+describe('.not.toBeEmptyArray', () => {
+  test.each([[false], [true], [0], [{}], [() => {}], [undefined], [null], [NaN]])(
+    'passes when not given an empty array: %s',
+    given => {
+      expect(given).not.toBeEmptyArray();
+    },
+  );
+  {
+    test('fails when given an empty array', () => {
+      expect(() => expect([]).not.toBeEmptyArray()).toThrowErrorMatchingSnapshot();
+    });
+  }
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -512,6 +512,11 @@ declare namespace jest {
     toBeArray(): R;
 
     /**
+     * Use `.toBeEmptyArray` when checking if a value is an empty `Array`.
+     */
+    toBeEmptyArray(): R;
+
+    /**
      * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
      * @param {Number} x
      */

--- a/website/docs/matchers/array.mdx
+++ b/website/docs/matchers/array.mdx
@@ -14,6 +14,17 @@ Use `.toBeArray` when checking if a value is an `Array`.
 });`}
 </TestFile>
 
+### .toBeEmptyArray()
+
+Use `.toBeEmptyArray` when checking if a value is an empty `Array`.
+
+<TestFile name="toBeEmptyArray">
+  {`test('passes when value is an empty array', () => {
+  expect([]).toBeEmptyArray();
+  expect(['hello']).not.toBeEmptyArray();
+});`}
+</TestFile>
+
 ### .toBeArrayOfSize()
 
 Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.

--- a/website/docs/matchers/index.md
+++ b/website/docs/matchers/index.md
@@ -14,6 +14,7 @@ sidebar_position: 1
 ## [Array](/docs/matchers/array)
 
 - [.toBeArray()](/docs/matchers/array/#tobearray)
+- [.toBeEmptyArray()](/docs/matchers/array/#tobeemptyarray)
 - [.toBeArrayOfSize()](/docs/matchers/array/#tobearrayofsize)
 - [.toIncludeAllMembers([members])](/docs/matchers/array/#toincludeallmembersmembers)
 - [.toIncludeAllPartialMembers([members])](/docs/matchers/array/#toincludeallpartialmembersmembers)


### PR DESCRIPTION
<!--
Thanks for spending the time to send this PR :D.

Please fill out the information below and make sure you're familiar
with the contributing guidelines (found in the CONTRIBUTING.md file).
-->

<!-- What changes are being made? (feature/bug) -->

### What

Added a new matcher that is inspired on the `isEmptyObject` matcher.

<!-- Why are these changes necessary? Link any related issues -->

### Why

Personally I think using the `arrayOfSize(0)` matcher is less straight forward then `toBeEmptyArray()`. Secondly since the matcher `toBeEmptyObject` already existed, I thought it was a good idea to also add this one for convenience  

<!-- If necessary add any additional notes on the implementation -->

### Notes

### Housekeeping

- [x] Unit tests
- [x] Documentation is up to date
- [x] No additional lint warnings
- [x] [Typescript definitions](https://github.com/jest-community/jest-extended/blob/main/types/index.d.ts) are added/updated where relevant
