### PR TITLE
fix: allow `toContainValue` and `toContainValues` to work with arrays again

### DIFF
--- a/.changeset/olive-pugs-argue.md
+++ b/.changeset/olive-pugs-argue.md
@@ -1,0 +1,5 @@
+---
+"jest-extended": patch
+---
+
+fix: allow `toContainValue` and `toContainValues` to work with arrays again

--- a/src/matchers/toContainValue.ts
+++ b/src/matchers/toContainValue.ts
@@ -5,7 +5,7 @@ export function toContainValue<E = unknown>(actual: unknown, expected: E) {
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   let pass = false;
-  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+  if (typeof actual === 'object' && actual !== null) {
     const values = Object.values(actual as Record<string, unknown>);
     // @ts-expect-error OK to have implicit any for this.equals
     pass = contains((a, b) => this.equals(a, b, this.customTesters), values, expected);

--- a/src/matchers/toContainValues.ts
+++ b/src/matchers/toContainValues.ts
@@ -5,7 +5,7 @@ export function toContainValues<E = unknown>(actual: unknown, expected: readonly
   const { printReceived, printExpected, matcherHint } = this.utils;
 
   let pass = false;
-  if (typeof actual === 'object' && actual !== null && !Array.isArray(actual)) {
+  if (typeof actual === 'object' && actual !== null) {
     const values = Object.values(actual as Record<string, unknown>);
     // @ts-expect-error OK to have implicit any for this.equals
     pass = expected.every(value => contains((a, b) => this.equals(a, b, this.customTesters), values, value));

--- a/test/matchers/__snapshots__/toContainValue.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValue.test.ts.snap
@@ -27,6 +27,15 @@ Received:
   <red>{"hello": "world"}</color>"
 `;
 
+exports[`.not.toContainValue with arrays fails when given array contains value 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toContainValue(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to not contain value:
+  <green>"world"</color>
+Received:
+  <red>["world", "foo"]</color>"
+`;
+
 exports[`.toContainValue fails when actual is not an object 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
 
@@ -70,6 +79,15 @@ Expected object to contain value:
   <green>"hello"</color>
 Received:
   <red>{"hello": "world"}</color>"
+`;
+
+exports[`.toContainValue with arrays fails when given array does not contain value 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValue(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain value:
+  <green>"hello"</color>
+Received:
+  <red>["world", "foo"]</color>"
 `;
 
 exports[`toContainValue with custom equality tester fails when custom equality does not match any of the values 1`] = `

--- a/test/matchers/__snapshots__/toContainValues.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainValues.test.ts.snap
@@ -27,6 +27,15 @@ Received:
   <red>{"bar": false, "foo": 0, "hello": "world"}</color>"
 `;
 
+exports[`.not.toContainValues with arrays fails when given array contains values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).not.toContainValues(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to not contain all values:
+  <green>["world", "foo"]</color>
+Received:
+  <red>["world", "foo", "bar"]</color>"
+`;
+
 exports[`.toContainValues fails when actual is not an object 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
 
@@ -70,6 +79,15 @@ Expected object to contain all values:
   <green>[{"hello": "world"}]</color>
 Received:
   <red>{"donald": "duck", "message": {"bar": false, "foo": 0, "hello": "world"}}</color>"
+`;
+
+exports[`.toContainValues with arrays fails when given array does not contain values 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainValues(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain all values:
+  <green>["hello", "world"]</color>
+Received:
+  <red>["world", "foo"]</color>"
 `;
 
 exports[`toContainValues with custom equality tester fails when custom equality does not match any of the values 1`] = `

--- a/test/matchers/toContainValue.test.ts
+++ b/test/matchers/toContainValue.test.ts
@@ -76,6 +76,28 @@ describe('.not.toContainValue', () => {
   });
 });
 
+
+describe('.toContainValue with arrays', () => {
+  test('passes when given array contains value', () => {
+    expect(['world', 'foo']).toContainValue('world');
+    expect([{ hello: 'world' }, 'foo']).toContainValue({ hello: 'world' });
+  });
+
+  test('fails when given array does not contain value', () => {
+    expect(() => expect(['world', 'foo']).toContainValue('hello')).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toContainValue with arrays', () => {
+  test('passes when given array does not contain value', () => {
+    expect(['world', 'foo']).not.toContainValue('hello');
+  });
+
+  test('fails when given array contains value', () => {
+    expect(() => expect(['world', 'foo']).not.toContainValue('world')).toThrowErrorMatchingSnapshot();
+  });
+});
+
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 (expect.addEqualityTesters ? describe : describe.skip)('toContainValue with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;

--- a/test/matchers/toContainValues.test.ts
+++ b/test/matchers/toContainValues.test.ts
@@ -82,6 +82,28 @@ describe('.not.toContainValues', () => {
   });
 });
 
+
+describe('.toContainValues with arrays', () => {
+  test('passes when given array contains values', () => {
+    expect(['world', 'foo', 'bar']).toContainValues(['world', 'foo']);
+    expect([{ hello: 'world' }, 'foo']).toContainValues([{ hello: 'world' }]);
+  });
+
+  test('fails when given array does not contain values', () => {
+    expect(() => expect(['world', 'foo']).toContainValues(['hello', 'world'])).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('.not.toContainValues with arrays', () => {
+  test('passes when given array does not contain values', () => {
+    expect(['world', 'foo']).not.toContainValues(['hello', 'world']);
+  });
+
+  test('fails when given array contains values', () => {
+    expect(() => expect(['world', 'foo', 'bar']).not.toContainValues(['world', 'foo'])).toThrowErrorMatchingSnapshot();
+  });
+});
+
 // Note - custom equality tester must be at the end of the file because once we add it, it cannot be removed
 (expect.addEqualityTesters ? describe : describe.skip)('toContainValues with custom equality tester', () => {
   let mockEqualityTester: jest.Mock;


### PR DESCRIPTION
Fixes #800.

Since v5.0, `toContainValue` and `toContainValues` no longer handled arrays, breaking backward compatibility with v4 and differing from `toContainEntry`. This removes the `!Array.isArray(actual)` check in `toContainValue` and `toContainValues` so arrays are treated correctly again. Added tests to verify.