### PR TITLE
fix(matchers): avoid TypeError in toContainAllKeys when received is nullish

### DIFF
--- a/.changeset/tidy-keys-recover.md
+++ b/.changeset/tidy-keys-recover.md
@@ -1,0 +1,5 @@
+---
+'jest-extended': patch
+---
+
+Fix `toContainAllKeys` throwing a `TypeError` instead of producing an assertion failure message when the received value is `null` or `undefined`

--- a/src/matchers/toContainAllKeys.ts
+++ b/src/matchers/toContainAllKeys.ts
@@ -13,6 +13,8 @@ export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonl
       expected.every(key => contains((a, b) => this.equals(a, b, this.customTesters), objectKeys, key));
   }
 
+  const received = actual == null ? actual : Object.keys(actual as Record<string, unknown>);
+
   return {
     pass,
     message: () =>
@@ -22,12 +24,12 @@ export function toContainAllKeys<E = unknown>(actual: unknown, expected: readonl
           'Expected object to not contain all keys:\n' +
           `  ${printExpected(expected)}\n` +
           'Received:\n' +
-          `  ${printReceived(Object.keys(actual as Record<string, unknown>))}`
+          `  ${printReceived(received)}`
         : matcherHint('.toContainAllKeys') +
           '\n\n' +
           'Expected object to contain all keys:\n' +
           `  ${printExpected(expected)}\n` +
           'Received:\n' +
-          `  ${printReceived(Object.keys(actual as Record<string, unknown>))}`,
+          `  ${printReceived(received)}`,
   };
 }

--- a/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
+++ b/test/matchers/__snapshots__/toContainAllKeys.test.ts.snap
@@ -9,9 +9,25 @@ Received:
   <red>["a", "b"]</color>"
 `;
 
-exports[`.toContainAllKeys fails when actual is not an object 1`] = `"Cannot convert undefined or null to object"`;
+exports[`.toContainAllKeys fails when actual is not an object 1`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain all keys:
+  <green>["a", "b"]</color>
+Received:
+  <red>null</color>"
+`;
 
 exports[`.toContainAllKeys fails when actual is not an object 2`] = `
+"<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
+
+Expected object to contain all keys:
+  <green>["a", "b"]</color>
+Received:
+  <red>undefined</color>"
+`;
+
+exports[`.toContainAllKeys fails when actual is not an object 3`] = `
 "<dim>expect(</intensity><red>received</color><dim>).toContainAllKeys(</intensity><green>expected</color><dim>)</intensity>
 
 Expected object to contain all keys:

--- a/test/matchers/toContainAllKeys.test.ts
+++ b/test/matchers/toContainAllKeys.test.ts
@@ -23,6 +23,7 @@ describe('.toContainAllKeys', () => {
 
   test('fails when actual is not an object', () => {
     expect(() => expect(null).toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
+    expect(() => expect(undefined).toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
     expect(() => expect(42).toContainAllKeys(['a', 'b'])).toThrowErrorMatchingSnapshot();
   });
 });


### PR DESCRIPTION
`toContainAllKeys` builds its failure message from `Object.keys(actual)`, called unconditionally in both branches. When the received value is `null` or `undefined` this throws `TypeError: Cannot convert undefined or null to object`, so you get an unrelated crash instead of a normal assertion failure:

```js
expect(null).toContainAllKeys(['a', 'b']);
// TypeError: Cannot convert undefined or null to object
```

The `pass` result itself is already null-safe (it is guarded by `typeof actual === 'object' && actual !== null`); only the message builder is affected.

The sibling key matchers `toContainKey`, `toContainKeys` and `toContainAnyKeys` were made null-safe in #878 and print the received value directly. This does the same for `toContainAllKeys`: the message prints the raw value for `null`/`undefined` (matching `toContainKey`'s output) and is unchanged for every other input.

The existing test already called `expect(null).toContainAllKeys(['a', 'b'])` under "fails when actual is not an object", but its snapshot had captured the `TypeError` text rather than an assertion message. The snapshot is updated and an `undefined` case is added to match the sibling tests.
