### PR TITLE
fix: add homepage and bugs fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
   "author": "Matt Phillips <matt@mattphillips.io> (mattphillips.io)",
   "license": "MIT",
   "repository": "jest-community/jest-extended",
+  "homepage": "https://jest-extended.jestcommunity.dev/",
+  "bugs": {
+    "url": "https://github.com/jest-community/jest-extended/issues"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",
     "@eslint/compat": "^2.0.0",


### PR DESCRIPTION
## Summary

Adds `homepage` and `bugs` fields to `package.json` to improve npm package metadata.

### Changes
- Added `"homepage": "https://jest-extended.jestcommunity.dev/"`
- Added `"bugs": { "url": "https://github.com/jest-community/jest-extended/issues" }`

These fields help users find the project homepage and issue tracker directly from npm.